### PR TITLE
fix: Add dep and tests to release workflow after first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,15 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@frmscoe'
           
-      #- name: Install dependencies
-      #  run: npm ci
-      #  env:
-      #    GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Install dependencies
+        run: npm ci
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          
+      - name: Run Tests
+        run: npm test
+        env:
+          STARTUP_TYPE: 'nats'
         
       # Determine the release type (major, minor, patch) based on commit messages  
       - name: Determine Release Type


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

## Why are we doing this?

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
