### PR TITLE
fix: http `GET` for condition retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ GET
 | `schmeNm`   | String | Yes      | Scheme name of the entity |
 | `syncCache`   | String | No      | Accepts `all`, `active`, `default` or `no`  |
 
+> [!IMPORTANT]  
+> Ensure your query parameters are encoded as some properties can contain special characters. An `id` of `+12344567890` would need to be encoded as `+` is a special character.
+
 Possible values for some fields mention in the table above
 1. **evtTp**  : [`'pacs.008.001.10'`,`'pacs.002.001.12'`,`'pain.001.001.11'`,`'pain.013.001.09'`]
 2. **condTp** : `non-overridable-block` or `override` or `overridable-block`

--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ POST
 
 #### URL 3
 ```
-/v1/admin/event-flow-control/entity/getcondition
+/v1/admin/event-flow-control/entity/getconditions
 ```
 #### Method 3
 ```
-POST
+GET
 ```
 **Some endpoints share properties except for ntty and acct. These properties are specific to each endpoint and indicate the governing condition**
 #### Body
@@ -194,7 +194,7 @@ POST
 | Parameter | Type   | Required | Description                     |
 |-----------|--------|----------|---------------------------------|
 | `id`   | String | Yes      | Entity ID. |
-| `proprietary`   | String | Yes      | `schmnm` proprietary value |
+| `schmeNm`   | String | Yes      | Scheme name of the entity |
 | `syncCache`   | String | No      | Accepts `all`, `active`, `default` or `no`  |
 
 Possible values for some fields mention in the table above

--- a/__tests__/unit/app.test.ts
+++ b/__tests__/unit/app.test.ts
@@ -465,7 +465,7 @@ describe('getConditionForEntity', () => {
   });
 
   it('should get conditions for entity', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '', syncCache: 'no' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '', syncCache: 'no' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
@@ -474,31 +474,31 @@ describe('getConditionForEntity', () => {
     jest.spyOn(databaseManager, 'getEntityConditionsByGraph').mockImplementation(() => {
       return Promise.resolve([]);
     });
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '', syncCache: 'no' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '', syncCache: 'no' });
     // Assert
     expect(result).toEqual(undefined);
   });
 
   it('should get conditions for entity and update cache', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '', syncCache: 'active' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '', syncCache: 'active' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
 
   it('should prune active conditions for cache', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '', syncCache: 'all' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '', syncCache: 'all' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
 
   it('should prune active conditions for cache (using env)', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '', syncCache: 'default' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '', syncCache: 'default' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
 
   it('should skip caching', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
@@ -507,7 +507,7 @@ describe('getConditionForEntity', () => {
     jest.spyOn(databaseManager, 'getEntityConditionsByGraph').mockImplementation(() => {
       return Promise.reject(new Error('something bad happened'));
     });
-    const result = await handleGetConditionsForEntity({ id: '', proprietary: '' });
+    const result = await handleGetConditionsForEntity({ id: '', schmeNm: '' });
 
     expect(result).toBe(undefined);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,9 +2233,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
-      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.2.tgz",
+      "integrity": "sha512-nAvM3Ey230/XzxtyDcJ+VjvlzpzoHwLsF7JaDRfoI0ytO0mVheerNmM45CtA0yOILXwXXxOrcUWH3wltX+7PSw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4097,9 +4097,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.12.tgz",
-      "integrity": "sha512-tIhPkdlEoCL1Y+PToq3zRNehUaKp3wBX/sr7aclAWdIWjvqAe/Im/H0SiCM4c1Q8BLPHCdoJTol+ZblflydehA==",
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5750,9 +5750,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
-      "integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -72,7 +72,7 @@ export const handleHealthCheck = async (): Promise<{ status: string }> => {
 export const getConditionHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
   loggerService.trace('getting conditions for an entity');
   try {
-    const data = await handleGetConditionsForEntity(req.body as GetEntityConditions);
+    const data = await handleGetConditionsForEntity(req.query as GetEntityConditions);
     if (data) {
       reply.status(200);
       reply.send(data);

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export interface IConfig {
 }
 
 export const configuration: IConfig = {
-  cacheTTL: parseInt(process.env.MAX_CPU!, 10) || 0,
+  cacheTTL: parseInt(process.env.CACHE_TTL!, 10) || 0,
   maxCPU: parseInt(process.env.MAX_CPU!, 10) || 1,
   env: process.env.NODE_ENV!,
   activeConditionsOnly: process.env.ACTIVE_CONDITIONS_ONLY === 'true',

--- a/src/interface/query.ts
+++ b/src/interface/query.ts
@@ -1,5 +1,5 @@
 export interface GetEntityConditions {
   id: string;
-  proprietary: string;
+  schmeNm: string;
   syncCache?: string;
 }

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -126,9 +126,9 @@ export const handleGetConditionsForEntity = async (params: GetEntityConditions):
   const fnName = 'getConditionsForEntity';
   try {
     loggerService.trace('successfully parsed parameters', fnName, params.id);
-    const cacheKey = `entityCond-${params.id}-${params.proprietary}`;
+    const cacheKey = `entityCond-${params.id}-${params.schmeNm}`;
 
-    const report = (await databaseManager.getEntityConditionsByGraph(params.id, params.proprietary)) as RawConditionResponse[][];
+    const report = (await databaseManager.getEntityConditionsByGraph(params.id, params.schmeNm)) as RawConditionResponse[][];
 
     loggerService.log('called database', fnName, params.id);
     if (!report.length || !report[0].length) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,7 +13,7 @@ async function Routes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/', handleHealthCheck);
   fastify.get('/health', handleHealthCheck);
   fastify.get('/v1/admin/reports/getreportbymsgid', SetOptionsParams(reportRequestHandler, 'messageIDSchema'));
-  fastify.post('/v1/admin/event-flow-control/entity/getcondition', SetOptionsBody(getConditionHandler, 'queryEntityConditionSchema'));
+  fastify.get('/v1/admin/event-flow-control/entity/getconditions', SetOptionsParams(getConditionHandler, 'queryEntityConditionSchema'));
   fastify.post('/v1/admin/event-flow-control/entity', SetOptionsBody(postConditionHandlerEntity, 'entityConditionSchema'));
   fastify.post('/v1/admin/event-flow-control/account', SetOptionsBody(postConditionHandlerAccount, 'accountConditionSchema'));
 }

--- a/src/schemas/queryEntityCondition.json
+++ b/src/schemas/queryEntityCondition.json
@@ -4,7 +4,7 @@
     "id": {
       "type": "string"
     },
-    "proprietary": {
+    "schmeNm": {
       "type": "string"
     },
     "syncCache": {
@@ -12,5 +12,5 @@
       "enum": ["no", "all", "active", "default"]
     }
   },
-  "required":["id", "proprietary"]
+  "required":["id", "schmeNm"]
 }


### PR DESCRIPTION
## What did we change?
Use GET method for condition retrieval

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
