### PR TITLE
fix: Bug fix condition result array

### DIFF
--- a/__tests__/unit/app.test.ts
+++ b/__tests__/unit/app.test.ts
@@ -189,7 +189,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsDebtorByEdge).toHaveBeenCalledWith('cond123', 'entity456', sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [sampleCondition],
+      conditions: [sampleCondition],
     });
   });
 
@@ -210,7 +210,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsDebtorByEdge).toHaveBeenCalledWith('cond123', existingEntityId, sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [sampleCondition],
+      conditions: [sampleCondition],
     });
   });
 
@@ -232,7 +232,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsDebtorByEdge).toHaveBeenCalledWith('cond123', 'entity456', conditionDebtor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [conditionDebtor],
+      conditions: [conditionDebtor],
     });
   });
 
@@ -271,7 +271,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsCreditorByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionCreditor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [conditionCreditor],
+      conditions: [conditionCreditor],
     });
   });
 
@@ -299,7 +299,7 @@ describe('handlePostConditionEntity', () => {
     expect(loggerService.warn).toHaveBeenCalledWith('2 conditions already exist for the entity');
     expect(result).toEqual({
       message: '2 conditions already exist for the entity',
-      condition: existingConditions[0],
+      conditions: existingConditions[0],
     });
   });
 
@@ -587,7 +587,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsDebtorAccountByEdge).toHaveBeenCalledWith('cond123', 'account456', sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [sampleCondition],
+      conditions: [sampleCondition],
     });
   });
 
@@ -610,7 +610,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsDebtorAccountByEdge).toHaveBeenCalledWith('cond123', existingAccountId, sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [sampleCondition],
+      conditions: [sampleCondition],
     });
   });
 
@@ -632,7 +632,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsDebtorAccountByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionDebtor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [conditionDebtor],
+      conditions: [conditionDebtor],
     });
   });
 
@@ -667,7 +667,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsCreditorAccountByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionCreditor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: [conditionCreditor],
+      conditions: [conditionCreditor],
     });
   });
 
@@ -695,7 +695,7 @@ describe('handlePostConditionAccount', () => {
     expect(loggerService.warn).toHaveBeenCalledWith('2 conditions already exist for the account');
     expect(result).toEqual({
       message: '2 conditions already exist for the account',
-      condition: existingConditions[0],
+      conditions: existingConditions[0],
     });
   });
 

--- a/__tests__/unit/app.test.ts
+++ b/__tests__/unit/app.test.ts
@@ -189,7 +189,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsDebtorByEdge).toHaveBeenCalledWith('cond123', 'entity456', sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: sampleCondition,
+      condition: [sampleCondition],
     });
   });
 
@@ -210,7 +210,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsDebtorByEdge).toHaveBeenCalledWith('cond123', existingEntityId, sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: sampleCondition,
+      condition: [sampleCondition],
     });
   });
 
@@ -232,7 +232,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsDebtorByEdge).toHaveBeenCalledWith('cond123', 'entity456', conditionDebtor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: conditionDebtor,
+      condition: [conditionDebtor],
     });
   });
 
@@ -271,7 +271,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveGovernedAsCreditorByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionCreditor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: conditionCreditor,
+      condition: [conditionCreditor],
     });
   });
 
@@ -587,7 +587,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsDebtorAccountByEdge).toHaveBeenCalledWith('cond123', 'account456', sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: sampleCondition,
+      condition: [sampleCondition],
     });
   });
 
@@ -610,7 +610,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsDebtorAccountByEdge).toHaveBeenCalledWith('cond123', existingAccountId, sampleCondition);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: sampleCondition,
+      condition: [sampleCondition],
     });
   });
 
@@ -632,7 +632,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsDebtorAccountByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionDebtor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: conditionDebtor,
+      condition: [conditionDebtor],
     });
   });
 
@@ -667,7 +667,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveGovernedAsCreditorAccountByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionCreditor);
     expect(result).toEqual({
       message: 'New condition was saved successfully.',
-      condition: conditionCreditor,
+      condition: [conditionCreditor],
     });
   });
 

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -128,13 +128,13 @@ export const handlePostConditionEntity = async (condition: EntityCondition): Pro
       loggerService.warn(message);
       return {
         message,
-        condition: alreadyExistingCondition[0],
+        conditions: alreadyExistingCondition[0],
       };
     }
 
     return {
       message: 'New condition was saved successfully.',
-      condition: [condition],
+      conditions: [condition],
     };
   } catch (error) {
     const errorMessage = error as { message: string };
@@ -244,13 +244,13 @@ export const handlePostConditionAccount = async (condition: AccountCondition): P
       loggerService.warn(message);
       return {
         message,
-        condition: alreadyExistingCondition[0],
+        conditions: alreadyExistingCondition[0],
       };
     }
 
     return {
       message: 'New condition was saved successfully.',
-      condition: [condition],
+      conditions: [condition],
     };
   } catch (error) {
     const errorMessage = error as { message: string };

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -134,7 +134,7 @@ export const handlePostConditionEntity = async (condition: EntityCondition): Pro
 
     return {
       message: 'New condition was saved successfully.',
-      condition,
+      condition: [condition],
     };
   } catch (error) {
     const errorMessage = error as { message: string };
@@ -250,7 +250,7 @@ export const handlePostConditionAccount = async (condition: AccountCondition): P
 
     return {
       message: 'New condition was saved successfully.',
-      condition,
+      condition: [condition],
     };
   } catch (error) {
     const errorMessage = error as { message: string };


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Result object for a new condition post

## Why are we doing this?
Condition object should always be array even if you have one condition to return


## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
