### PR TITLE
fix: case sensitivity validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,20 +189,20 @@ POST, GET, PUT
 | Parameter | Type   | Required | Description                     |
 |-----------|--------|----------|---------------------------------|
 | `id`   | String | Yes      | Entity identifier |
-| `schmeNm`   | String | Yes      |  Scheme name of the entity |
-| `syncCache`   | String | No      | Accepts `all`, `active`, `default` or `no`  |
+| `schmenm`   | String | Yes      |  Scheme name of the entity |
+| `synccache`   | String | No      | Accepts `all`, `active`, `default` or `no`  |
 #### URL 2 GET METHOD
 | Parameter | Type   | Required | Description                     |
 |-----------|--------|----------|---------------------------------|
 | `id`   | String | Yes      | Entity ID. |
-| `schmeNm`   | String | Yes      | Scheme name of the account |
+| `schmenm`   | String | Yes      | Scheme name of the account |
 | `agt`   | String | Yes      | proprietary agent identifier |
-| `syncCache`   | String | No      | Accepts `all`, `active`, `default` or `no`  |
+| `synccache`   | String | No      | Accepts `all`, `active`, `default` or `no`  |
 #### URL 1 PUT METHOD
 | Parameter | Type   | Required | Description                     |
 |-----------|--------|----------|---------------------------------|
 | `id`   | String | Yes      | Entity identifier |
-| `schmeNm`   | String | Yes      |  Scheme name of the entity |
+| `schmenm`   | String | Yes      |  Scheme name of the entity |
 | `condId`   | String | Yes      | Condition identifier  |
 #### Body data
 | Body | Type   | Required | Description                     |
@@ -212,7 +212,7 @@ POST, GET, PUT
 | Parameter | Type   | Required | Description                     |
 |-----------|--------|----------|---------------------------------|
 | `id`   | String | Yes      | Entity ID. |
-| `schmeNm`   | String | Yes      | Scheme name of the account |
+| `schmenm`   | String | Yes      | Scheme name of the account |
 | `agt`   | String | Yes      | proprietary agent identifier |
 | `condId`   | String | Yes      | Condition identifier  |
 #### Body data

--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -307,7 +307,7 @@ describe('getConditionForEntity', () => {
   });
 
   it('should get conditions for entity', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', syncCache: 'no' });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'no' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
@@ -316,25 +316,25 @@ describe('getConditionForEntity', () => {
     jest.spyOn(databaseManager, 'getEntityConditionsByGraph').mockImplementation(() => {
       return Promise.resolve([]);
     });
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', syncCache: 'no' });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'no' });
     // Assert
     expect(result).toEqual(undefined);
   });
 
   it('should get conditions for entity and update cache', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', syncCache: 'active' });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'active' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
 
   it('should prune active conditions for cache', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', syncCache: 'all' });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'all' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
 
   it('should prune active conditions for cache (using env)', async () => {
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', syncCache: 'default' });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'default' });
     // Assert
     expect(result).toEqual(entityResponse);
   });
@@ -347,7 +347,7 @@ describe('getConditionForEntity', () => {
 
   it('should sync active condition by using default and environment variable', async () => {
     configuration.activeConditionsOnly = true;
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', syncCache: 'default' });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'default' });
     configuration.activeConditionsOnly = false;
     // Assert
     expect(result).toEqual(entityResponse);
@@ -584,7 +584,7 @@ describe('getConditionForAccount', () => {
   });
 
   it('should get conditions for account', async () => {
-    const result = await handleGetConditionsForAccount({ id: '1010101010', syncCache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
+    const result = await handleGetConditionsForAccount({ id: '1010101010', synccache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
@@ -593,52 +593,52 @@ describe('getConditionForAccount', () => {
     jest.spyOn(databaseManager, 'getAccountConditionsByGraph').mockImplementation(() => {
       return Promise.resolve([]);
     });
-    const result = await handleGetConditionsForAccount({ id: '1010101010', syncCache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
+    const result = await handleGetConditionsForAccount({ id: '1010101010', synccache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
 
     // Assert
     expect(result).toEqual(undefined);
   });
 
   it('should get conditions for account and update cache', async () => {
-    const result = await handleGetConditionsForAccount({ id: '1010101010', syncCache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
+    const result = await handleGetConditionsForAccount({ id: '1010101010', synccache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
 
   it('should prune active conditions for cache', async () => {
-    const result = await handleGetConditionsForAccount({ id: '1010101010', syncCache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
+    const result = await handleGetConditionsForAccount({ id: '1010101010', synccache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
 
   it('should prune active conditions for cache (using env)', async () => {
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '007', syncCache: 'default' });
+    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '007', synccache: 'default' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
 
   it('should skip caching', async () => {
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '008', syncCache: 'no' });
+    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '008', synccache: 'no' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
 
   it('should sync all cache', async () => {
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '009', syncCache: 'all' });
+    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '009', synccache: 'all' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
 
   it('should sync active cache by using environment variable', async () => {
     configuration.activeConditionsOnly = true;
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '001', syncCache: 'default' });
+    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '001', synccache: 'default' });
     configuration.activeConditionsOnly = false;
     // Assert
     expect(result).toEqual(accountResponse);
   });
 
   it('should sync active cache only', async () => {
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '001', syncCache: 'active' });
+    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '001', synccache: 'active' });
     // Assert
     expect(result).toEqual(accountResponse);
   });
@@ -647,7 +647,7 @@ describe('getConditionForAccount', () => {
     jest.spyOn(databaseManager, 'getAccountConditionsByGraph').mockImplementation(() => {
       return Promise.reject(new Error('something bad happened'));
     });
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '002', syncCache: 'no' });
+    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '002', synccache: 'no' });
 
     expect(result).toBe(undefined);
   });

--- a/src/interface/query.ts
+++ b/src/interface/query.ts
@@ -1,7 +1,7 @@
 export interface ConditionRequest {
   id: string;
   schmenm: string;
-  syncCache?: string;
+  synccache?: string;
   condid?: string;
   agt?: string;
 }

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -155,7 +155,7 @@ export const handleGetConditionsForEntity = async (params: ConditionRequest): Pr
 
     const retVal = parseConditionEntity(report[0]);
 
-    switch (params.syncCache) {
+    switch (params.synccache) {
       case 'all':
         loggerService.trace('syncCache=all option specified', 'cache update', cacheKey);
         await updateCache(cacheKey, retVal);
@@ -341,7 +341,7 @@ export const handleGetConditionsForAccount = async (params: ConditionRequest): P
 
     const retVal = parseConditionAccount(report[0]);
 
-    switch (params.syncCache) {
+    switch (params.synccache) {
       case 'all':
         loggerService.trace('syncCache=all option specified', 'cache update', cacheKey);
         await updateCache(cacheKey, retVal);

--- a/src/schemas/queryAccountCondition.json
+++ b/src/schemas/queryAccountCondition.json
@@ -10,7 +10,7 @@
       "agt": {
         "type": "string"
       },
-      "syncCache": {
+      "synccache": {
         "type": "string",
         "enum": ["no", "all", "active", "default"]
       }

--- a/src/schemas/queryEntityCondition.json
+++ b/src/schemas/queryEntityCondition.json
@@ -7,7 +7,7 @@
     "schmenm": {
       "type": "string"
     },
-    "syncCache": {
+    "synccache": {
       "type": "string",
       "enum": ["no", "all", "active", "default"]
     }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
1. We changed the params interface mainly the `syncCache` to `synccache`
2. We changed the logic file to use the new property 
3. Updated test data

## Why are we doing this?
1. Remove the bug of the invalid case for params


## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

Related to : https://github.com/tazama-lf/event-flow/issues/3 and https://github.com/tazama-lf/event-flow/issues/4
