### PR TITLE
fix: handle invalid date times as errors

### DIFF
--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -685,8 +685,8 @@ describe('handleUpdateExpiryDateForConditionsOfAccount', () => {
     const result = await handleUpdateExpiryDateForConditionsOfAccount(params, '');
 
     expect(result).toEqual({
-      code: 404,
-      message: 'No records were found in the database using the provided data.',
+      code: 400,
+      message: 'Expiration date time was not provided',
     });
   });
 
@@ -697,7 +697,7 @@ describe('handleUpdateExpiryDateForConditionsOfAccount', () => {
 
     expect(result).toEqual({
       code: 400,
-      message: 'Expiration time date provided was invalid.',
+      message: 'Expiration date time provided was invalid.',
     });
   });
 
@@ -800,17 +800,6 @@ describe('handleUpdateExpiryDateForConditionsOfEntity', () => {
     });
   });
 
-  it('should handle when xprtnDtTm is not provided', async () => {
-    (databaseManager.getEntityConditionsByGraph as jest.Mock).mockResolvedValue([]);
-
-    const result = await handleUpdateExpiryDateForConditionsOfEntity(params, undefined);
-
-    expect(result).toEqual({
-      code: 404,
-      message: 'No records were found in the database using the provided data.',
-    });
-  });
-
   it('should handle when xprtnDtTm is provided but with invalid date', async () => {
     (databaseManager.getEntityConditionsByGraph as jest.Mock).mockResolvedValue([]);
 
@@ -818,7 +807,7 @@ describe('handleUpdateExpiryDateForConditionsOfEntity', () => {
 
     expect(result).toEqual({
       code: 400,
-      message: 'Expiration time date provided was invalid.',
+      message: 'Expiration date time provided was invalid.',
     });
   });
 

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -194,7 +194,7 @@ export const handleUpdateExpiryDateForConditionsOfEntity = async (
 ): Promise<{ code: number; message: string }> => {
   const expireDateResult = validateAndParseExpirationDate(xprtnDtTm);
 
-  if (!expireDateResult.isValid) {
+  if (!expireDateResult.dateStr) {
     loggerService.error(expireDateResult.message);
     return { code: 400, message: expireDateResult.message };
   }
@@ -401,7 +401,7 @@ export const handleUpdateExpiryDateForConditionsOfAccount = async (
 ): Promise<{ code: number; message: string }> => {
   const expireDateResult = validateAndParseExpirationDate(xprtnDtTm);
 
-  if (!expireDateResult.isValid) {
+  if (!expireDateResult.dateStr) {
     loggerService.error(expireDateResult.message);
     return { code: 400, message: expireDateResult.message };
   }

--- a/src/utils/condition-validation.ts
+++ b/src/utils/condition-validation.ts
@@ -43,8 +43,7 @@ export const checkConditionValidity = (condition: EntityCondition | AccountCondi
 };
 
 interface DateValidationResult {
-  isValid: boolean;
-  dateStr: string;
+  dateStr?: string;
   message: string;
 }
 
@@ -54,28 +53,26 @@ const hasDateExpired = (date: Date): boolean => {
 };
 
 const parseDate = (dateStr: string): string | undefined => {
-  return isDateValid(dateStr) ? new Date(dateStr).toISOString() : undefined;
-};
-
-const isDateValid = (dateStr: string): boolean => {
   const date = new Date(dateStr);
-  return !isNaN(date.getTime());
+  const isValid = !isNaN(date.getTime());
+
+  return isValid ? date.toISOString() : undefined;
 };
 
 export const validateAndParseExpirationDate = (dateStr?: string): DateValidationResult => {
   if (!dateStr) {
-    return { isValid: true, dateStr: new Date().toISOString(), message: 'Expiration time date was not provided' };
+    return { message: 'Expiration date time was not provided' };
   }
 
   const parsedDate = parseDate(dateStr);
 
   if (!parsedDate) {
-    return { isValid: false, dateStr: new Date().toISOString(), message: 'Expiration time date provided was invalid.' };
+    return { message: 'Expiration date time provided was invalid.' };
   }
 
   if (hasDateExpired(new Date(parsedDate))) {
-    return { isValid: false, dateStr: parsedDate, message: 'Expiration time date provided was before the current time date.' };
+    return { message: 'Expiration date time provided was before the current time date.' };
   }
 
-  return { isValid: true, dateStr: parsedDate, message: 'Validated' };
+  return { dateStr: parsedDate, message: 'Validated' };
 };


### PR DESCRIPTION
## What did we change?
Dates in the past are invalid

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
