### PR TITLE
fix: No account/entity handling

### DIFF
--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -367,17 +367,6 @@ describe('getConditionForEntity', () => {
     // Assert
     expect(result).toEqual(entityResponse);
   });
-
-  it('should throw an error', async () => {
-    jest.spyOn(databaseManager, 'getEntityConditionsByGraph').mockImplementation(() => {
-      return Promise.reject(new Error('something bad happened'));
-    });
-    try {
-      await handleGetConditionsForEntity({ id: '', schmenm: '' });
-    } catch (err) {
-      expect(String(err)).toBe('Error: something bad happened');
-    }
-  });
 });
 
 describe('handlePostConditionAccount', () => {
@@ -672,17 +661,6 @@ describe('getConditionForAccount', () => {
     const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '001', synccache: 'active' });
     // Assert
     expect(result).toEqual(accountResponse);
-  });
-
-  it('should throw an error', async () => {
-    jest.spyOn(databaseManager, 'getAccountConditionsByGraph').mockImplementation(() => {
-      return Promise.reject(new Error('something bad happened'));
-    });
-    try {
-      await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '002', synccache: 'no' });
-    } catch (error) {
-      expect(String(error)).toEqual(`Error: something bad happened`);
-    }
   });
 });
 

--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -306,6 +306,10 @@ describe('getConditionForEntity', () => {
     jest.spyOn(databaseManager, 'set').mockImplementation(() => {
       return Promise.resolve(undefined);
     });
+
+    jest.spyOn(databaseManager, 'getEntity').mockImplementation(() => {
+      return Promise.resolve([[{ _id: 'entity456' }]]);
+    });
   });
 
   it('should get conditions for entity', async () => {
@@ -320,7 +324,16 @@ describe('getConditionForEntity', () => {
     });
     const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'no' });
     // Assert
-    expect(result).toEqual(undefined);
+    expect(result).toEqual({ code: 404 });
+  });
+
+  it('should get no entity was found', async () => {
+    jest.spyOn(databaseManager, 'getEntity').mockImplementation(() => {
+      return Promise.resolve([]);
+    });
+    const result = await handleGetConditionsForEntity({ id: '', schmenm: '', synccache: 'no' });
+    // Assert
+    expect(result).toEqual({ result: 'Entity does not exist in the database', code: 404 });
   });
 
   it('should get conditions for entity and update cache', async () => {
@@ -359,9 +372,11 @@ describe('getConditionForEntity', () => {
     jest.spyOn(databaseManager, 'getEntityConditionsByGraph').mockImplementation(() => {
       return Promise.reject(new Error('something bad happened'));
     });
-    const result = await handleGetConditionsForEntity({ id: '', schmenm: '' });
-
-    expect(result).toBe(undefined);
+    try {
+      await handleGetConditionsForEntity({ id: '', schmenm: '' });
+    } catch (err) {
+      expect(String(err)).toBe('Error: something bad happened');
+    }
   });
 });
 
@@ -575,6 +590,10 @@ describe('getConditionForAccount', () => {
   beforeEach(() => {
     jest.clearAllMocks(); // Clear mocks before each test
 
+    jest.spyOn(databaseManager, 'getAccount').mockImplementation(() => {
+      return Promise.resolve([[{ _id: 'account456' }]]);
+    });
+
     jest.spyOn(databaseManager, 'getAccountConditionsByGraph').mockImplementation(() => {
       return Promise.resolve([[rawResponseAccount]]);
     });
@@ -599,7 +618,16 @@ describe('getConditionForAccount', () => {
     const result = await handleGetConditionsForAccount({ id: '1010101010', synccache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
 
     // Assert
-    expect(result).toEqual(undefined);
+    expect(result).toEqual({ code: 404 });
+  });
+
+  it('should get no account was found', async () => {
+    jest.spyOn(databaseManager, 'getAccount').mockImplementation(() => {
+      return Promise.resolve([]);
+    });
+    const result = await handleGetConditionsForAccount({ id: '1010101010', synccache: 'no', schmenm: 'Mxx', agt: 'dfsp001' });
+    // Assert
+    expect(result).toEqual({ result: 'Account does not exist in the database', code: 404 });
   });
 
   it('should get conditions for account and update cache', async () => {
@@ -650,9 +678,11 @@ describe('getConditionForAccount', () => {
     jest.spyOn(databaseManager, 'getAccountConditionsByGraph').mockImplementation(() => {
       return Promise.reject(new Error('something bad happened'));
     });
-    const result = await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '002', synccache: 'no' });
-
-    expect(result).toBe(undefined);
+    try {
+      await handleGetConditionsForAccount({ id: '', schmenm: '', agt: '002', synccache: 'no' });
+    } catch (error) {
+      expect(String(error)).toEqual(`Error: something bad happened`);
+    }
   });
 });
 
@@ -986,6 +1016,6 @@ describe('handleCacheUpdate', () => {
 
     const result = await handleRefreshCache(true, 12);
 
-    expect(result).toBeUndefined();
+    expect(result).toBe(undefined);
   });
 });

--- a/__tests__/unit/test.data.ts
+++ b/__tests__/unit/test.data.ts
@@ -186,78 +186,84 @@ export const rawResponseAccount = {
 };
 
 export const accountResponse = {
-  acct: {
-    id: '1010101010',
-    agt: {
-      finInstnId: {
-        clrSysMmbId: {
-          mmbId: 'dfsp001',
+  code: 200,
+  result: {
+    acct: {
+      id: '1010101010',
+      agt: {
+        finInstnId: {
+          clrSysMmbId: {
+            mmbId: 'dfsp001',
+          },
         },
       },
+      schmeNm: {
+        prtry: 'Mxx',
+      },
     },
-    schmeNm: {
-      prtry: 'Mxx',
-    },
+    conditions: [
+      {
+        condId: '2110',
+        xprtnDtTm,
+        condTp: 'overridable-block',
+        creDtTm: fixedDate,
+        incptnDtTm,
+        condRsn: 'R001',
+        usr: 'bob',
+        prsptvs: [
+          {
+            prsptv: 'governed_as_creditor_account_by',
+            evtTp: ['pacs.008.001.10'],
+            incptnDtTm,
+            xprtnDtTm,
+          },
+          {
+            prsptv: 'governed_as_debtor_account_by',
+            evtTp: ['pacs.008.001.10'],
+            incptnDtTm,
+            xprtnDtTm,
+          },
+        ],
+      },
+    ],
   },
-  conditions: [
-    {
-      condId: '2110',
-      xprtnDtTm,
-      condTp: 'overridable-block',
-      creDtTm: fixedDate,
-      incptnDtTm,
-      condRsn: 'R001',
-      usr: 'bob',
-      prsptvs: [
-        {
-          prsptv: 'governed_as_creditor_account_by',
-          evtTp: ['pacs.008.001.10'],
-          incptnDtTm,
-          xprtnDtTm,
-        },
-        {
-          prsptv: 'governed_as_debtor_account_by',
-          evtTp: ['pacs.008.001.10'],
-          incptnDtTm,
-          xprtnDtTm,
-        },
-      ],
-    },
-  ],
 };
 
 export const entityResponse = {
-  ntty: {
-    id: '+27733161225',
-    schmeNm: {
-      prtry: 'MSISDN',
+  code: 200,
+  result: {
+    ntty: {
+      id: '+27733161225',
+      schmeNm: {
+        prtry: 'MSISDN',
+      },
     },
+    conditions: [
+      {
+        condId: '2110',
+        condTp: 'overridable-block',
+        incptnDtTm,
+        xprtnDtTm,
+        condRsn: 'R001',
+        usr: 'bob',
+        creDtTm: fixedDate,
+        prsptvs: [
+          {
+            prsptv: 'governed_as_creditor_by',
+            evtTp: ['pacs.008.001.10'],
+            incptnDtTm,
+            xprtnDtTm,
+          },
+          {
+            prsptv: 'governed_as_debtor_by',
+            evtTp: ['pacs.008.001.10'],
+            incptnDtTm,
+            xprtnDtTm,
+          },
+        ],
+      },
+    ],
   },
-  conditions: [
-    {
-      condId: '2110',
-      condTp: 'overridable-block',
-      incptnDtTm,
-      xprtnDtTm,
-      condRsn: 'R001',
-      usr: 'bob',
-      creDtTm: fixedDate,
-      prsptvs: [
-        {
-          prsptv: 'governed_as_creditor_by',
-          evtTp: ['pacs.008.001.10'],
-          incptnDtTm,
-          xprtnDtTm,
-        },
-        {
-          prsptv: 'governed_as_debtor_by',
-          evtTp: ['pacs.008.001.10'],
-          incptnDtTm,
-          xprtnDtTm,
-        },
-      ],
-    },
-  ],
 };
 
 export const sampleEntityCondition: EntityCondition = {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -96,7 +96,9 @@ export const getEntityConditionHandler = async (req: FastifyRequest, reply: Fast
     reply.status(code);
     reply.send(result);
   } catch (err) {
+    loggerService.error(err as Error);
     reply.status(500);
+    reply.send(err);
   } finally {
     loggerService.trace('End - get condition for an entity');
   }
@@ -110,6 +112,7 @@ export const getAccountConditionsHandler = async (req: FastifyRequest, reply: Fa
     reply.status(code);
     reply.send(result);
   } catch (err) {
+    loggerService.error(err as Error);
     reply.status(500);
     reply.send(err);
   } finally {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -36,7 +36,7 @@ export const reportRequestHandler = async (req: FastifyRequest, reply: FastifyRe
 };
 
 export const postConditionHandlerEntity = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
-  loggerService.log('Start - Handle report request');
+  loggerService.log('Start - Handle saving entity condition  request');
   try {
     const condition = req.body as EntityCondition;
     const data = await handlePostConditionEntity(condition);
@@ -88,16 +88,13 @@ export const handleHealthCheck = async (): Promise<{ status: string }> => {
   };
 };
 
-export const getConditionHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+export const getEntityConditionHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
   loggerService.trace('getting conditions for an entity');
   try {
-    const data = await handleGetConditionsForEntity(req.query as ConditionRequest);
-    if (data) {
-      reply.status(200);
-      reply.send(data);
-    } else {
-      reply.status(404);
-    }
+    const { code, result } = await handleGetConditionsForEntity(req.query as ConditionRequest);
+
+    reply.status(code);
+    reply.send(result);
   } catch (err) {
     reply.status(500);
   } finally {
@@ -106,26 +103,22 @@ export const getConditionHandler = async (req: FastifyRequest, reply: FastifyRep
 };
 
 export const getAccountConditionsHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
-  loggerService.log('Start - Handle report request');
+  loggerService.log('Start - Handle get account condition request');
   try {
-    const data = await handleGetConditionsForAccount(req.query as ConditionRequest);
-    if (data) {
-      reply.status(200);
-      reply.send(data);
-    } else {
-      reply.status(404);
-    }
+    const { code, result } = await handleGetConditionsForAccount(req.query as ConditionRequest);
+
+    reply.status(code);
+    reply.send(result);
   } catch (err) {
-    const failMessage = `Failed to process execution request. \n${JSON.stringify(err, null, 4)}`;
     reply.status(500);
-    reply.send(failMessage);
+    reply.send(err);
   } finally {
-    loggerService.log('End - Handle report request');
+    loggerService.log('End - Handle get account condition request');
   }
 };
 
 export const updateAccountConditionExpiryDateHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
-  loggerService.log('Start - Handle update condition request');
+  loggerService.log('Start - Handle update condition for account request');
   const expiryDate = (req.body as { xprtnDtTm?: string })?.xprtnDtTm;
   try {
     const { code, message } = await handleUpdateExpiryDateForConditionsOfAccount(req.query as ConditionRequest, expiryDate);
@@ -136,12 +129,12 @@ export const updateAccountConditionExpiryDateHandler = async (req: FastifyReques
   } catch (err) {
     reply.send(err);
   } finally {
-    loggerService.log('End - Handle update condition request');
+    loggerService.log('End - Handle update condition for account request');
   }
 };
 
 export const updateEntityConditionExpiryDateHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
-  loggerService.log('Start - Handle update condition request');
+  loggerService.log('Start - Handle update condition for entity request');
   const expiryDate = (req.body as { xprtnDtTm?: string })?.xprtnDtTm;
   try {
     const { code, message } = await handleUpdateExpiryDateForConditionsOfEntity(req.query as ConditionRequest, expiryDate);
@@ -152,6 +145,6 @@ export const updateEntityConditionExpiryDateHandler = async (req: FastifyRequest
   } catch (err) {
     reply.send(err);
   } finally {
-    loggerService.log('End - Handle update condition request');
+    loggerService.log('End - Handle update condition for entity request');
   }
 };

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -149,60 +149,56 @@ export const handleGetConditionsForEntity = async (
   params: ConditionRequest,
 ): Promise<{ code: number; result?: string | EntityConditionResponse }> => {
   const fnName = 'getConditionsForEntity';
-  try {
-    loggerService.trace('successfully parsed parameters', fnName, params.id);
-    const accountExist = (await databaseManager.getEntity(params.id, params.schmenm)) as Entity[][];
 
-    if (!accountExist[0] || !accountExist[0][0] || !accountExist[0][0]._id) {
-      return { result: 'Entity does not exist in the database', code: 404 };
-    }
+  loggerService.trace('successfully parsed parameters', fnName, params.id);
+  const accountExist = (await databaseManager.getEntity(params.id, params.schmenm)) as Entity[][];
 
-    const cacheKey = `entities/${params.id}${params.schmenm}`;
-
-    const report = (await databaseManager.getEntityConditionsByGraph(params.id, params.schmenm)) as RawConditionResponse[][];
-
-    loggerService.log('called database', fnName, params.id);
-    if (!report.length || !report[0].length) {
-      return { code: 404 };
-    }
-
-    const retVal = parseConditionEntity(report[0]);
-
-    if (!retVal.conditions.length) {
-      return { code: 204 };
-    }
-
-    switch (params.synccache) {
-      case 'all':
-        loggerService.trace('syncCache=all option specified', 'cache update', cacheKey);
-        await updateCache(cacheKey, retVal);
-        break;
-      case 'active':
-        loggerService.trace('syncCache=active option specified', 'cache update', cacheKey);
-        await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
-
-        break;
-      case 'default':
-        // use env
-        loggerService.trace('syncCache=default option specified', 'cache update', cacheKey);
-        if (configuration.activeConditionsOnly) {
-          loggerService.trace('using env to update active conditions only', 'cache update', cacheKey);
-          await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
-        } else {
-          loggerService.trace('using env to update all conditions', 'cache update', cacheKey);
-          await updateCache(cacheKey, retVal);
-        }
-        break;
-      default:
-        loggerService.trace('syncCache=no/default option specified');
-        break;
-    }
-
-    return { code: 200, result: retVal };
-  } catch (error) {
-    loggerService.error(error as Error);
-    throw error as Error;
+  if (!accountExist[0] || !accountExist[0][0] || !accountExist[0][0]._id) {
+    return { result: 'Entity does not exist in the database', code: 404 };
   }
+
+  const cacheKey = `entities/${params.id}${params.schmenm}`;
+
+  const report = (await databaseManager.getEntityConditionsByGraph(params.id, params.schmenm)) as RawConditionResponse[][];
+
+  loggerService.log('called database', fnName, params.id);
+  if (!report.length || !report[0].length) {
+    return { code: 404 };
+  }
+
+  const retVal = parseConditionEntity(report[0]);
+
+  if (!retVal.conditions.length) {
+    return { code: 204 };
+  }
+
+  switch (params.synccache) {
+    case 'all':
+      loggerService.trace('syncCache=all option specified', 'cache update', cacheKey);
+      await updateCache(cacheKey, retVal);
+      break;
+    case 'active':
+      loggerService.trace('syncCache=active option specified', 'cache update', cacheKey);
+      await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
+
+      break;
+    case 'default':
+      // use env
+      loggerService.trace('syncCache=default option specified', 'cache update', cacheKey);
+      if (configuration.activeConditionsOnly) {
+        loggerService.trace('using env to update active conditions only', 'cache update', cacheKey);
+        await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
+      } else {
+        loggerService.trace('using env to update all conditions', 'cache update', cacheKey);
+        await updateCache(cacheKey, retVal);
+      }
+      break;
+    default:
+      loggerService.trace('syncCache=no/default option specified');
+      break;
+  }
+
+  return { code: 200, result: retVal };
 };
 
 export const handleUpdateExpiryDateForConditionsOfEntity = async (
@@ -367,62 +363,58 @@ export const handleGetConditionsForAccount = async (
   params: ConditionRequest,
 ): Promise<{ code: number; result?: string | AccountConditionResponse }> => {
   const fnName = 'getConditionsForAccount';
-  try {
-    loggerService.trace('successfully parsed parameters', fnName, params.id);
-    const cacheKey = `accounts/${params.id}${params.schmenm}${params.agt}`;
 
-    let report: RawConditionResponse[][] = [[]];
-    if (params.agt) {
-      const accountExist = (await databaseManager.getAccount(params.id, params.schmenm, params.agt)) as Account[][];
+  loggerService.trace('successfully parsed parameters', fnName, params.id);
+  const cacheKey = `accounts/${params.id}${params.schmenm}${params.agt}`;
 
-      if (!accountExist[0] || !accountExist[0][0] || !accountExist[0][0]._id) {
-        return { result: 'Account does not exist in the database', code: 404 };
-      }
+  let report: RawConditionResponse[][] = [[]];
+  if (params.agt) {
+    const accountExist = (await databaseManager.getAccount(params.id, params.schmenm, params.agt)) as Account[][];
 
-      report = (await databaseManager.getAccountConditionsByGraph(params.id, params.schmenm, params.agt)) as RawConditionResponse[][];
+    if (!accountExist[0] || !accountExist[0][0] || !accountExist[0][0]._id) {
+      return { result: 'Account does not exist in the database', code: 404 };
     }
 
-    loggerService.log('called database', fnName, params.id);
-    if (!report.length || !report[0].length) {
-      return { code: 404 };
-    }
-
-    const retVal = parseConditionAccount(report[0]);
-
-    if (!retVal.conditions.length) {
-      return { code: 204 };
-    }
-
-    switch (params.synccache) {
-      case 'all':
-        loggerService.trace('syncCache=all option specified', 'cache update', cacheKey);
-        await updateCache(cacheKey, retVal);
-        break;
-      case 'active':
-        loggerService.trace('syncCache=active option specified', 'cache update', cacheKey);
-        await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
-        break;
-      case 'default':
-        // use env
-        loggerService.trace('syncCache=default option specified', 'cache update', cacheKey);
-        if (configuration.activeConditionsOnly) {
-          loggerService.trace('using env to update active conditions only', 'cache update', cacheKey);
-          await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
-        } else {
-          loggerService.trace('using env to update all conditions', 'cache update', cacheKey);
-          await updateCache(cacheKey, retVal);
-        }
-        break;
-      default:
-        loggerService.trace('syncCache=no/default option specified');
-        break;
-    }
-
-    return { result: retVal, code: 200 };
-  } catch (error) {
-    loggerService.error(error as Error);
-    throw error as Error;
+    report = (await databaseManager.getAccountConditionsByGraph(params.id, params.schmenm, params.agt)) as RawConditionResponse[][];
   }
+
+  loggerService.log('called database', fnName, params.id);
+  if (!report.length || !report[0].length) {
+    return { code: 404 };
+  }
+
+  const retVal = parseConditionAccount(report[0]);
+
+  if (!retVal.conditions.length) {
+    return { code: 204 };
+  }
+
+  switch (params.synccache) {
+    case 'all':
+      loggerService.trace('syncCache=all option specified', 'cache update', cacheKey);
+      await updateCache(cacheKey, retVal);
+      break;
+    case 'active':
+      loggerService.trace('syncCache=active option specified', 'cache update', cacheKey);
+      await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
+      break;
+    case 'default':
+      // use env
+      loggerService.trace('syncCache=default option specified', 'cache update', cacheKey);
+      if (configuration.activeConditionsOnly) {
+        loggerService.trace('using env to update active conditions only', 'cache update', cacheKey);
+        await updateCache(cacheKey, { ...retVal, conditions: filterConditions(retVal.conditions) });
+      } else {
+        loggerService.trace('using env to update all conditions', 'cache update', cacheKey);
+        await updateCache(cacheKey, retVal);
+      }
+      break;
+    default:
+      loggerService.trace('syncCache=no/default option specified');
+      break;
+  }
+
+  return { result: retVal, code: 200 };
 };
 
 export const handleUpdateExpiryDateForConditionsOfAccount = async (

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@
 import { type FastifyInstance } from 'fastify';
 import {
   getAccountConditionsHandler,
-  getConditionHandler,
+  getEntityConditionHandler,
   handleHealthCheck,
   postConditionHandlerAccount,
   postConditionHandlerEntity,
@@ -33,7 +33,7 @@ async function Routes(fastify: FastifyInstance): Promise<void> {
   );
   fastify.get(
     '/v1/admin/event-flow-control/entity',
-    SetOptionsBodyAndParams(getConditionHandler, routePrivilege.getEntity, undefined, 'queryEntityConditionSchema'),
+    SetOptionsBodyAndParams(getEntityConditionHandler, routePrivilege.getEntity, undefined, 'queryEntityConditionSchema'),
   );
   fastify.get(
     '/v1/admin/event-flow-control/account',


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
We added logic for handling if no account or entity exists with specified keys
We added test cases for our handling
We apply the return of code and result on our get functions

## Why are we doing this?
To appropriately return specific messages for no account/entity
To Cover new logic
To allow specific code returns for each failure 

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
