### PR TITLE
fix: Fix expired condition in event flow logic service

### DIFF
--- a/src/services/event-flow.logic.service.ts
+++ b/src/services/event-flow.logic.service.ts
@@ -233,7 +233,7 @@ export const handleUpdateExpiryDateForConditionsOfEntity = async (
 
   if (params.condid) await databaseManager.updateCondition(params.condid, expireDateResult.dateStr);
 
-  const updatedReport = (await databaseManager.getEntityConditionsByGraph(params.id, params.schmenm)) as RawConditionResponse[][];
+  const updatedReport = (await databaseManager.getEntityConditionsByGraph(params.id, params.schmenm, true)) as RawConditionResponse[][];
 
   const retVal = parseConditionEntity(updatedReport[0]);
 
@@ -465,7 +465,12 @@ export const handleUpdateExpiryDateForConditionsOfAccount = async (
 
   let updatedReport: RawConditionResponse[][] = [[]];
   if (params.agt) {
-    updatedReport = (await databaseManager.getAccountConditionsByGraph(params.id, params.schmenm, params.agt)) as RawConditionResponse[][];
+    updatedReport = (await databaseManager.getAccountConditionsByGraph(
+      params.id,
+      params.schmenm,
+      params.agt,
+      true,
+    )) as RawConditionResponse[][];
   }
   const retVal = parseConditionAccount(updatedReport[0]);
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
1. When changed the parameter for getting all or active only

## Why are we doing this?
2. To update conditions in cache

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
