### PR TITLE
fix: use enum to list possible values

### DIFF
--- a/src/schemas/accountConditionSchema.ts
+++ b/src/schemas/accountConditionSchema.ts
@@ -4,13 +4,9 @@ import { Type, type Static } from '@sinclair/typebox';
 export const AccountConditionSchema = Type.Object(
   {
     evtTp: Type.Array(
-      Type.Union([
-        Type.Literal('pacs.008.001.10'),
-        Type.Literal('pacs.002.001.12'),
-        Type.Literal('pain.013.001.09'),
-        Type.Literal('pain.001.001.11'),
-        Type.Literal('all'),
-      ]),
+      Type.String({
+        enum: ['pain.013.001.09', 'pain.001.001.11', 'pacs.008.001.10', 'pacs.002.001.12', 'all'],
+      }),
       { minItems: 1, uniqueItems: true },
     ),
 

--- a/src/schemas/entityConditionSchema.ts
+++ b/src/schemas/entityConditionSchema.ts
@@ -4,13 +4,9 @@ import { Type, type Static } from '@sinclair/typebox';
 export const EntityConditionSchema = Type.Object(
   {
     evtTp: Type.Array(
-      Type.Union([
-        Type.Literal('pacs.008.001.10'),
-        Type.Literal('pacs.002.001.12'),
-        Type.Literal('pain.013.001.09'),
-        Type.Literal('pain.001.001.11'),
-        Type.Literal('all'),
-      ]),
+      Type.String({
+        enum: ['pain.013.001.09', 'pain.001.001.11', 'pacs.008.001.10', 'pacs.002.001.12', 'all'],
+      }),
       { minItems: 1, uniqueItems: true },
     ),
     condTp: Type.String({


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Use enums instead of unions

## Why are we doing this?
Remove spammy error message

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
