### PR TITLE
fix: RuleRequest payload and improve test case coverage

### DIFF
--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -205,8 +205,6 @@ describe('handlePostConditionEntity', () => {
       return Promise.resolve({ id: undefined } as unknown as Entity);
     });
 
-    const nowDateTime = new Date().toISOString();
-
     // Arrange
     const condition = {
       ...sampleEntityCondition,
@@ -217,7 +215,7 @@ describe('handlePostConditionEntity', () => {
     // Act & Assert
     await handlePostConditionEntity(condition as EntityCondition, 'DEFAULT');
     const entityId = condition.ntty.id + condition.ntty.schmeNm.prtry;
-    expect(databaseManager.saveEntity).toHaveBeenCalledWith(entityId, 'DEFAULT', nowDateTime);
+    expect(databaseManager.saveEntity).toHaveBeenCalledWith(entityId, 'DEFAULT', expect.any(String));
   });
   it('should handle error when creating a new entity if entity does not exist and forceCret is set to true', async () => {
     jest.spyOn(databaseManager, 'getEntity').mockImplementation((): Promise<Entity | undefined> => {

--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -462,7 +462,6 @@ describe('handlePostConditionAccount', () => {
 
   it('should handle a successful post request for a creditor perspective', async () => {
     // Arrange
-    const nowDateTime = new Date().toISOString();
     const conditionCreditor = { ...sampleAccountCondition, prsptv: 'creditor' };
 
     // Act
@@ -472,7 +471,7 @@ describe('handlePostConditionAccount', () => {
     expect(databaseManager.saveCondition).toHaveBeenCalledWith(
       expect.objectContaining({
         ...conditionCreditor,
-        creDtTm: nowDateTime,
+        creDtTm: expect.any(String),
       }),
     );
     const accountId = `${sampleAccountCondition.acct.id + sampleAccountCondition.acct.schmeNm.prtry + sampleAccountCondition.acct.agt.finInstnId.clrSysMmbId.mmbId}`;

--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -142,7 +142,6 @@ describe('handlePostConditionEntity', () => {
 
   it('should handle a successful post request for a debtor perspective', async () => {
     // Arrange
-    const nowDateTime = new Date().toISOString();
     const conditionDebtor = { ...sampleEntityCondition, prsptv: 'debtor' };
 
     // Act
@@ -152,7 +151,7 @@ describe('handlePostConditionEntity', () => {
     expect(databaseManager.saveCondition).toHaveBeenCalledWith(
       expect.objectContaining({
         ...conditionDebtor,
-        creDtTm: nowDateTime,
+        creDtTm: expect.any(String),
       }),
     );
     const entityId = `${conditionDebtor.ntty.id}${conditionDebtor.ntty.schmeNm.prtry}`;

--- a/__tests__/unit/tcs-config.logic.service.test.ts
+++ b/__tests__/unit/tcs-config.logic.service.test.ts
@@ -456,6 +456,37 @@ describe('TCS Config Logic Service', () => {
       expect(result.mapping).toHaveLength(2);
     });
 
+    it('should add mapping when source is undefined', async () => {
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        mapping: undefined,
+        updatedAt: new Date(),
+      };
+
+      const newMapping = {
+        destination: 'targetField',
+        type: 'direct',
+      };
+
+      const mockUpdatedConfig = {
+        ...mockConfig,
+        mapping: [{ ...newMapping, source: undefined }],
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
+
+      const result = await tcsConfigService.handleAddMapping(1, mockTenantId, newMapping as any);
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(
+        1,
+        mockTenantId,
+        expect.objectContaining({ mapping: expect.any(Array) }),
+      );
+      expect(result).toEqual(mockUpdatedConfig);
+    });
+
     it('should throw error when config is not found', async () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
@@ -510,6 +541,28 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
 
       await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 5)).rejects.toThrow('Failed to remove mapping');
+    });
+
+    it('should set mapping to empty array when last mapping is removed', async () => {
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        mapping: [{ source: ['field1'], destination: 'target1', type: 'direct' }],
+        updatedAt: new Date(),
+      };
+
+      const mockUpdatedConfig = {
+        ...mockConfig,
+        mapping: [],
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
+
+      const result = await tcsConfigService.handleRemoveMapping(1, mockTenantId, 0);
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [] });
+      expect(result.mapping).toEqual([]);
     });
   });
 
@@ -575,6 +628,35 @@ describe('TCS Config Logic Service', () => {
       expect(result.functions?.[0]).toEqual(expectedFunction);
     });
 
+    it('should add function to config when functions list is null', async () => {
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        functions: null,
+        updatedAt: new Date(),
+      };
+
+      const newFunction = {
+        functionName: 'testFunction',
+        params: ['param1'],
+        tableName: 'testTable',
+        columns: ['col1'],
+      };
+
+      const mockUpdatedConfig = {
+        ...mockConfig,
+        functions: [newFunction],
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
+
+      const result = await tcsConfigService.handleAddFunction(1, mockTenantId, newFunction);
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [newFunction] });
+      expect(result.functions?.[0]).toEqual(newFunction);
+    });
+
     it('should throw error when config is not found', async () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
@@ -616,6 +698,28 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
       await expect(tcsConfigService.handleRemoveFunction(999, mockTenantId, 0)).rejects.toThrow('Failed to remove function');
+    });
+
+    it('should set functions to empty array when last function is removed', async () => {
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        functions: [{ functionName: 'func1', params: [], tableName: '', columns: [] }],
+        updatedAt: new Date(),
+      };
+
+      const mockUpdatedConfig = {
+        ...mockConfig,
+        functions: [],
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
+
+      const result = await tcsConfigService.handleRemoveFunction(1, mockTenantId, 0);
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [] });
+      expect(result.functions).toEqual([]);
     });
 
     it('should throw error when function index is invalid', async () => {
@@ -716,6 +820,26 @@ describe('TCS Config Logic Service', () => {
       await expect(tcsConfigService.handleGetConfigByTransactionType('invalid.type', '1.0.0', mockTenantId)).rejects.toThrow(
         'Configuration not found',
       );
+    });
+
+    it('should retrieve config with XML payload when content type is XML', async () => {
+      const mockConfig = {
+        schema: { type: 'object' },
+        mapping: { field: 'value' },
+        content_type: 'application/xml',
+        payload_xml: '<root><data>test</data></root>',
+        payload_json: null,
+      };
+
+      (tcsConfigRepository.getSchemaByTransactionType as jest.Mock).mockResolvedValue(mockConfig);
+
+      const result = await tcsConfigService.handleGetConfigByTransactionType('pacs.008.001.10', '1.0.0', mockTenantId);
+
+      expect(result).toEqual({
+        schema: mockConfig.schema,
+        mapping: mockConfig.mapping,
+        payload: mockConfig.payload_xml,
+      });
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2370,6 +2371,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3029,6 +3031,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3206,6 +3209,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3694,6 +3698,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4369,6 +4374,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5591,6 +5597,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5691,6 +5698,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6424,6 +6432,7 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -7427,6 +7436,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -8005,6 +8015,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8734,6 +8745,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9967,6 +9979,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10272,6 +10285,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11880,6 +11894,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12122,6 +12137,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -380,19 +380,16 @@ export const getPayloadByTransactionType = async (transactionType: string, tenan
   if (!transactionType || !tenantId || !version) {
     throw new Error('Transaction type, tenant ID, and version are required');
   }
-
   const query = `
     SELECT 
       content_type,
-      CASE 
-        WHEN content_type = 'XML' THEN payload_xml 
-        ELSE payload_json 
-      END AS payload
+      payload_xml,
+      payload_json
     FROM tcs_config
     WHERE transaction_type = $1 AND tenant_id = $2 AND version = $3
   `;
 
-  const result = await handlePostExecuteSqlStatement<{ content_type: string; payload: unknown }>(
+  const result = await handlePostExecuteSqlStatement<{ content_type: string; payload_xml: string | null; payload_json: unknown }>(
     { text: query, values: [transactionType, tenantId, version] } satisfies PgQueryConfig,
     'configuration',
   );
@@ -400,8 +397,11 @@ export const getPayloadByTransactionType = async (transactionType: string, tenan
   if (result.rows.length === 0) {
     throw new Error('Configuration not found');
   }
-
-  return result.rows[0].payload;
+  if (result.rows[0].payload_xml) {
+    return result.rows[0].payload_xml;
+  } else {
+    return result.rows[0].payload_json;
+  }
 };
 
 export const getSchemaByTransactionType = async (
@@ -430,10 +430,7 @@ export const getSchemaByTransactionType = async (
     content_type: string;
     payload_xml: string | null;
     payload_json: unknown;
-  }>(
-    { text: query, values: [transactionType, version, tenantId] } satisfies PgQueryConfig,
-    'configuration',
-  );
+  }>({ text: query, values: [transactionType, version, tenantId] } satisfies PgQueryConfig, 'configuration');
 
   if (result.rows.length === 0) {
     throw new Error('Configuration not found');

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -355,9 +355,9 @@ export const updateConfig = async (
   return updatedConfig as unknown as Config;
 };
 
-export const findAllTransactionTypes = async (tenantId: string): Promise<string[]> => {
+export const findAllTransactionTypes = async (tenantId: string): Promise<Array<Record<string, unknown>>> => {
   const query = `
-    SELECT DISTINCT transaction_type
+    SELECT DISTINCT transaction_type, endpoint_path
     FROM tcs_config
     WHERE tenant_id = $1
       AND (
@@ -368,12 +368,12 @@ export const findAllTransactionTypes = async (tenantId: string): Promise<string[
     ORDER BY transaction_type
   `;
 
-  const result = await handlePostExecuteSqlStatement<{ transaction_type: string }>(
+  const result = await handlePostExecuteSqlStatement<{ transaction_type: string; endpoint_path: string }>(
     { text: query, values: [tenantId] } satisfies PgQueryConfig,
     'configuration',
   );
 
-  return result.rows.map((row) => row.transaction_type);
+  return result.rows.map((row) => row);
 };
 
 export const getPayloadByTransactionType = async (transactionType: string, tenantId: string, version: string): Promise<unknown> => {
@@ -430,10 +430,7 @@ export const getSchemaByTransactionType = async (
     content_type: string;
     payload_xml: string | null;
     payload_json: unknown;
-  }>(
-    { text: query, values: [transactionType, version, tenantId] } satisfies PgQueryConfig,
-    'configuration',
-  );
+  }>({ text: query, values: [transactionType, version, tenantId] } satisfies PgQueryConfig, 'configuration');
 
   if (result.rows.length === 0) {
     throw new Error('Configuration not found');

--- a/src/services/tcs-config.logic.service.ts
+++ b/src/services/tcs-config.logic.service.ts
@@ -350,14 +350,14 @@ export const handleRemoveFunction = async (id: number, tenantId: string, functio
   }
 };
 
-export const handleGetAllTransactionTypes = async (tenantId: string): Promise<string[]> => {
+export const handleGetAllTransactionTypes = async (tenantId: string): Promise<Array<Record<string, unknown>>> => {
   try {
     loggerService.log(`Getting all transaction types for tenant: ${tenantId}`);
 
-    const transactionTypes = await findAllTransactionTypes(tenantId);
+    const transactiondetails = await findAllTransactionTypes(tenantId);
 
-    loggerService.log(`Successfully retrieved ${transactionTypes.length} transaction types`);
-    return transactionTypes;
+    loggerService.log(`Successfully retrieved ${transactiondetails.length} transaction types`);
+    return transactiondetails;
   } catch (error) {
     const errorMessage = error as { message: string };
     loggerService.error(`Error getting transaction types: ${errorMessage.message}`, 'handleGetAllTransactionTypes');
@@ -386,10 +386,7 @@ export const handleGetConfigByTransactionType = async (transactionType: string, 
 
     const config = await getSchemaByTransactionType(transactionType, version, tenantId);
 
-    const payload =
-      config.content_type === ContentType.XML
-        ? config.payload_xml
-        : config.payload_json;
+    const payload = (config.content_type as ContentType) === ContentType.XML ? config.payload_xml : config.payload_json;
 
     return {
       schema: config.schema,


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request primarily enhances the test coverage and robustness of the TCS Config Logic Service and related repository logic. It introduces additional unit tests for edge cases (such as handling undefined or empty arrays for mappings/functions), and improves the handling of payload retrieval based on content type in the repository. Minor test simplifications were also made in the event flow tests.

**TCS Config Logic Service Test Improvements:**

- Added tests to ensure that mappings can be added when the mapping list is undefined, and that the mapping array is set to empty when the last mapping is removed. [[1]](diffhunk://#diff-4e8d5384447f6958915a3af61f2251e825bbc5a82379fa0b2cb979f1d159e11bR459-R489) [[2]](diffhunk://#diff-4e8d5384447f6958915a3af61f2251e825bbc5a82379fa0b2cb979f1d159e11bR545-R566)
- Added tests to verify that functions can be added when the functions list is null, and that the functions array is set to empty when the last function is removed. [[1]](diffhunk://#diff-4e8d5384447f6958915a3af61f2251e825bbc5a82379fa0b2cb979f1d159e11bR631-R659) [[2]](diffhunk://#diff-4e8d5384447f6958915a3af61f2251e825bbc5a82379fa0b2cb979f1d159e11bR703-R724)
- Added a test to confirm that configuration retrieval returns the XML payload when the content type is XML.

**Repository Logic Enhancements:**

- Updated `getPayloadByTransactionType` in `tcs.config.repository.ts` to explicitly select and return either the XML or JSON payload based on which is present, rather than relying on a CASE statement in SQL.
- Minor query formatting improvement in `getSchemaByTransactionType` for clarity and consistency.

**Event Flow Test Simplifications:**

- Simplified assertions in event flow tests to use `expect.any(String)` for date-time fields, removing unnecessary date setup. [[1]](diffhunk://#diff-3184b2c3425a429ba9fcb1a629b957dbe46d9582712583b1f18269fccfdf69f9L145) [[2]](diffhunk://#diff-3184b2c3425a429ba9fcb1a629b957dbe46d9582712583b1f18269fccfdf69f9L155-R154) [[3]](diffhunk://#diff-3184b2c3425a429ba9fcb1a629b957dbe46d9582712583b1f18269fccfdf69f9L208-L209) [[4]](diffhunk://#diff-3184b2c3425a429ba9fcb1a629b957dbe46d9582712583b1f18269fccfdf69f9L220-R217) [[5]](diffhunk://#diff-3184b2c3425a429ba9fcb1a629b957dbe46d9582712583b1f18269fccfdf69f9L468) [[6]](diffhunk://#diff-3184b2c3425a429ba9fcb1a629b957dbe46d9582712583b1f18269fccfdf69f9L478-R474)

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
