### PR TITLE
fix:  restore optimistic locking for TCS config updates

### DIFF
--- a/__tests__/unit/tcs-config.logic.service.test.ts
+++ b/__tests__/unit/tcs-config.logic.service.test.ts
@@ -495,6 +495,13 @@ describe('TCS Config Logic Service', () => {
       await expect(
         tcsConfigService.handleAddMapping(1, mockTenantId, { source: ['field'], destination: 'target', type: 'direct' } as any, updatedAt),
       ).rejects.toMatchObject({ status: 409 });
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(
+        1,
+        mockTenantId,
+        { mapping: [{ source: ['field'], destination: 'target', type: 'direct' }] },
+        updatedAt,
+      );
     });
   });
 
@@ -564,6 +571,8 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
       await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 0, updatedAt)).rejects.toMatchObject({ status: 409 });
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [] }, updatedAt);
     });
   });
 
@@ -656,6 +665,13 @@ describe('TCS Config Logic Service', () => {
       await expect(tcsConfigService.handleAddFunction(1, mockTenantId, { functionName: 'testFn' }, updatedAt)).rejects.toMatchObject({
         status: 409,
       });
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(
+        1,
+        mockTenantId,
+        { functions: [{ functionName: 'testFn', params: [], tableName: '', columns: [] }] },
+        updatedAt,
+      );
     });
   });
 
@@ -725,6 +741,8 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
       await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 0, updatedAt)).rejects.toMatchObject({ status: 409 });
+
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [] }, updatedAt);
     });
   });
 

--- a/__tests__/unit/tcs-config.logic.service.test.ts
+++ b/__tests__/unit/tcs-config.logic.service.test.ts
@@ -229,11 +229,13 @@ describe('TCS Config Logic Service', () => {
 
   describe('handleUpdateConfig', () => {
     it('should update config successfully', async () => {
-      const mockExistingConfig = {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
+      const mockUpdatedConfig = {
         id: 1,
-        msgFam: 'ISO20022',
+        msgFam: 'ISO20022Updated',
         transactionType: 'pacs.008.001.10',
-        updatedAt: new Date(),
+        description: 'Updated description',
+        updatedAt,
       };
 
       const updateData = {
@@ -241,58 +243,39 @@ describe('TCS Config Logic Service', () => {
         description: 'Updated description',
       };
 
-      const mockUpdatedConfig = {
-        ...mockExistingConfig,
-        ...updateData,
-      };
-
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleUpdateConfig(1, mockTenantId, updateData);
+      const result = await tcsConfigService.handleUpdateConfig(1, mockTenantId, updateData, updatedAt);
 
-      expect(tcsConfigRepository.findConfigById).toHaveBeenCalledWith(1, mockTenantId);
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, updateData, expect.any(String));
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, updateData, updatedAt);
       expect(result).toEqual(mockUpdatedConfig);
     });
 
     it('should throw HTTP 409 when update has a version conflict', async () => {
-      const mockExistingConfig = {
-        id: 1,
-        msgFam: 'ISO20022',
-        updatedAt: new Date(),
-      };
+      const updatedAt = '2026-04-07T10:00:00.000Z';
 
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(
         new (tcsConfigRepository.ConfigConflictError as any)('Configuration has been modified by another process'),
       );
 
-      await expect(tcsConfigService.handleUpdateConfig(1, mockTenantId, { msgFam: 'Updated' })).rejects.toMatchObject({
+      await expect(tcsConfigService.handleUpdateConfig(1, mockTenantId, { msgFam: 'Updated' }, updatedAt)).rejects.toMatchObject({
         status: 409,
         message: 'Configuration has been modified by another process',
       });
     });
 
     it('should throw error when config to update is not found', async () => {
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new Error('Configuration not found'));
 
-      await expect(tcsConfigService.handleUpdateConfig(999, mockTenantId, { msgFam: 'Test' })).rejects.toThrow(
+      await expect(tcsConfigService.handleUpdateConfig(999, mockTenantId, { msgFam: 'Test' }, '2026-04-07T10:00:00.000Z')).rejects.toThrow(
         'Failed to update configuration',
       );
     });
 
     it('should throw error when update fails', async () => {
-      const mockExistingConfig = {
-        id: 1,
-        msgFam: 'ISO20022',
-        updatedAt: new Date(),
-      };
-
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new Error('Update failed'));
 
-      await expect(tcsConfigService.handleUpdateConfig(1, mockTenantId, { msgFam: 'Updated' })).rejects.toThrow(
+      await expect(tcsConfigService.handleUpdateConfig(1, mockTenantId, { msgFam: 'Updated' }, '2026-04-07T10:00:00.000Z')).rejects.toThrow(
         'Failed to update configuration',
       );
     });
@@ -300,68 +283,52 @@ describe('TCS Config Logic Service', () => {
 
   describe('handleUpdatePublishingStatus', () => {
     it('should update publishing status to active', async () => {
-      const mockExistingConfig = {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
+      const mockUpdatedConfig = {
         id: 1,
         msgFam: 'ISO20022',
-        publishing_status: 'inactive',
-        updatedAt: new Date(),
-      };
-
-      const mockUpdatedConfig = {
-        ...mockExistingConfig,
         publishing_status: 'active',
+        updatedAt,
       };
 
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'active');
+      const result = await tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'active', updatedAt);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { publishing_status: 'active' }, expect.any(String));
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { publishing_status: 'active' }, updatedAt);
       expect(result.publishing_status).toBe('active');
     });
 
     it('should update publishing status to inactive', async () => {
-      const mockExistingConfig = {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
+      const mockUpdatedConfig = {
         id: 1,
         msgFam: 'ISO20022',
-        publishing_status: 'active',
-        updatedAt: new Date(),
-      };
-
-      const mockUpdatedConfig = {
-        ...mockExistingConfig,
         publishing_status: 'inactive',
+        updatedAt,
       };
 
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'inactive');
+      const result = await tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'inactive', updatedAt);
 
       expect(result.publishing_status).toBe('inactive');
     });
 
     it('should throw error when config is not found', async () => {
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new Error('Configuration not found'));
 
-      await expect(tcsConfigService.handleUpdatePublishingStatus(999, mockTenantId, 'active')).rejects.toThrow(
+      await expect(tcsConfigService.handleUpdatePublishingStatus(999, mockTenantId, 'active', '2026-04-07T10:00:00.000Z')).rejects.toThrow(
         'Failed to update publishing status',
       );
     });
 
     it('should throw HTTP 409 when publishing status update has a version conflict', async () => {
-      const mockExistingConfig = {
-        id: 1,
-        msgFam: 'ISO20022',
-        publishing_status: 'inactive',
-        updatedAt: new Date(),
-      };
-
-      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
-      await expect(tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'active')).rejects.toMatchObject({
+      await expect(
+        tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'active', '2026-04-07T10:00:00.000Z'),
+      ).rejects.toMatchObject({
         status: 409,
       });
     });
@@ -438,11 +405,12 @@ describe('TCS Config Logic Service', () => {
 
   describe('handleAddMapping', () => {
     it('should add mapping to config successfully', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         mapping: [],
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       const newMapping = {
@@ -459,13 +427,14 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleAddMapping(1, mockTenantId, newMapping);
+      const result = await tcsConfigService.handleAddMapping(1, mockTenantId, newMapping, updatedAt);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [newMapping] }, expect.any(String));
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [newMapping] }, updatedAt);
       expect(result.mapping?.[0]).toEqual(newMapping);
     });
 
     it('should add mapping to existing mappings', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const existingMapping = {
         source: ['oldField'],
         destination: 'oldTarget',
@@ -476,7 +445,7 @@ describe('TCS Config Logic Service', () => {
         id: 1,
         msgFam: 'ISO20022',
         mapping: [existingMapping],
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       const newMapping = {
@@ -493,7 +462,7 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleAddMapping(1, mockTenantId, newMapping as any);
+      const result = await tcsConfigService.handleAddMapping(1, mockTenantId, newMapping as any, updatedAt);
 
       expect(result.mapping).toHaveLength(2);
     });
@@ -502,29 +471,36 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
       await expect(
-        tcsConfigService.handleAddMapping(999, mockTenantId, { source: ['field'], destination: 'target', type: 'direct' } as any),
+        tcsConfigService.handleAddMapping(
+          999,
+          mockTenantId,
+          { source: ['field'], destination: 'target', type: 'direct' } as any,
+          '2026-04-07T10:00:00.000Z',
+        ),
       ).rejects.toThrow('Failed to add mapping');
     });
 
     it('should throw HTTP 409 when add mapping has a version conflict', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         mapping: [],
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
       await expect(
-        tcsConfigService.handleAddMapping(1, mockTenantId, { source: ['field'], destination: 'target', type: 'direct' } as any),
+        tcsConfigService.handleAddMapping(1, mockTenantId, { source: ['field'], destination: 'target', type: 'direct' } as any, updatedAt),
       ).rejects.toMatchObject({ status: 409 });
     });
   });
 
   describe('handleRemoveMapping', () => {
     it('should remove mapping from config successfully', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mappings = [
         { source: ['field1'], destination: 'target1', type: 'direct' },
         { source: ['field2'], destination: 'target2', type: 'transform' },
@@ -534,7 +510,7 @@ describe('TCS Config Logic Service', () => {
         id: 1,
         msgFam: 'ISO20022',
         mapping: mappings,
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       const mockUpdatedConfig = {
@@ -545,16 +521,18 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleRemoveMapping(1, mockTenantId, 0);
+      const result = await tcsConfigService.handleRemoveMapping(1, mockTenantId, 0, updatedAt);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [mappings[1]] }, expect.any(String));
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [mappings[1]] }, updatedAt);
       expect(result.mapping?.[0]).toEqual(mappings[1]);
     });
 
     it('should throw error when config is not found', async () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
-      await expect(tcsConfigService.handleRemoveMapping(999, mockTenantId, 0)).rejects.toThrow('Failed to remove mapping');
+      await expect(tcsConfigService.handleRemoveMapping(999, mockTenantId, 0, '2026-04-07T10:00:00.000Z')).rejects.toThrow(
+        'Failed to remove mapping',
+      );
     });
 
     it('should throw error when mapping index is invalid', async () => {
@@ -567,32 +545,36 @@ describe('TCS Config Logic Service', () => {
 
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
 
-      await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 5)).rejects.toThrow('Failed to remove mapping');
+      await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 5, '2026-04-07T10:00:00.000Z')).rejects.toThrow(
+        'Failed to remove mapping',
+      );
     });
 
     it('should throw HTTP 409 when remove mapping has a version conflict', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mappings = [{ source: ['field1'], destination: 'target1', type: 'direct' }];
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         mapping: mappings,
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
-      await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 0)).rejects.toMatchObject({ status: 409 });
+      await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 0, updatedAt)).rejects.toMatchObject({ status: 409 });
     });
   });
 
   describe('handleAddFunction', () => {
     it('should add function to config successfully', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         functions: [],
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       const newFunction = {
@@ -610,18 +592,19 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleAddFunction(1, mockTenantId, newFunction);
+      const result = await tcsConfigService.handleAddFunction(1, mockTenantId, newFunction, updatedAt);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [newFunction] }, expect.any(String));
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [newFunction] }, updatedAt);
       expect(result.functions?.[0]).toEqual(newFunction);
     });
 
     it('should add function with default empty arrays', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         functions: [],
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       const newFunction = {
@@ -643,7 +626,7 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleAddFunction(1, mockTenantId, newFunction);
+      const result = await tcsConfigService.handleAddFunction(1, mockTenantId, newFunction, updatedAt);
 
       expect(result.functions?.[0]).toEqual(expectedFunction);
     });
@@ -651,23 +634,26 @@ describe('TCS Config Logic Service', () => {
     it('should throw error when config is not found', async () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
-      await expect(tcsConfigService.handleAddFunction(999, mockTenantId, { functionName: 'test' })).rejects.toThrow(
+      await expect(
+        tcsConfigService.handleAddFunction(999, mockTenantId, { functionName: 'test' }, '2026-04-07T10:00:00.000Z'),
+      ).rejects.toThrow(
         'Failed to add function',
       );
     });
 
     it('should throw HTTP 409 when add function has a version conflict', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         functions: [],
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
-      await expect(tcsConfigService.handleAddFunction(1, mockTenantId, { functionName: 'testFn' })).rejects.toMatchObject({
+      await expect(tcsConfigService.handleAddFunction(1, mockTenantId, { functionName: 'testFn' }, updatedAt)).rejects.toMatchObject({
         status: 409,
       });
     });
@@ -675,6 +661,7 @@ describe('TCS Config Logic Service', () => {
 
   describe('handleRemoveFunction', () => {
     it('should remove function from config successfully', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const functions = [
         { functionName: 'func1', params: [], tableName: '', columns: [] },
         { functionName: 'func2', params: ['param1'], tableName: 'table1', columns: ['col1'] },
@@ -684,7 +671,7 @@ describe('TCS Config Logic Service', () => {
         id: 1,
         msgFam: 'ISO20022',
         functions: functions,
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       const mockUpdatedConfig = {
@@ -695,16 +682,18 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockResolvedValue(mockUpdatedConfig);
 
-      const result = await tcsConfigService.handleRemoveFunction(1, mockTenantId, 0);
+      const result = await tcsConfigService.handleRemoveFunction(1, mockTenantId, 0, updatedAt);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [functions[1]] }, expect.any(String));
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [functions[1]] }, updatedAt);
       expect(result.functions?.[0]).toEqual(functions[1]);
     });
 
     it('should throw error when config is not found', async () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(null);
 
-      await expect(tcsConfigService.handleRemoveFunction(999, mockTenantId, 0)).rejects.toThrow('Failed to remove function');
+      await expect(tcsConfigService.handleRemoveFunction(999, mockTenantId, 0, '2026-04-07T10:00:00.000Z')).rejects.toThrow(
+        'Failed to remove function',
+      );
     });
 
     it('should throw error when function index is invalid', async () => {
@@ -717,22 +706,25 @@ describe('TCS Config Logic Service', () => {
 
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
 
-      await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 10)).rejects.toThrow('Failed to remove function');
+      await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 10, '2026-04-07T10:00:00.000Z')).rejects.toThrow(
+        'Failed to remove function',
+      );
     });
 
     it('should throw HTTP 409 when remove function has a version conflict', async () => {
+      const updatedAt = '2026-04-07T10:00:00.000Z';
       const functions = [{ functionName: 'func1', params: [], tableName: '', columns: [] }];
       const mockConfig = {
         id: 1,
         msgFam: 'ISO20022',
         functions,
-        updatedAt: new Date(),
+        updatedAt: '2026-04-07T09:59:00.000Z',
       };
 
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
       (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
 
-      await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 0)).rejects.toMatchObject({ status: 409 });
+      await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 0, updatedAt)).rejects.toMatchObject({ status: 409 });
     });
   });
 

--- a/__tests__/unit/tcs-config.logic.service.test.ts
+++ b/__tests__/unit/tcs-config.logic.service.test.ts
@@ -13,6 +13,12 @@ jest.mock('../../src/services/database.logic.service', () => ({
 }));
 
 jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
+  ConfigConflictError: class ConfigConflictError extends Error {
+    constructor(message = 'Configuration has been modified by another process') {
+      super(message);
+      this.name = 'ConfigConflictError';
+    }
+  },
   createConfig: jest.fn(),
   findConfigById: jest.fn(),
   findConfigsByStatus: jest.fn(),
@@ -246,8 +252,26 @@ describe('TCS Config Logic Service', () => {
       const result = await tcsConfigService.handleUpdateConfig(1, mockTenantId, updateData);
 
       expect(tcsConfigRepository.findConfigById).toHaveBeenCalledWith(1, mockTenantId);
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, updateData);
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, updateData, expect.any(String));
       expect(result).toEqual(mockUpdatedConfig);
+    });
+
+    it('should throw HTTP 409 when update has a version conflict', async () => {
+      const mockExistingConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        updatedAt: new Date(),
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(
+        new (tcsConfigRepository.ConfigConflictError as any)('Configuration has been modified by another process'),
+      );
+
+      await expect(tcsConfigService.handleUpdateConfig(1, mockTenantId, { msgFam: 'Updated' })).rejects.toMatchObject({
+        status: 409,
+        message: 'Configuration has been modified by another process',
+      });
     });
 
     it('should throw error when config to update is not found', async () => {
@@ -280,6 +304,7 @@ describe('TCS Config Logic Service', () => {
         id: 1,
         msgFam: 'ISO20022',
         publishing_status: 'inactive',
+        updatedAt: new Date(),
       };
 
       const mockUpdatedConfig = {
@@ -292,7 +317,7 @@ describe('TCS Config Logic Service', () => {
 
       const result = await tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'active');
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { publishing_status: 'active' });
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { publishing_status: 'active' }, expect.any(String));
       expect(result.publishing_status).toBe('active');
     });
 
@@ -301,6 +326,7 @@ describe('TCS Config Logic Service', () => {
         id: 1,
         msgFam: 'ISO20022',
         publishing_status: 'active',
+        updatedAt: new Date(),
       };
 
       const mockUpdatedConfig = {
@@ -322,6 +348,22 @@ describe('TCS Config Logic Service', () => {
       await expect(tcsConfigService.handleUpdatePublishingStatus(999, mockTenantId, 'active')).rejects.toThrow(
         'Failed to update publishing status',
       );
+    });
+
+    it('should throw HTTP 409 when publishing status update has a version conflict', async () => {
+      const mockExistingConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        publishing_status: 'inactive',
+        updatedAt: new Date(),
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockExistingConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
+
+      await expect(tcsConfigService.handleUpdatePublishingStatus(1, mockTenantId, 'active')).rejects.toMatchObject({
+        status: 409,
+      });
     });
   });
 
@@ -419,7 +461,7 @@ describe('TCS Config Logic Service', () => {
 
       const result = await tcsConfigService.handleAddMapping(1, mockTenantId, newMapping);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [newMapping] });
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [newMapping] }, expect.any(String));
       expect(result.mapping?.[0]).toEqual(newMapping);
     });
 
@@ -463,6 +505,22 @@ describe('TCS Config Logic Service', () => {
         tcsConfigService.handleAddMapping(999, mockTenantId, { source: ['field'], destination: 'target', type: 'direct' } as any),
       ).rejects.toThrow('Failed to add mapping');
     });
+
+    it('should throw HTTP 409 when add mapping has a version conflict', async () => {
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        mapping: [],
+        updatedAt: new Date(),
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
+
+      await expect(
+        tcsConfigService.handleAddMapping(1, mockTenantId, { source: ['field'], destination: 'target', type: 'direct' } as any),
+      ).rejects.toMatchObject({ status: 409 });
+    });
   });
 
   describe('handleRemoveMapping', () => {
@@ -489,7 +547,7 @@ describe('TCS Config Logic Service', () => {
 
       const result = await tcsConfigService.handleRemoveMapping(1, mockTenantId, 0);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [mappings[1]] });
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { mapping: [mappings[1]] }, expect.any(String));
       expect(result.mapping?.[0]).toEqual(mappings[1]);
     });
 
@@ -510,6 +568,21 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
 
       await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 5)).rejects.toThrow('Failed to remove mapping');
+    });
+
+    it('should throw HTTP 409 when remove mapping has a version conflict', async () => {
+      const mappings = [{ source: ['field1'], destination: 'target1', type: 'direct' }];
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        mapping: mappings,
+        updatedAt: new Date(),
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
+
+      await expect(tcsConfigService.handleRemoveMapping(1, mockTenantId, 0)).rejects.toMatchObject({ status: 409 });
     });
   });
 
@@ -539,7 +612,7 @@ describe('TCS Config Logic Service', () => {
 
       const result = await tcsConfigService.handleAddFunction(1, mockTenantId, newFunction);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [newFunction] });
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [newFunction] }, expect.any(String));
       expect(result.functions?.[0]).toEqual(newFunction);
     });
 
@@ -582,6 +655,22 @@ describe('TCS Config Logic Service', () => {
         'Failed to add function',
       );
     });
+
+    it('should throw HTTP 409 when add function has a version conflict', async () => {
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        functions: [],
+        updatedAt: new Date(),
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
+
+      await expect(tcsConfigService.handleAddFunction(1, mockTenantId, { functionName: 'testFn' })).rejects.toMatchObject({
+        status: 409,
+      });
+    });
   });
 
   describe('handleRemoveFunction', () => {
@@ -608,7 +697,7 @@ describe('TCS Config Logic Service', () => {
 
       const result = await tcsConfigService.handleRemoveFunction(1, mockTenantId, 0);
 
-      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [functions[1]] });
+      expect(tcsConfigRepository.updateConfig).toHaveBeenCalledWith(1, mockTenantId, { functions: [functions[1]] }, expect.any(String));
       expect(result.functions?.[0]).toEqual(functions[1]);
     });
 
@@ -629,6 +718,21 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
 
       await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 10)).rejects.toThrow('Failed to remove function');
+    });
+
+    it('should throw HTTP 409 when remove function has a version conflict', async () => {
+      const functions = [{ functionName: 'func1', params: [], tableName: '', columns: [] }];
+      const mockConfig = {
+        id: 1,
+        msgFam: 'ISO20022',
+        functions,
+        updatedAt: new Date(),
+      };
+
+      (tcsConfigRepository.findConfigById as jest.Mock).mockResolvedValue(mockConfig);
+      (tcsConfigRepository.updateConfig as jest.Mock).mockRejectedValue(new (tcsConfigRepository.ConfigConflictError as any)());
+
+      await expect(tcsConfigService.handleRemoveFunction(1, mockTenantId, 0)).rejects.toMatchObject({ status: 409 });
     });
   });
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -272,10 +272,10 @@ export const writeConfigUpdateHandler = async (req: FastifyRequest, reply: Fasti
   loggerService.log('Start - Handle write config update request');
   try {
     const { id } = req.params as { id: string };
-    const updateData = req.body as Record<string, unknown>;
+    const { updatedAt, ...updateData } = req.body as Record<string, unknown> & { updatedAt?: unknown };
     const { tenantId } = req as ITenantRequest;
 
-    const updatedConfig = await handleUpdateConfig(parseInt(id), tenantId, updateData as Partial<Config>);
+    const updatedConfig = await handleUpdateConfig(parseInt(id), tenantId, updateData as Partial<Config>, updatedAt);
     reply.code(200).send({ success: true, message: 'Config updated successfully', config: updatedConfig });
   } catch (error: unknown) {
     ErrorHandler.sendError(reply, error, 'Failed to update config');
@@ -288,7 +288,10 @@ export const updatePublishingStatusHandler = async (req: FastifyRequest, reply: 
   loggerService.log('Start - Handle update publishing status request');
   try {
     const { id } = req.params as { id: string };
-    const { publishing_status: publishingStatus } = req.body as { publishing_status?: 'active' | 'inactive' };
+    const { publishing_status: publishingStatus, updatedAt } = req.body as {
+      publishing_status?: 'active' | 'inactive';
+      updatedAt?: unknown;
+    };
     const { tenantId } = req as ITenantRequest;
     const configId = parseInt(id);
 
@@ -302,7 +305,7 @@ export const updatePublishingStatusHandler = async (req: FastifyRequest, reply: 
       return;
     }
 
-    const updatedConfig = await handleUpdatePublishingStatus(configId, tenantId, publishingStatus);
+    const updatedConfig = await handleUpdatePublishingStatus(configId, tenantId, publishingStatus, updatedAt);
     reply.code(200).send({
       success: true,
       message: `Publishing status updated to ${publishingStatus}`,
@@ -391,9 +394,9 @@ export const addMappingHandler = async (req: FastifyRequest, reply: FastifyReply
   try {
     const { id } = req.params as { id: string };
     const { tenantId } = req as ITenantRequest;
-    const mappingDto = req.body as AddMappingDto;
+    const { updatedAt, ...mappingDto } = req.body as AddMappingDto & { updatedAt?: unknown };
 
-    const updatedConfig = await handleAddMapping(Number(id), tenantId, mappingDto);
+    const updatedConfig = await handleAddMapping(Number(id), tenantId, mappingDto as AddMappingDto, updatedAt);
 
     reply.status(200).send({
       success: true,
@@ -413,8 +416,9 @@ export const removeMappingHandler = async (req: FastifyRequest, reply: FastifyRe
     const { id, index } = req.params as { id: string; index: string };
     const { tenantId } = req as ITenantRequest;
     const mappingIndex = Number(index);
+    const { updatedAt } = req.body as { updatedAt?: unknown };
 
-    const updatedConfig = await handleRemoveMapping(Number(id), tenantId, mappingIndex);
+    const updatedConfig = await handleRemoveMapping(Number(id), tenantId, mappingIndex, updatedAt);
 
     reply.status(200).send({
       success: true,
@@ -433,9 +437,9 @@ export const addFunctionHandler = async (req: FastifyRequest, reply: FastifyRepl
   try {
     const { id } = req.params as { id: string };
     const { tenantId } = req as ITenantRequest;
-    const functionDto = req.body as AddFunctionDto;
+    const { updatedAt, ...functionDto } = req.body as AddFunctionDto & { updatedAt?: unknown };
 
-    const updatedConfig = await handleAddFunction(Number(id), tenantId, functionDto);
+    const updatedConfig = await handleAddFunction(Number(id), tenantId, functionDto as AddFunctionDto, updatedAt);
 
     reply.status(200).send({
       success: true,
@@ -455,8 +459,9 @@ export const removeFunctionHandler = async (req: FastifyRequest, reply: FastifyR
     const { id, index } = req.params as { id: string; index: string };
     const { tenantId } = req as ITenantRequest;
     const functionIndex = Number(index);
+    const { updatedAt } = req.body as { updatedAt?: unknown };
 
-    const updatedConfig = await handleRemoveFunction(Number(id), tenantId, functionIndex);
+    const updatedConfig = await handleRemoveFunction(Number(id), tenantId, functionIndex, updatedAt);
 
     reply.status(200).send({
       success: true,

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -230,7 +230,7 @@ export const updateConfig = async (
   id: number,
   tenantId: string,
   updates: Partial<Config> & { relatedTransaction?: string; related_transaction?: string },
-  expectedUpdatedAt: string,
+  updatedAt: string,
 ): Promise<Config> => {
   const setClauses: string[] = [];
   const values: Array<string | number | object> = [];
@@ -309,7 +309,7 @@ export const updateConfig = async (
               status, publishing_status, created_at, updated_at, tenant_id, created_by, related_transaction
   `;
 
-  values.push(id, tenantId, expectedUpdatedAt);
+  values.push(id, tenantId, updatedAt);
 
   interface UpdateConfigRow {
     id: number;

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -7,6 +7,13 @@ import { validateTableName } from '../../utils/enrichment-utils';
 
 export type { ConfigData, ConfigRow };
 
+export class ConfigConflictError extends Error {
+  constructor(message = 'Configuration has been modified by another process') {
+    super(message);
+    this.name = 'ConfigConflictError';
+  }
+}
+
 const mapRowToConfig = (row: ConfigRow): Config => {
   const mapped = {
     id: row.id,
@@ -223,6 +230,7 @@ export const updateConfig = async (
   id: number,
   tenantId: string,
   updates: Partial<Config> & { relatedTransaction?: string; related_transaction?: string },
+  expectedUpdatedAt: string,
 ): Promise<Config> => {
   const setClauses: string[] = [];
   const values: Array<string | number | object> = [];
@@ -289,7 +297,8 @@ export const updateConfig = async (
 
   setClauses.push('updated_at = NOW()');
 
-  const whereClause = `WHERE id = $${paramIndex} AND tenant_id = $${paramIndex + 1}`;
+  // Optimistic lock: update only when updated_at still matches the token returned by the previous read.
+  const whereClause = `WHERE id = $${paramIndex} AND tenant_id = $${paramIndex + 1} AND updated_at = $${paramIndex + 2}::timestamptz`;
 
   const query = `
     UPDATE tcs_config
@@ -300,7 +309,7 @@ export const updateConfig = async (
               status, publishing_status, created_at, updated_at, tenant_id, created_by, related_transaction
   `;
 
-  values.push(id, tenantId);
+  values.push(id, tenantId, expectedUpdatedAt);
 
   interface UpdateConfigRow {
     id: number;
@@ -327,6 +336,18 @@ export const updateConfig = async (
   const result = await handlePostExecuteSqlStatement<UpdateConfigRow>({ text: query, values } satisfies PgQueryConfig, 'configuration');
 
   if (result.rows.length === 0) {
+    const existenceCheck = await handlePostExecuteSqlStatement<{ id: number }>(
+      {
+        text: 'SELECT id FROM tcs_config WHERE id = $1 AND tenant_id = $2',
+        values: [id, tenantId],
+      } satisfies PgQueryConfig,
+      'configuration',
+    );
+
+    if (existenceCheck.rows.length > 0) {
+      throw new ConfigConflictError();
+    }
+
     throw new Error('Configuration not found');
   }
 

--- a/src/services/tcs-config.logic.service.ts
+++ b/src/services/tcs-config.logic.service.ts
@@ -27,15 +27,11 @@ import type { ConfigData, ConfigInput, ConfigResponse } from '../interface/confi
 import { HttpException, HttpStatus } from '../utils/error';
 
 const getUpdatedAt = (updatedAt: unknown): string => {
-  if (updatedAt instanceof Date) {
-    return updatedAt.toISOString();
-  }
-
-  if (typeof updatedAt === 'string' && updatedAt.length > 0) {
+  if (typeof updatedAt === 'string' && updatedAt.trim().length > 0) {
     return updatedAt;
   }
 
-  throw new Error('Missing configuration version token');
+  throw new HttpException('Missing configuration version token', HttpStatus.BAD_REQUEST);
 };
 
 export const handlePostConfig = async (config: ConfigInput, tenantId: string): Promise<{ message: string; result: ConfigResponse }> => {
@@ -159,6 +155,10 @@ export const handleUpdateConfig = async (id: number, tenantId: string, updates: 
     loggerService.log(`Successfully updated config ID: ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
     if (error instanceof ConfigConflictError) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
     }
@@ -184,6 +184,10 @@ export const handleUpdatePublishingStatus = async (
 
     return updatedConfig;
   } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
     if (error instanceof ConfigConflictError) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
     }
@@ -271,6 +275,10 @@ export const handleAddMapping = async (id: number, tenantId: string, mappingDto:
     loggerService.log(`Successfully added mapping to config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
     if (error instanceof ConfigConflictError) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
     }
@@ -307,6 +315,10 @@ export const handleRemoveMapping = async (id: number, tenantId: string, mappingI
     loggerService.log(`Successfully removed mapping from config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
     if (error instanceof ConfigConflictError) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
     }
@@ -341,6 +353,10 @@ export const handleAddFunction = async (id: number, tenantId: string, functionDt
     loggerService.log(`Successfully added function to config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
     if (error instanceof ConfigConflictError) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
     }
@@ -377,6 +393,10 @@ export const handleRemoveFunction = async (id: number, tenantId: string, functio
     loggerService.log(`Successfully removed function from config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
     if (error instanceof ConfigConflictError) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
     }

--- a/src/services/tcs-config.logic.service.ts
+++ b/src/services/tcs-config.logic.service.ts
@@ -11,6 +11,7 @@ import {
 } from '@tazama-lf/tcs-lib';
 import {
   createConfig,
+  ConfigConflictError,
   findConfigById,
   findConfigsByStatus,
   updateConfig,
@@ -23,6 +24,19 @@ import {
   getRelatedTransactions,
 } from '../repositories/configuration/tcs.config.repository';
 import type { ConfigData, ConfigInput, ConfigResponse } from '../interface/config.interface';
+import { HttpException, HttpStatus } from '../utils/error';
+
+const getExpectedUpdatedAt = (updatedAt: unknown): string => {
+  if (updatedAt instanceof Date) {
+    return updatedAt.toISOString();
+  }
+
+  if (typeof updatedAt === 'string' && updatedAt.length > 0) {
+    return updatedAt;
+  }
+
+  throw new Error('Missing configuration version token');
+};
 
 export const handlePostConfig = async (config: ConfigInput, tenantId: string): Promise<{ message: string; result: ConfigResponse }> => {
   try {
@@ -146,11 +160,15 @@ export const handleUpdateConfig = async (id: number, tenantId: string, updates: 
       throw new Error('Configuration not found');
     }
 
-    const updatedConfig = await updateConfig(id, tenantId, updates);
+    const updatedConfig = await updateConfig(id, tenantId, updates, getExpectedUpdatedAt(existingConfig.updatedAt));
 
     loggerService.log(`Successfully updated config ID: ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof ConfigConflictError) {
+      throw new HttpException(error.message, HttpStatus.CONFLICT);
+    }
+
     const errorMessage = error as { message: string };
     loggerService.error(`Error: updating config with error message: ${errorMessage.message}`, 'handleUpdateConfig');
     throw new Error('Failed to update configuration');
@@ -171,12 +189,16 @@ export const handleUpdatePublishingStatus = async (
       throw new Error('Configuration not found');
     }
 
-    const updatedConfig = await updateConfig(id, tenantId, { publishing_status: publishingStatus });
+    const updatedConfig = await updateConfig(id, tenantId, { publishing_status: publishingStatus }, getExpectedUpdatedAt(existingConfig.updatedAt));
 
     loggerService.log(`[${tenantId}] Publishing status updated to '${publishingStatus}' for config ${id}`);
 
     return updatedConfig;
   } catch (error) {
+    if (error instanceof ConfigConflictError) {
+      throw new HttpException(error.message, HttpStatus.CONFLICT);
+    }
+
     const errorMessage = error as { message: string };
     loggerService.error(`Error: updating publishing status with error message: ${errorMessage.message}`, 'handleUpdatePublishingStatus');
     throw new Error('Failed to update publishing status');
@@ -255,11 +277,15 @@ export const handleAddMapping = async (id: number, tenantId: string, mappingDto:
 
     const updatedMappings = [...(config.mapping ?? []), newMapping];
 
-    const updatedConfig = await updateConfig(id, tenantId, { mapping: updatedMappings });
+    const updatedConfig = await updateConfig(id, tenantId, { mapping: updatedMappings }, getExpectedUpdatedAt(config.updatedAt));
 
     loggerService.log(`Successfully added mapping to config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof ConfigConflictError) {
+      throw new HttpException(error.message, HttpStatus.CONFLICT);
+    }
+
     const errorMessage = error as { message: string };
     loggerService.error(`Error adding mapping: ${errorMessage.message}`, 'handleAddMapping');
     throw new Error('Failed to add mapping');
@@ -282,11 +308,20 @@ export const handleRemoveMapping = async (id: number, tenantId: string, mappingI
 
     const updatedMappings = config.mapping.filter((_item, idx) => idx !== mappingIndex);
 
-    const updatedConfig = await updateConfig(id, tenantId, { mapping: updatedMappings.length > 0 ? updatedMappings : [] });
+    const updatedConfig = await updateConfig(
+      id,
+      tenantId,
+      { mapping: updatedMappings.length > 0 ? updatedMappings : [] },
+      getExpectedUpdatedAt(config.updatedAt),
+    );
 
     loggerService.log(`Successfully removed mapping from config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof ConfigConflictError) {
+      throw new HttpException(error.message, HttpStatus.CONFLICT);
+    }
+
     const errorMessage = error as { message: string };
     loggerService.error(`Error removing mapping: ${errorMessage.message}`, 'handleRemoveMapping');
     throw new Error('Failed to remove mapping');
@@ -312,11 +347,15 @@ export const handleAddFunction = async (id: number, tenantId: string, functionDt
 
     const updatedFunctions = [...(config.functions ?? []), newFunction];
 
-    const updatedConfig = await updateConfig(id, tenantId, { functions: updatedFunctions });
+    const updatedConfig = await updateConfig(id, tenantId, { functions: updatedFunctions }, getExpectedUpdatedAt(config.updatedAt));
 
     loggerService.log(`Successfully added function to config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof ConfigConflictError) {
+      throw new HttpException(error.message, HttpStatus.CONFLICT);
+    }
+
     const errorMessage = error as { message: string };
     loggerService.error(`Error adding function: ${errorMessage.message}`, 'handleAddFunction');
     throw new Error('Failed to add function');
@@ -339,11 +378,20 @@ export const handleRemoveFunction = async (id: number, tenantId: string, functio
 
     const updatedFunctions = config.functions.filter((_item, idx) => idx !== functionIndex);
 
-    const updatedConfig = await updateConfig(id, tenantId, { functions: updatedFunctions.length > 0 ? updatedFunctions : [] });
+    const updatedConfig = await updateConfig(
+      id,
+      tenantId,
+      { functions: updatedFunctions.length > 0 ? updatedFunctions : [] },
+      getExpectedUpdatedAt(config.updatedAt),
+    );
 
     loggerService.log(`Successfully removed function from config ${id}`);
     return updatedConfig;
   } catch (error) {
+    if (error instanceof ConfigConflictError) {
+      throw new HttpException(error.message, HttpStatus.CONFLICT);
+    }
+
     const errorMessage = error as { message: string };
     loggerService.error(`Error removing function: ${errorMessage.message}`, 'handleRemoveFunction');
     throw new Error('Failed to remove function');

--- a/src/services/tcs-config.logic.service.ts
+++ b/src/services/tcs-config.logic.service.ts
@@ -26,7 +26,7 @@ import {
 import type { ConfigData, ConfigInput, ConfigResponse } from '../interface/config.interface';
 import { HttpException, HttpStatus } from '../utils/error';
 
-const getExpectedUpdatedAt = (updatedAt: unknown): string => {
+const getUpdatedAt = (updatedAt: unknown): string => {
   if (updatedAt instanceof Date) {
     return updatedAt.toISOString();
   }
@@ -150,17 +150,11 @@ export const handleGetAllConfigs = async (
   }
 };
 
-export const handleUpdateConfig = async (id: number, tenantId: string, updates: Partial<Config>): Promise<Config> => {
+export const handleUpdateConfig = async (id: number, tenantId: string, updates: Partial<Config>, updatedAt: unknown): Promise<Config> => {
   try {
     loggerService.log(`Started handling update config request for ID: ${id}, tenant: ${tenantId}`);
 
-    const existingConfig = await findConfigById(id, tenantId);
-    if (!existingConfig) {
-      loggerService.error(`Config with id ${id} not found for tenant ${tenantId}`, 'handleUpdateConfig');
-      throw new Error('Configuration not found');
-    }
-
-    const updatedConfig = await updateConfig(id, tenantId, updates, getExpectedUpdatedAt(existingConfig.updatedAt));
+    const updatedConfig = await updateConfig(id, tenantId, updates, getUpdatedAt(updatedAt));
 
     loggerService.log(`Successfully updated config ID: ${id}`);
     return updatedConfig;
@@ -179,17 +173,12 @@ export const handleUpdatePublishingStatus = async (
   id: number,
   tenantId: string,
   publishingStatus: 'active' | 'inactive',
+  updatedAt: unknown,
 ): Promise<Config> => {
   try {
     loggerService.log(`[${tenantId}] Started updating publishing status to '${publishingStatus}' for config ${id}`);
 
-    const existingConfig = await findConfigById(id, tenantId);
-    if (!existingConfig) {
-      loggerService.error(`Config ${id} not found for tenant ${tenantId}`, 'handleUpdatePublishingStatus');
-      throw new Error('Configuration not found');
-    }
-
-    const updatedConfig = await updateConfig(id, tenantId, { publishing_status: publishingStatus }, getExpectedUpdatedAt(existingConfig.updatedAt));
+    const updatedConfig = await updateConfig(id, tenantId, { publishing_status: publishingStatus }, getUpdatedAt(updatedAt));
 
     loggerService.log(`[${tenantId}] Publishing status updated to '${publishingStatus}' for config ${id}`);
 
@@ -256,7 +245,7 @@ export const handleUpdateConfigByStatus = async (id: string, status: string, ten
   }
 };
 
-export const handleAddMapping = async (id: number, tenantId: string, mappingDto: AddMappingDto): Promise<Config> => {
+export const handleAddMapping = async (id: number, tenantId: string, mappingDto: AddMappingDto, updatedAt: unknown): Promise<Config> => {
   try {
     loggerService.log(`Adding mapping to config ${id} for tenant ${tenantId}`);
 
@@ -277,7 +266,7 @@ export const handleAddMapping = async (id: number, tenantId: string, mappingDto:
 
     const updatedMappings = [...(config.mapping ?? []), newMapping];
 
-    const updatedConfig = await updateConfig(id, tenantId, { mapping: updatedMappings }, getExpectedUpdatedAt(config.updatedAt));
+    const updatedConfig = await updateConfig(id, tenantId, { mapping: updatedMappings }, getUpdatedAt(updatedAt));
 
     loggerService.log(`Successfully added mapping to config ${id}`);
     return updatedConfig;
@@ -292,7 +281,7 @@ export const handleAddMapping = async (id: number, tenantId: string, mappingDto:
   }
 };
 
-export const handleRemoveMapping = async (id: number, tenantId: string, mappingIndex: number): Promise<Config> => {
+export const handleRemoveMapping = async (id: number, tenantId: string, mappingIndex: number, updatedAt: unknown): Promise<Config> => {
   try {
     loggerService.log(`Removing mapping at index ${mappingIndex} from config ${id} for tenant ${tenantId}`);
 
@@ -312,7 +301,7 @@ export const handleRemoveMapping = async (id: number, tenantId: string, mappingI
       id,
       tenantId,
       { mapping: updatedMappings.length > 0 ? updatedMappings : [] },
-      getExpectedUpdatedAt(config.updatedAt),
+      getUpdatedAt(updatedAt),
     );
 
     loggerService.log(`Successfully removed mapping from config ${id}`);
@@ -328,7 +317,7 @@ export const handleRemoveMapping = async (id: number, tenantId: string, mappingI
   }
 };
 
-export const handleAddFunction = async (id: number, tenantId: string, functionDto: AddFunctionDto): Promise<Config> => {
+export const handleAddFunction = async (id: number, tenantId: string, functionDto: AddFunctionDto, updatedAt: unknown): Promise<Config> => {
   try {
     loggerService.log(`Adding function to config ${id} for tenant ${tenantId}`);
 
@@ -347,7 +336,7 @@ export const handleAddFunction = async (id: number, tenantId: string, functionDt
 
     const updatedFunctions = [...(config.functions ?? []), newFunction];
 
-    const updatedConfig = await updateConfig(id, tenantId, { functions: updatedFunctions }, getExpectedUpdatedAt(config.updatedAt));
+    const updatedConfig = await updateConfig(id, tenantId, { functions: updatedFunctions }, getUpdatedAt(updatedAt));
 
     loggerService.log(`Successfully added function to config ${id}`);
     return updatedConfig;
@@ -362,7 +351,7 @@ export const handleAddFunction = async (id: number, tenantId: string, functionDt
   }
 };
 
-export const handleRemoveFunction = async (id: number, tenantId: string, functionIndex: number): Promise<Config> => {
+export const handleRemoveFunction = async (id: number, tenantId: string, functionIndex: number, updatedAt: unknown): Promise<Config> => {
   try {
     loggerService.log(`Removing function at index ${functionIndex} from config ${id} for tenant ${tenantId}`);
 
@@ -382,7 +371,7 @@ export const handleRemoveFunction = async (id: number, tenantId: string, functio
       id,
       tenantId,
       { functions: updatedFunctions.length > 0 ? updatedFunctions : [] },
-      getExpectedUpdatedAt(config.updatedAt),
+      getUpdatedAt(updatedAt),
     );
 
     loggerService.log(`Successfully removed function from config ${id}`);


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
[Issue-273](https://github.com/tazama-lf/admin-service/issues/273)
1. Reintroduced version-token based optimistic locking in repository update path:

src/repositories/configuration/tcs.config.repository.ts
updateConfig now requires expectedUpdatedAt
UPDATE WHERE includes updated_at match
Added code comment documenting locking mechanism

2. Added typed conflict error and distinct conflict path:

src/repositories/configuration/tcs.config.repository.ts
Added ConfigConflictError
If UPDATE returns 0 rows:
row exists => throw ConfigConflictError (concurrent modification)
row missing => throw Configuration not found
3. Guarded all write paths with expected version token from prior read:
src/services/tcs-config.logic.service.ts
```
handleUpdateConfig
handleUpdatePublishingStatus
handleAddMapping
handleRemoveMapping
handleAddFunction
handleRemoveFunction
```
Added helper to normalize updatedAt token before passing to repository
4. Surfaced conflicts as HTTP 409:
src/services/tcs-config.logic.service.ts
Service catches ConfigConflictError and throws HttpException with 409 status
5. Added/updated unit tests for success and conflict behavior per write path:
tests/unit/tcs-config.logic.service.test.ts
Verifies expectedUpdatedAt token is passed
Verifies conflict maps to HTTP 409
## Why are we doing this?
Concurrent updates could silently overwrite each other:

Client A reads version T1
Client B updates T1 to T2
Client A writes stale data from T1
B’s changes are lost without conflict feedback
For TCS workflow configuration, this can cause silent rule drift and unsafe operational behavior.
## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mutation endpoints accept an optional version token ("updatedAt") to enable optimistic concurrency; conflicting updates return HTTP 409.
  * Endpoints now accept the token separately (it is not stored in the payload) and validate its format, returning HTTP 400 for missing/invalid tokens.

* **Tests**
  * Added/updated unit tests covering conflict scenarios and asserting 409 responses across all configuration mutation operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->