### PR TITLE
fix: issue 309 & 310

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "ajv": "^8.17.1",
         "dotenv": "^17.2.0",
         "fastify": "^5.4.0",
+        "qs": "^6.15.1",
         "reflect-metadata": "^0.2.2",
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
@@ -32,6 +33,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.2.1",
+        "@types/qs": "^6.15.0",
         "@typescript-eslint/eslint-plugin": "^8.37.0",
         "@typescript-eslint/parser": "^8.37.0",
         "eslint": "^9.31.0",
@@ -93,7 +95,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2371,7 +2372,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2928,7 +2928,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2943,6 +2942,12 @@
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true
     },
     "node_modules/@types/request": {
       "version": "2.48.13",
@@ -3075,7 +3080,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3564,7 +3568,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4240,7 +4243,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5463,7 +5465,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5564,7 +5565,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6298,7 +6298,6 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -7302,7 +7301,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -7881,7 +7879,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8611,7 +8608,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9845,7 +9841,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10151,7 +10146,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10295,6 +10289,20 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -11760,7 +11768,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12003,7 +12010,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ajv": "^8.17.1",
     "dotenv": "^17.2.0",
     "fastify": "^5.4.0",
+    "qs": "^6.15.1",
     "reflect-metadata": "^0.2.2",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0"
@@ -50,6 +51,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.2.1",
+    "@types/qs": "^6.15.0",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",
     "eslint": "^9.31.0",

--- a/src/clients/fastify.ts
+++ b/src/clients/fastify.ts
@@ -7,8 +7,14 @@ import { fastifySwagger } from '@fastify/swagger';
 import { fastifySwaggerUi } from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { configuration } from '..';
+import qs from 'qs';
 
-const fastify = Fastify();
+const fastify = Fastify({
+  routerOptions: {
+    querystringParser: (str) => qs.parse(str),
+  },
+});
+
 const ajv = new Ajv({
   removeAdditional: 'all',
   useDefaults: true,

--- a/src/repositories/configuration/network.map.repository.ts
+++ b/src/repositories/configuration/network.map.repository.ts
@@ -10,8 +10,9 @@ export const NetworkMapRepo: CrudRepository<NetworkMap> = {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'cfg', value: '' };
     if (filters) {
-      filter.field = filters[0];
-      filter.value = filters[1];
+      const [field, value] = Object.entries(filters)[0];
+      filter.field = field;
+      filter.value = value;
     }
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
       {
@@ -26,11 +27,11 @@ export const NetworkMapRepo: CrudRepository<NetworkMap> = {
       : { data: [], total: 0 };
   },
 
-  get: async function ({ id, cfg, tenantId }): Promise<NetworkMap | null> {
+  get: async function ({ cfg, tenantId }): Promise<NetworkMap | null> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
       {
-        text: 'SELECT configuration FROM network_map WHERE configuration->>name = $1, configuration->>cfg = $2 AND tenantId = $3;',
-        values: [id, cfg, tenantId],
+        text: 'SELECT configuration FROM network_map WHERE configuration->>cfg = $1 AND tenantId = $2;',
+        values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
@@ -55,24 +56,25 @@ export const NetworkMapRepo: CrudRepository<NetworkMap> = {
     return queryRes.rows[0].configuration;
   },
 
-  update: async function ({ id, cfg, tenantId }, payload: NetworkMap): Promise<NetworkMap | null> {
+  update: async function ({ cfg, tenantId }, payload: NetworkMap): Promise<NetworkMap | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
+    payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
       {
-        text: 'UPDATE network_map SET configuration = $1 WHERE configuration->>name = $2 AND configuration->>cfg = $3 AND tenantId = $4 RETURNING configuration;',
-        values: [payload, id, cfg, tenantId],
+        text: 'UPDATE network_map SET configuration = $1 WHERE cfg = $2 AND tenantId = $3 RETURNING configuration;',
+        values: [payload, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
-  remove: async function ({ id, cfg, tenantId }): Promise<boolean> {
+  remove: async function ({ cfg, tenantId }): Promise<boolean> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
       {
-        text: 'DELETE FROM network_map WHERE configuration->>name = $1 AND configuration->>cfg = $2 AND tenantId = $3;',
-        values: [id, cfg, tenantId],
+        text: 'DELETE FROM network_map WHERE configuration->>cfg = $1 AND tenantId = $2;',
+        values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );

--- a/src/repositories/configuration/rule.config.repository.ts
+++ b/src/repositories/configuration/rule.config.repository.ts
@@ -9,8 +9,9 @@ export const RuleConfigRepo: CrudRepository<RuleConfig> = {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'ruleid', value: '' };
     if (filters) {
-      filter.field = filters[0];
-      filter.value = filters[1];
+      const [field, value] = Object.entries(filters)[0];
+      filter.field = field;
+      filter.value = value;
     }
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
@@ -58,6 +59,7 @@ export const RuleConfigRepo: CrudRepository<RuleConfig> = {
   update: async function ({ id, cfg, tenantId }, payload: RuleConfig): Promise<RuleConfig | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
+    payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {

--- a/src/repositories/configuration/typology.config.repository.ts
+++ b/src/repositories/configuration/typology.config.repository.ts
@@ -9,8 +9,9 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'typologyid', value: '' };
     if (filters) {
-      filter.field = filters[0];
-      filter.value = filters[1];
+      const [field, value] = Object.entries(filters)[0];
+      filter.field = field;
+      filter.value = value;
     }
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
@@ -58,6 +59,7 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
   update: async function ({ id, cfg, tenantId }, payload: TypologyConfig): Promise<TypologyConfig | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
+    payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
- Fixed an issue where all networkmap queries were looking for a property called "name", which doesn't exist on the actual object - the primary key is only CFG + TenantID; 
- Fixed an issue where you can override the tenantId from the token by passing a queryparameter, allowing you to see other tenants' networkmap, rule- and typology config. 

## Why are we doing this?
Bugs raised. #309 & #310 

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

I tested by modifying a user's tenantId in KeyCloak and ensuring that no matter what the query param is from Postman, the provided token's tenantId is the only data returned for Networkmap, Rule- and Typology config. 

  Fixes #309 
  Fixes #310 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 4.0.0-rc.2 and added a query-string parsing dependency.

* **New Features**
  * Incoming request query strings are now parsed with a different query-string parser for richer parsing behavior.

* **Bug Fixes**
  * Tenant resolution for list endpoints now consistently uses the authenticated user context.
  * Update/remove operations now reliably scope changes to the correct configuration and tenant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->