### PR TITLE
sybrin fix: issue-321 - ensured that the tenantID from the token is u…

### DIFF
--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -35,9 +35,7 @@ const DefaultQuery = Type.Object({
   filters: Type.Optional(Type.Record(Type.String(), Type.String())),
 });
 
-const makeIdSchema = (
-  cfg?: { kind: 'single'; name?: string } | { kind: 'composite'; names: readonly [string, string] },
-): TObject<Record<string, TSchema>> => {
+const makeIdSchema = (cfg?: { kind: 'single'; name?: string } | { kind: 'composite'; names: readonly [string, string] }): TObject => {
   const props: Record<string, TSchema> = { cfg: Type.String() };
   if (cfg?.kind === 'composite') {
     const [firstParamKey, secondParamKey] = cfg.names;
@@ -88,8 +86,8 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
       },
       async (req, reply) => {
         const queryParams = req.query as Static<typeof QuerySchema>;
-        const { tenantId: authTenantId } = req as ITenantRequest;
-        const { limit = 20, tenantId = authTenantId, offset = 0, sort, order = 'ASC', filters } = queryParams;
+        const { tenantId } = req as ITenantRequest;
+        const { limit = 20, offset = 0, sort, order = 'ASC', filters } = queryParams;
 
         type SortField = Extract<keyof TEntity, string>;
 


### PR DESCRIPTION
…sed for all config queries - networkmap, rule, typology

# SPDX-License-Identifier: Apache-2.0

## What did we change?
Removed the queryparams overwriting the provided token's tenantId for all Queries (networkmap, rule and typology). 

## Why are we doing this?
https://github.com/tazama-lf/admin-service/issues/321

## How was it tested?
- [X] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

No matter which tenantId (if any) is passed in queryParams, all get queries only respond with your tenant's data:
<img width="680" height="913" alt="image" src="https://github.com/user-attachments/assets/9cc133e3-8921-4663-9031-f9550e518f7d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tenant identifier resolution in list operations to ensure consistent and reliable tenant data handling across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->