### PR TITLE
fix: consistent tenantId handling in configuration repo's

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,12 @@ Each repository implementation follows a standardized interface, ensuring consis
 | 2. | Rule Configuration |  rule.config.repository | `/v1/admin/configuration/rule` |  GET,POST,PUT,DEL |
 | 3. | Typology Configuration | typology.config.repository | `/v1/admin/configuration/typology` | GET,POST,PUT,DEL |
 
+For all GET queries:
+ * You can either do a pure GET, which will list all items; 
+ * You can do a GET with a query parameter to find, for example, only Active networkmaps: /v1/admin/configuration/network_map?filters[active]=false;
+ * Right now, if you specify more than one query param, only the first one will take afffect. 
+
+
 ---
 
 ## 4) Conceptual Flow of Operations
@@ -587,7 +593,7 @@ The result is normalized into a consistent `{ data, total }` format expected by 
 
 ### Get Operation
 
-The `get` method retrieves a single entity record based on the combination of ID, and tenantId. If the record exists, it returns the parsed configuration object.
+The `get` method retrieves a single entity record based on the combination of `cfg` and tenantId. If the record exists, it returns the parsed configuration object.
 
 ### Create Operation
 
@@ -595,11 +601,11 @@ The creation method inserts a new configuration entry into the database. The pay
 
 ### Update Operation
 
-The update process replaces an existing configuration record that matches the composite key (`id`, `payload: configuration`, and `tenantId`). The repository ensures atomic updates by returning the modified record upon success or `null` if the record does not exist.
+The update process replaces an existing configuration record that matches `cfg` and `tenantId`. The repository ensures atomic updates by returning the modified record upon success or `null` if the record does not exist.
 
 ### Delete Operation
 
-The deletion process removes the record from the table matching the same composite identifiers (id and tenantId). It returns a boolean indicating success, enabling the API to respond with a standardized `{ success: boolean }` payload.
+The deletion process removes the record from the table matching the same `cfg` and `tenantId` identifiers. It returns a boolean indicating success, enabling the API to respond with a standardized `{ success: boolean }` payload.
 
 ---
 
@@ -704,7 +710,7 @@ For the configuration entities shown earlier, recommended permission strings inc
 **Notes**
 
 * `tenantId` is established by middleware and injected into every repository call.
-* `id: identifier` is provided as a path segment for GET/PUT/DELETE and included in ID construction.
+* `cfg` is provided as the path segment for generated configuration GET/PUT/DELETE routes and included in ID construction.
 * Capability strings follow the `<METHOD><PREFIX_WITH_SLASHES_AS_UNDERSCORES>` pattern (e.g., `GET_V1_ADMIN_CONFIGURATION_RULE`).
 
 ---

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Each repository implementation follows a standardized interface, ensuring consis
 
 For all GET queries:
  * You can either do a pure GET, which will list all items; 
- * You can do a GET with a query parameter to find, for example, only Active networkmaps: /v1/admin/configuration/network_map?filters[active]=false;
+ * You can do a GET with a query parameter to find, for example, only Active networkmaps: /v1/admin/configuration/network_map?filters[active]=true;
  * Right now, if you specify more than one query param, only the first one will take afffect. 
 
 

--- a/__tests__/unit/repositories/network.map.repository.test.ts
+++ b/__tests__/unit/repositories/network.map.repository.test.ts
@@ -146,7 +146,7 @@ describe('NetworkMapRepository', () => {
   });
 
   describe('update', () => {
-    const mockIdentifier = { id: 'test-id', cfg: '1.0.0', tenantId: mockTenantId };
+    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
 
     it('should set updDtTm to a new ISO 8601 timestamp and preserve creDtTm', async () => {
       const mockToISOString = jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
@@ -170,8 +170,8 @@ describe('NetworkMapRepository', () => {
       // Verify database call was made with correct parameters
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
         {
-          text: 'UPDATE network_map SET configuration = $1 WHERE configuration->>name = $2 AND configuration->>cfg = $3 AND tenantId = $4 RETURNING configuration;',
-          values: [inputPayload, mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+          text: 'UPDATE network_map SET configuration = $1 WHERE cfg = $2 AND tenantId = $3 RETURNING configuration;',
+          values: [inputPayload, mockIdentifier.cfg, mockIdentifier.tenantId],
         },
         'configuration',
       );

--- a/__tests__/unit/repositories/rule.config.repository.test.ts
+++ b/__tests__/unit/repositories/rule.config.repository.test.ts
@@ -149,7 +149,7 @@ describe('RuleConfigRepository', () => {
   });
 
   describe('update', () => {
-    const mockIdentifier = { id: 'test-id', cfg: '1.0.0', tenantId: mockTenantId };
+    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
 
     it('should set updDtTm to a new ISO 8601 timestamp and preserve creDtTm', async () => {
       const mockToISOString = jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
@@ -173,8 +173,8 @@ describe('RuleConfigRepository', () => {
       // Verify database call was made with correct parameters
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
         {
-          text: 'UPDATE rule SET configuration = $1 WHERE ruleid = $2 AND rulecfg = $3 AND tenantid = $4 RETURNING configuration;',
-          values: [inputPayload, mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+          text: 'UPDATE rule SET configuration = $1 WHERE rulecfg = $2 AND tenantid = $3 RETURNING configuration;',
+          values: [inputPayload, mockIdentifier.cfg, mockIdentifier.tenantId],
         },
         'configuration',
       );

--- a/__tests__/unit/repositories/typology.config.repository.test.ts
+++ b/__tests__/unit/repositories/typology.config.repository.test.ts
@@ -164,7 +164,7 @@ describe('TypologyConfigRepository', () => {
   });
 
   describe('update', () => {
-    const mockIdentifier = { id: 'test-id', cfg: '1.0.0', tenantId: mockTenantId };
+    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
 
     it('should set updDtTm to a new ISO 8601 timestamp and preserve creDtTm', async () => {
       const mockToISOString = jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
@@ -188,8 +188,8 @@ describe('TypologyConfigRepository', () => {
       // Verify database call was made with correct parameters
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
         {
-          text: 'UPDATE typology SET configuration = $1 WHERE typologyid = $2 AND typologycfg = $3 AND tenantid = $4 RETURNING configuration',
-          values: [inputPayload, mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+          text: 'UPDATE typology SET configuration = $1 WHERE typologycfg = $2 AND tenantid = $3 RETURNING configuration',
+          values: [inputPayload, mockIdentifier.cfg, mockIdentifier.tenantId],
         },
         'configuration',
       );

--- a/src/repositories/configuration/network.map.repository.ts
+++ b/src/repositories/configuration/network.map.repository.ts
@@ -2,10 +2,10 @@
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
-import type { CrudRepository } from '../repository.base';
+import type { ConfigVersion, CrudRepository } from '../repository.base';
 import type { ActiveNetworkMap } from '../../interface/rule.interface';
 
-export const NetworkMapRepo: CrudRepository<NetworkMap> = {
+export const NetworkMapRepo: CrudRepository<NetworkMap, ConfigVersion> = {
   list: async function ({ limit, offset, sort, order, filters, tenantId }): Promise<{ data: NetworkMap[]; total: number }> {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'cfg', value: '' };
@@ -30,7 +30,7 @@ export const NetworkMapRepo: CrudRepository<NetworkMap> = {
   get: async function ({ cfg, tenantId }): Promise<NetworkMap | null> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
       {
-        text: 'SELECT configuration FROM network_map WHERE configuration->>cfg = $1 AND tenantId = $2;',
+        text: 'SELECT configuration FROM network_map WHERE cfg = $1 AND tenantId = $2;',
         values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
@@ -73,7 +73,7 @@ export const NetworkMapRepo: CrudRepository<NetworkMap> = {
   remove: async function ({ cfg, tenantId }): Promise<boolean> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
       {
-        text: 'DELETE FROM network_map WHERE configuration->>cfg = $1 AND tenantId = $2;',
+        text: 'DELETE FROM network_map WHERE cfg = $1 AND tenantId = $2;',
         values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',

--- a/src/repositories/configuration/rule.config.repository.ts
+++ b/src/repositories/configuration/rule.config.repository.ts
@@ -2,9 +2,9 @@
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
-import type { CrudRepository } from '../repository.base';
+import type { ConfigVersion, CrudRepository } from '../repository.base';
 
-export const RuleConfigRepo: CrudRepository<RuleConfig> = {
+export const RuleConfigRepo: CrudRepository<RuleConfig, ConfigVersion> = {
   list: async function ({ offset, limit, filters, order, sort, tenantId }): Promise<{ data: RuleConfig[]; total: number }> {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'ruleid', value: '' };
@@ -27,11 +27,11 @@ export const RuleConfigRepo: CrudRepository<RuleConfig> = {
       : { data: [], total: 0 };
   },
 
-  get: async function ({ id, cfg, tenantId }): Promise<RuleConfig | null> {
+  get: async function ({ cfg, tenantId }): Promise<RuleConfig | null> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {
-        text: 'SELECT configuration FROM rule WHERE ruleid = $1 AND rulecfg = $2 AND tenantid = $3;',
-        values: [id, cfg, tenantId],
+        text: 'SELECT configuration FROM rule WHERE rulecfg = $1 AND tenantid = $2;',
+        values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
@@ -56,26 +56,26 @@ export const RuleConfigRepo: CrudRepository<RuleConfig> = {
     return queryRes.rows[0].configuration;
   },
 
-  update: async function ({ id, cfg, tenantId }, payload: RuleConfig): Promise<RuleConfig | null> {
+  update: async function ({ cfg, tenantId }, payload: RuleConfig): Promise<RuleConfig | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
     payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {
-        text: 'UPDATE rule SET configuration = $1 WHERE ruleid = $2 AND rulecfg = $3 AND tenantid = $4 RETURNING configuration;',
-        values: [payload, id, cfg, tenantId],
+        text: 'UPDATE rule SET configuration = $1 WHERE rulecfg = $2 AND tenantid = $3 RETURNING configuration;',
+        values: [payload, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 
-  remove: async function ({ id, cfg, tenantId }): Promise<boolean> {
+  remove: async function ({ cfg, tenantId }): Promise<boolean> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {
-        text: 'DELETE FROM rule WHERE ruleid = $1 AND rulecfg = $2 AND tenantid = $3;',
-        values: [id, cfg, tenantId],
+        text: 'DELETE FROM rule WHERE rulecfg = $1 AND tenantid = $2;',
+        values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );

--- a/src/repositories/configuration/typology.config.repository.ts
+++ b/src/repositories/configuration/typology.config.repository.ts
@@ -2,9 +2,9 @@
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { TypologyConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
-import type { CrudRepository } from '../repository.base';
+import type { ConfigVersion, CrudRepository } from '../repository.base';
 
-export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
+export const TypologyConfigRepo: CrudRepository<TypologyConfig, ConfigVersion> = {
   list: async function ({ filters, limit, offset, order, sort, tenantId }): Promise<{ data: TypologyConfig[]; total: number }> {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'typologyid', value: '' };
@@ -27,11 +27,11 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
       : { data: [], total: 0 };
   },
 
-  get: async function ({ id, cfg, tenantId }): Promise<TypologyConfig | null> {
+  get: async function ({ cfg, tenantId }): Promise<TypologyConfig | null> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {
-        text: 'SELECT configuration FROM typology WHERE typologyid = $1 AND typologycfg = $2 AND tenantid = $3;',
-        values: [id, cfg, tenantId],
+        text: 'SELECT configuration FROM typology WHERE typologycfg = $1 AND tenantid = $2;',
+        values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
@@ -56,26 +56,26 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
     return queryRes.rows[0].configuration;
   },
 
-  update: async function ({ id, cfg, tenantId }, payload: TypologyConfig): Promise<TypologyConfig | null> {
+  update: async function ({ cfg, tenantId }, payload: TypologyConfig): Promise<TypologyConfig | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
     payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {
-        text: 'UPDATE typology SET configuration = $1 WHERE typologyid = $2 AND typologycfg = $3 AND tenantid = $4 RETURNING configuration',
-        values: [payload, id, cfg, tenantId],
+        text: 'UPDATE typology SET configuration = $1 WHERE typologycfg = $2 AND tenantid = $3 RETURNING configuration',
+        values: [payload, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 
-  remove: async function ({ id, cfg, tenantId }): Promise<boolean> {
+  remove: async function ({ cfg, tenantId }): Promise<boolean> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {
-        text: 'DELETE FROM typology WHERE typologyid = $1 AND typologycfg = $2 AND tenantid = $3;',
-        values: [id, cfg, tenantId],
+        text: 'DELETE FROM typology WHERE typologycfg = $1 AND tenantid = $2;',
+        values: [cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );

--- a/src/repositories/repository.base.ts
+++ b/src/repositories/repository.base.ts
@@ -14,6 +14,10 @@ export interface Node {
   cfg: string;
   tenantId: string;
 }
+export interface ConfigVersion {
+  cfg: string;
+  tenantId: string;
+}
 export interface Connector {
   source: string;
   destination: string;
@@ -21,7 +25,7 @@ export interface Connector {
 }
 
 // Table types one with composite keys and with primary id key
-export type AllowedId = Node | Connector;
+export type AllowedId = Node | ConfigVersion | Connector;
 
 export interface CrudRepository<TEntity, TId extends AllowedId = Node> {
   list: (params: ListQuery<StringKeys<TEntity>>) => Promise<{ data: TEntity[]; total: number }>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -157,6 +157,7 @@ function Routes(fastify: FastifyInstance): void {
       prefix: '/v1/admin/configuration/network_map',
       repo: NetworkMapRepo,
       schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema },
+      idParam: { kind: 'cfg' },
     }),
   );
 
@@ -165,6 +166,7 @@ function Routes(fastify: FastifyInstance): void {
       prefix: '/v1/admin/configuration/rule',
       repo: RuleConfigRepo,
       schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
+      idParam: { kind: 'cfg' },
     }),
   );
 
@@ -173,6 +175,7 @@ function Routes(fastify: FastifyInstance): void {
       prefix: '/v1/admin/configuration/typology',
       repo: TypologyConfigRepo,
       schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema },
+      idParam: { kind: 'cfg' },
     }),
   );
 

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -17,7 +17,7 @@ export interface CrudSchemas {
   Query?: typeof DefaultQuery;
 }
 
-type IdParamConfig = { kind: 'single'; name?: string } | { kind: 'composite'; names: readonly [string, string] };
+type IdParamConfig = { kind: 'single'; name?: string } | { kind: 'cfg' } | { kind: 'composite'; names: readonly [string, string] };
 
 interface BuildCrudOptions<TEntity, TId extends AllowedId> {
   prefix: string;
@@ -29,19 +29,18 @@ interface BuildCrudOptions<TEntity, TId extends AllowedId> {
 const DefaultQuery = Type.Object({
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
   offset: Type.Optional(Type.Integer({ minimum: 0 })),
-  tenantId: Type.Optional(Type.String({ default: 'DEFAULT' })),
   sort: Type.Optional(Type.String()),
   order: Type.Optional(Type.Union([Type.Literal('ASC'), Type.Literal('DESC')])),
   filters: Type.Optional(Type.Record(Type.String(), Type.String())),
 });
 
-const makeIdSchema = (cfg?: { kind: 'single'; name?: string } | { kind: 'composite'; names: readonly [string, string] }): TObject => {
+const makeIdSchema = (cfg?: IdParamConfig): TObject => {
   const props: Record<string, TSchema> = { cfg: Type.String() };
   if (cfg?.kind === 'composite') {
     const [firstParamKey, secondParamKey] = cfg.names;
     props[firstParamKey] = Type.String();
     props[secondParamKey] = Type.String();
-  } else {
+  } else if (cfg?.kind !== 'cfg') {
     const name = cfg?.kind === 'single' ? (cfg.name ?? 'id') : 'id';
     props[name] = Type.String();
   }
@@ -57,9 +56,23 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
 
     // --- Build path and param schema based on idParam ---
     const singleName: string = idParam?.kind === 'single' ? (idParam.name ?? 'id') : 'id';
-    const idPath = idParam?.kind === 'composite' ? `/:${idParam.names[0]}/:${idParam.names[1]}/:cfg` : `/:${singleName}/:cfg`;
+    const idPath =
+      idParam?.kind === 'composite'
+        ? `/:${idParam.names[0]}/:${idParam.names[1]}/:cfg`
+        : idParam?.kind === 'cfg'
+          ? '/:cfg'
+          : `/:${singleName}/:cfg`;
 
     const IdParam = schemas.Id ?? makeIdSchema(idParam);
+    const makeRepositoryId = (params: Record<string, string>, tenantId: string): TId => {
+      const id =
+        idParam?.kind === 'composite'
+          ? { [idParam.names[0]]: params[idParam.names[0]], [idParam.names[1]]: params[idParam.names[1]], cfg: params.cfg, tenantId }
+          : idParam?.kind === 'cfg'
+            ? { cfg: params.cfg, tenantId }
+            : { id: params[singleName], cfg: params.cfg, tenantId };
+      return id as unknown as TId;
+    };
 
     const QuerySchema = schemas.Query ?? DefaultQuery;
 
@@ -122,12 +135,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         const p = req.params as Record<string, string>;
         const { tenantId } = req as ITenantRequest;
 
-        const id =
-          idParam?.kind === 'composite'
-            ? { [idParam.names[0]]: p[idParam.names[0]], [idParam.names[1]]: p[idParam.names[1]], cfg: p.cfg, tenantId }
-            : { id: p[singleName], cfg: p.cfg, tenantId };
-
-        const entity = await repo.get(id as TId);
+        const entity = await repo.get(makeRepositoryId(p, tenantId));
         if (!entity) return await reply.code(404).send({ message: 'Not found' });
         return entity;
       },
@@ -170,12 +178,8 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
       async (req, reply) => {
         const p = req.params as Record<string, string>;
         const { tenantId } = req as ITenantRequest;
-        const id =
-          idParam?.kind === 'composite'
-            ? { [idParam.names[0]]: p[idParam.names[0]], [idParam.names[1]]: p[idParam.names[1]], cfg: p.cfg, tenantId }
-            : { id: p[singleName], cfg: p.cfg, tenantId };
 
-        const updated = await repo.update(id as TId, req.body as TEntity);
+        const updated = await repo.update(makeRepositoryId(p, tenantId), req.body as TEntity);
         if (!updated) return await reply.code(404).send({ message: 'Not found' });
         return updated;
       },
@@ -197,12 +201,8 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
       async (req, reply) => {
         const p = req.params as Record<string, string>;
         const { tenantId } = req as ITenantRequest;
-        const id =
-          idParam?.kind === 'composite'
-            ? { [idParam.names[0]]: p[idParam.names[0]], [idParam.names[1]]: p[idParam.names[1]], cfg: p.cfg, tenantId }
-            : { id: p[singleName], cfg: p.cfg, tenantId };
 
-        const ok = await repo.remove(id as TId);
+        const ok = await repo.remove(makeRepositoryId(p, tenantId));
         return { success: ok };
       },
     );

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -70,7 +70,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
           ? { [idParam.names[0]]: params[idParam.names[0]], [idParam.names[1]]: params[idParam.names[1]], cfg: params.cfg, tenantId }
           : idParam?.kind === 'cfg'
             ? { cfg: params.cfg, tenantId }
-            : { id: params[singleName], cfg: params.cfg, tenantId };
+            : { [singleName]: params[singleName], cfg: params.cfg, tenantId };
       return id as unknown as TId;
     };
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
* Removed all TenantId parameters for CRUD-, network map-, rule-  and typology repo, to ensure in all cases we always use the tenantId from the supplied Token for all queries.
* Updated related unit tests.

## Why are we doing this?
To apply fixes requested by:
#310 #321 #325 #326 

## How was it tested?
- [X] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

fixes: #310 #321 #325 #326 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified GET query behavior and updated docs to show configuration partition-key identification using cfg + tenantId; notes on RESTful integration added.

* **Refactor**
  * Configuration CRUD endpoints for network maps, rules, and typologies now identify records by cfg + tenantId (no per-item id).

* **Tests**
  * Unit tests updated to reflect the new identifier shape and query semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->