### PR TITLE
fix: allow find by ID & CFG for rules and typologies; fix missing uni…

### DIFF
--- a/__tests__/unit/repositories/network.map.repository.test.ts
+++ b/__tests__/unit/repositories/network.map.repository.test.ts
@@ -21,7 +21,7 @@ jest.mock('../../../src', () => ({
   },
 }));
 
-import { NetworkMapRepo } from '../../../src/repositories/configuration/network.map.repository';
+import { findActiveNetworkMapInDb, NetworkMapRepo } from '../../../src/repositories/configuration/network.map.repository';
 
 describe('NetworkMapRepository', () => {
   const mockTenantId = 'test-tenant-123';
@@ -74,6 +74,93 @@ describe('NetworkMapRepository', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
+  });
+
+  describe('list', () => {
+    it('should list network maps with default sort and no filters', async () => {
+      const firstMap = createMockNetworkMap();
+      const secondMap = { ...createMockNetworkMap(), cfg: '2.0.0', active: false };
+
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration: firstMap }, { configuration: secondMap }],
+        rowCount: 2,
+      });
+
+      const result = await NetworkMapRepo.list({
+        offset: 5,
+        limit: 10,
+        order: 'DESC',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [firstMap, secondMap], total: 2 });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: "SELECT configuration FROM network_map WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 DESC OFFSET $4 LIMIT $5;",
+          values: ['cfg', '', 'cfg', 5, 10, mockTenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should list with the first provided filter and custom sort', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await NetworkMapRepo.list({
+        filters: { active: 'true', cfg: '1.0.0' },
+        offset: 0,
+        limit: 25,
+        order: 'ASC',
+        sort: 'active',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [], total: 0 });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: "SELECT configuration FROM network_map WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 ASC OFFSET $4 LIMIT $5;",
+          values: ['active', 'true', 'active', 0, 25, mockTenantId],
+        },
+        'configuration',
+      );
+    });
+  });
+
+  describe('get', () => {
+    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
+
+    it('should return a network map when found', async () => {
+      const configuration = createMockNetworkMap();
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration }],
+        rowCount: 1,
+      });
+
+      const result = await NetworkMapRepo.get(mockIdentifier);
+
+      expect(result).toEqual(configuration);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'SELECT configuration FROM network_map WHERE cfg = $1 AND tenantId = $2;',
+          values: [mockIdentifier.cfg, mockIdentifier.tenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return null when the network map is not found', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await NetworkMapRepo.get(mockIdentifier);
+
+      expect(result).toBeNull();
+    });
   });
 
   describe('create', () => {
@@ -198,6 +285,18 @@ describe('NetworkMapRepository', () => {
       expect(mockToISOString).toHaveBeenCalled();
     });
 
+    it('should override payload tenantId with the identifier tenantId', async () => {
+      jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
+      mockHandlePostExecuteSqlStatement.mockResolvedValue(mockUpdateResponse);
+
+      const inputPayload = createMockNetworkMap();
+      const originalTenantId = inputPayload.tenantId;
+
+      await NetworkMapRepo.update(mockIdentifier, inputPayload);
+
+      expect(inputPayload.tenantId).toBe(mockIdentifier.tenantId);
+    });
+
     it('should return null when no rows are affected', async () => {
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
 
@@ -207,6 +306,81 @@ describe('NetworkMapRepository', () => {
       const result = await NetworkMapRepo.update(mockIdentifier, inputPayload);
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
+
+    it('should return true when a network map is deleted', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 1,
+      });
+
+      const result = await NetworkMapRepo.remove(mockIdentifier);
+
+      expect(result).toBe(true);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'DELETE FROM network_map WHERE cfg = $1 AND tenantId = $2;',
+          values: [mockIdentifier.cfg, mockIdentifier.tenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return false when no network map is deleted', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await NetworkMapRepo.remove(mockIdentifier);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('findActiveNetworkMapInDb', () => {
+    it('should return the active network map configuration when exactly one is found', async () => {
+      const configuration = createMockNetworkMap();
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration }],
+        rowCount: 1,
+      });
+
+      const result = await findActiveNetworkMapInDb(mockTenantId);
+
+      expect(result).toEqual({ configuration });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(expect.objectContaining({ values: [mockTenantId] }), 'configuration');
+
+      const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[0][0] as { text: string };
+      expect(callArg.text).toContain('FROM network_map');
+      expect(callArg.text).toContain('tenantId = $1');
+      expect(callArg.text).toContain("configuration->>'active' = 'true'");
+    });
+
+    it('should return null when no active network map is found', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await findActiveNetworkMapInDb(mockTenantId);
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw when more than one active network map is found for the tenant', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration: createMockNetworkMap() }, { configuration: { ...createMockNetworkMap(), cfg: '2.0.0' } }],
+        rowCount: 2,
+      });
+
+      await expect(findActiveNetworkMapInDb(mockTenantId)).rejects.toThrow(
+        `Multiple active network maps found for tenant ${mockTenantId}. Expected only one active network map.`,
+      );
     });
   });
 

--- a/__tests__/unit/repositories/rule.config.repository.test.ts
+++ b/__tests__/unit/repositories/rule.config.repository.test.ts
@@ -79,6 +79,93 @@ describe('RuleConfigRepository', () => {
     jest.restoreAllMocks();
   });
 
+  describe('list', () => {
+    it('should list rule configurations with default sort and no filters', async () => {
+      const firstConfig = createMockRuleConfig();
+      const secondConfig = { ...createMockRuleConfig(), id: 'rule-002', cfg: '2.0.0' };
+
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration: firstConfig }, { configuration: secondConfig }],
+        rowCount: 2,
+      });
+
+      const result = await RuleConfigRepo.list({
+        offset: 5,
+        limit: 10,
+        order: 'DESC',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: "SELECT configuration FROM rule WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 DESC OFFSET $4 LIMIT $5;",
+          values: ['ruleid', '', 'cfg', 5, 10, mockTenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should list with the first provided filter and custom sort', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await RuleConfigRepo.list({
+        filters: { id: 'rule-002', cfg: '2.0.0' },
+        offset: 0,
+        limit: 25,
+        order: 'ASC',
+        sort: 'id',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [], total: 0 });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: "SELECT configuration FROM rule WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 ASC OFFSET $4 LIMIT $5;",
+          values: ['id', 'rule-002', 'id', 0, 25, mockTenantId],
+        },
+        'configuration',
+      );
+    });
+  });
+
+  describe('get', () => {
+    const mockIdentifier = { id: 'rule-001', cfg: '1.0.0', tenantId: mockTenantId };
+
+    it('should return a rule configuration when found', async () => {
+      const configuration = createMockRuleConfig();
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration }],
+        rowCount: 1,
+      });
+
+      const result = await RuleConfigRepo.get(mockIdentifier);
+
+      expect(result).toEqual(configuration);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'SELECT configuration FROM rule WHERE ruleid = $1 AND rulecfg = $2 AND tenantid = $3;',
+          values: [mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return null when the rule configuration is not found', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await RuleConfigRepo.get(mockIdentifier);
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('create', () => {
     it('should set both creDtTm and updDtTm to the same ISO 8601 timestamp', async () => {
       // Mock Date.prototype.toISOString to return predictable timestamp
@@ -149,7 +236,7 @@ describe('RuleConfigRepository', () => {
   });
 
   describe('update', () => {
-    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
+    const mockIdentifier = { id: '001@1.0.0', cfg: '1.0.0', tenantId: mockTenantId };
 
     it('should set updDtTm to a new ISO 8601 timestamp and preserve creDtTm', async () => {
       const mockToISOString = jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
@@ -173,8 +260,8 @@ describe('RuleConfigRepository', () => {
       // Verify database call was made with correct parameters
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
         {
-          text: 'UPDATE rule SET configuration = $1 WHERE rulecfg = $2 AND tenantid = $3 RETURNING configuration;',
-          values: [inputPayload, mockIdentifier.cfg, mockIdentifier.tenantId],
+          text: 'UPDATE rule SET configuration = $1 WHERE ruleid = $2 AND rulecfg = $3 AND tenantid = $4 RETURNING configuration;',
+          values: [inputPayload, mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
         },
         'configuration',
       );
@@ -201,6 +288,18 @@ describe('RuleConfigRepository', () => {
       expect(mockToISOString).toHaveBeenCalled();
     });
 
+    it('should override payload tenantId with the identifier tenantId', async () => {
+      jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
+      mockHandlePostExecuteSqlStatement.mockResolvedValue(mockUpdateResponse);
+
+      const inputPayload = createMockRuleConfig();
+      const originalTenantId = inputPayload.tenantId;
+
+      await RuleConfigRepo.update(mockIdentifier, inputPayload);
+
+      expect(inputPayload.tenantId).toBe(mockIdentifier.tenantId);
+    });
+
     it('should return null when no rows are affected', async () => {
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
 
@@ -210,6 +309,39 @@ describe('RuleConfigRepository', () => {
       const result = await RuleConfigRepo.update(mockIdentifier, inputPayload);
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    const mockIdentifier = { id: 'rule-001', cfg: '1.0.0', tenantId: mockTenantId };
+
+    it('should return true when a rule configuration is deleted', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 1,
+      });
+
+      const result = await RuleConfigRepo.remove(mockIdentifier);
+
+      expect(result).toBe(true);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'DELETE FROM rule WHERE ruleid = $1 AND rulecfg = $2 AND tenantid = $3;',
+          values: [mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return false when no rule configuration is deleted', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await RuleConfigRepo.remove(mockIdentifier);
+
+      expect(result).toBe(false);
     });
   });
 

--- a/__tests__/unit/repositories/typology.config.repository.test.ts
+++ b/__tests__/unit/repositories/typology.config.repository.test.ts
@@ -87,6 +87,93 @@ describe('TypologyConfigRepository', () => {
     jest.restoreAllMocks();
   });
 
+  describe('list', () => {
+    it('should list typology configurations with default sort and no filters', async () => {
+      const firstConfig = createMockTypologyConfig();
+      const secondConfig = { ...createMockTypologyConfig(), id: 'typology-002', cfg: '2.0.0' };
+
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration: firstConfig }, { configuration: secondConfig }],
+        rowCount: 2,
+      });
+
+      const result = await TypologyConfigRepo.list({
+        offset: 5,
+        limit: 10,
+        order: 'DESC',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: "SELECT configuration FROM typology WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$5 DESC OFFSET $3 LIMIT $4;",
+          values: ['typologyid', '', 5, 10, 'cfg', mockTenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should list with the first provided filter and custom sort', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await TypologyConfigRepo.list({
+        filters: { id: 'typology-002', cfg: '2.0.0' },
+        offset: 0,
+        limit: 25,
+        order: 'ASC',
+        sort: 'id',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [], total: 0 });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: "SELECT configuration FROM typology WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$5 ASC OFFSET $3 LIMIT $4;",
+          values: ['id', 'typology-002', 0, 25, 'id', mockTenantId],
+        },
+        'configuration',
+      );
+    });
+  });
+
+  describe('get', () => {
+    const mockIdentifier = { id: 'typology-001', cfg: '1.0.0', tenantId: mockTenantId };
+
+    it('should return a typology configuration when found', async () => {
+      const configuration = createMockTypologyConfig();
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration }],
+        rowCount: 1,
+      });
+
+      const result = await TypologyConfigRepo.get(mockIdentifier);
+
+      expect(result).toEqual(configuration);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'SELECT configuration FROM typology WHERE typologyid = $1 AND typologycfg = $2 AND tenantid = $3;',
+          values: [mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return null when the typology configuration is not found', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await TypologyConfigRepo.get(mockIdentifier);
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('create', () => {
     it('should set both creDtTm and updDtTm to the same ISO 8601 timestamp', async () => {
       // Mock Date.prototype.toISOString to return predictable timestamp
@@ -164,7 +251,7 @@ describe('TypologyConfigRepository', () => {
   });
 
   describe('update', () => {
-    const mockIdentifier = { cfg: '1.0.0', tenantId: mockTenantId };
+    const mockIdentifier = { id: '001@1.0.0', cfg: '1.0.0', tenantId: mockTenantId };
 
     it('should set updDtTm to a new ISO 8601 timestamp and preserve creDtTm', async () => {
       const mockToISOString = jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
@@ -188,8 +275,8 @@ describe('TypologyConfigRepository', () => {
       // Verify database call was made with correct parameters
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
         {
-          text: 'UPDATE typology SET configuration = $1 WHERE typologycfg = $2 AND tenantid = $3 RETURNING configuration',
-          values: [inputPayload, mockIdentifier.cfg, mockIdentifier.tenantId],
+          text: 'UPDATE typology SET configuration = $1 WHERE typologyid = $2 AND typologycfg = $3 AND tenantid = $4 RETURNING configuration',
+          values: [inputPayload, mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
         },
         'configuration',
       );
@@ -216,6 +303,18 @@ describe('TypologyConfigRepository', () => {
       expect(mockToISOString).toHaveBeenCalled();
     });
 
+    it('should override payload tenantId with the identifier tenantId', async () => {
+      jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
+      mockHandlePostExecuteSqlStatement.mockResolvedValue(mockUpdateResponse);
+
+      const inputPayload = createMockTypologyConfig();
+      const originalTenantId = inputPayload.tenantId;
+
+      await TypologyConfigRepo.update(mockIdentifier, inputPayload);
+
+      expect(inputPayload.tenantId).toBe(mockIdentifier.tenantId);
+    });
+
     it('should return null when no rows are affected', async () => {
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockUpdateDate);
 
@@ -225,6 +324,39 @@ describe('TypologyConfigRepository', () => {
       const result = await TypologyConfigRepo.update(mockIdentifier, inputPayload);
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    const mockIdentifier = { id: 'typology-001', cfg: '1.0.0', tenantId: mockTenantId };
+
+    it('should return true when a typology configuration is deleted', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 1,
+      });
+
+      const result = await TypologyConfigRepo.remove(mockIdentifier);
+
+      expect(result).toBe(true);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'DELETE FROM typology WHERE typologyid = $1 AND typologycfg = $2 AND tenantid = $3;',
+          values: [mockIdentifier.id, mockIdentifier.cfg, mockIdentifier.tenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return false when no typology configuration is deleted', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await TypologyConfigRepo.remove(mockIdentifier);
+
+      expect(result).toBe(false);
     });
   });
 

--- a/src/repositories/configuration/network.map.repository.ts
+++ b/src/repositories/configuration/network.map.repository.ts
@@ -10,7 +10,7 @@ export const NetworkMapRepo: CrudRepository<NetworkMap, ConfigVersion> = {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'cfg', value: '' };
     if (filters) {
-      const [field, value] = Object.entries(filters)[0];
+      const [[field, value]] = Object.entries(filters);
       filter.field = field;
       filter.value = value;
     }

--- a/src/repositories/configuration/rule.config.repository.ts
+++ b/src/repositories/configuration/rule.config.repository.ts
@@ -2,14 +2,14 @@
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
-import type { ConfigVersion, CrudRepository } from '../repository.base';
+import type { CrudRepository } from '../repository.base';
 
-export const RuleConfigRepo: CrudRepository<RuleConfig, ConfigVersion> = {
+export const RuleConfigRepo: CrudRepository<RuleConfig> = {
   list: async function ({ offset, limit, filters, order, sort, tenantId }): Promise<{ data: RuleConfig[]; total: number }> {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'ruleid', value: '' };
     if (filters) {
-      const [field, value] = Object.entries(filters)[0];
+      const [[field, value]] = Object.entries(filters);
       filter.field = field;
       filter.value = value;
     }
@@ -27,11 +27,11 @@ export const RuleConfigRepo: CrudRepository<RuleConfig, ConfigVersion> = {
       : { data: [], total: 0 };
   },
 
-  get: async function ({ cfg, tenantId }): Promise<RuleConfig | null> {
+  get: async function ({ id, cfg, tenantId }): Promise<RuleConfig | null> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {
-        text: 'SELECT configuration FROM rule WHERE rulecfg = $1 AND tenantid = $2;',
-        values: [cfg, tenantId],
+        text: 'SELECT configuration FROM rule WHERE ruleid = $1 AND rulecfg = $2 AND tenantid = $3;',
+        values: [id, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
@@ -56,26 +56,26 @@ export const RuleConfigRepo: CrudRepository<RuleConfig, ConfigVersion> = {
     return queryRes.rows[0].configuration;
   },
 
-  update: async function ({ cfg, tenantId }, payload: RuleConfig): Promise<RuleConfig | null> {
+  update: async function ({ id, cfg, tenantId }, payload: RuleConfig): Promise<RuleConfig | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
     payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {
-        text: 'UPDATE rule SET configuration = $1 WHERE rulecfg = $2 AND tenantid = $3 RETURNING configuration;',
-        values: [payload, cfg, tenantId],
+        text: 'UPDATE rule SET configuration = $1 WHERE ruleid = $2 AND rulecfg = $3 AND tenantid = $4 RETURNING configuration;',
+        values: [payload, id, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 
-  remove: async function ({ cfg, tenantId }): Promise<boolean> {
+  remove: async function ({ id, cfg, tenantId }): Promise<boolean> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
       {
-        text: 'DELETE FROM rule WHERE rulecfg = $1 AND tenantid = $2;',
-        values: [cfg, tenantId],
+        text: 'DELETE FROM rule WHERE ruleid = $1 AND rulecfg = $2 AND tenantid = $3;',
+        values: [id, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );

--- a/src/repositories/configuration/typology.config.repository.ts
+++ b/src/repositories/configuration/typology.config.repository.ts
@@ -2,14 +2,14 @@
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { TypologyConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
-import type { ConfigVersion, CrudRepository } from '../repository.base';
+import type { CrudRepository } from '../repository.base';
 
-export const TypologyConfigRepo: CrudRepository<TypologyConfig, ConfigVersion> = {
+export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
   list: async function ({ filters, limit, offset, order, sort, tenantId }): Promise<{ data: TypologyConfig[]; total: number }> {
     sort ??= 'cfg';
     const filter: { field: string; value: string } = { field: 'typologyid', value: '' };
     if (filters) {
-      const [field, value] = Object.entries(filters)[0];
+      const [[field, value]] = Object.entries(filters);
       filter.field = field;
       filter.value = value;
     }
@@ -27,11 +27,11 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig, ConfigVersion> =
       : { data: [], total: 0 };
   },
 
-  get: async function ({ cfg, tenantId }): Promise<TypologyConfig | null> {
+  get: async function ({ id, cfg, tenantId }): Promise<TypologyConfig | null> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {
-        text: 'SELECT configuration FROM typology WHERE typologycfg = $1 AND tenantid = $2;',
-        values: [cfg, tenantId],
+        text: 'SELECT configuration FROM typology WHERE typologyid = $1 AND typologycfg = $2 AND tenantid = $3;',
+        values: [id, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
@@ -56,26 +56,26 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig, ConfigVersion> =
     return queryRes.rows[0].configuration;
   },
 
-  update: async function ({ cfg, tenantId }, payload: TypologyConfig): Promise<TypologyConfig | null> {
+  update: async function ({ id, cfg, tenantId }, payload: TypologyConfig): Promise<TypologyConfig | null> {
     const dtTme = new Date().toISOString();
     payload.updDtTm = dtTme;
     payload.tenantId = tenantId;
 
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {
-        text: 'UPDATE typology SET configuration = $1 WHERE typologycfg = $2 AND tenantid = $3 RETURNING configuration',
-        values: [payload, cfg, tenantId],
+        text: 'UPDATE typology SET configuration = $1 WHERE typologyid = $2 AND typologycfg = $3 AND tenantid = $4 RETURNING configuration',
+        values: [payload, id, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 
-  remove: async function ({ cfg, tenantId }): Promise<boolean> {
+  remove: async function ({ id, cfg, tenantId }): Promise<boolean> {
     const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
       {
-        text: 'DELETE FROM typology WHERE typologycfg = $1 AND tenantid = $2;',
-        values: [cfg, tenantId],
+        text: 'DELETE FROM typology WHERE typologyid = $1 AND typologycfg = $2 AND tenantid = $3;',
+        values: [id, cfg, tenantId],
       } satisfies PgQueryConfig,
       'configuration',
     );

--- a/src/router.ts
+++ b/src/router.ts
@@ -166,7 +166,7 @@ function Routes(fastify: FastifyInstance): void {
       prefix: '/v1/admin/configuration/rule',
       repo: RuleConfigRepo,
       schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
-      idParam: { kind: 'cfg' },
+      idParam: { kind: 'single', name: 'id' },
     }),
   );
 
@@ -175,7 +175,7 @@ function Routes(fastify: FastifyInstance): void {
       prefix: '/v1/admin/configuration/typology',
       repo: TypologyConfigRepo,
       schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema },
-      idParam: { kind: 'cfg' },
+      idParam: { kind: 'single', name: 'id' },
     }),
   );
 

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -34,7 +34,9 @@ const DefaultQuery = Type.Object({
   filters: Type.Optional(Type.Record(Type.String(), Type.String())),
 });
 
-const makeIdSchema = (cfg?: IdParamConfig): TObject => {
+const makeIdSchema = (
+  cfg?: { kind: 'single'; name?: string } | { kind: 'cfg' } | { kind: 'composite'; names: readonly [string, string] },
+): TObject => {
   const props: Record<string, TSchema> = { cfg: Type.String() };
   if (cfg?.kind === 'composite') {
     const [firstParamKey, secondParamKey] = cfg.names;
@@ -70,7 +72,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
           ? { [idParam.names[0]]: params[idParam.names[0]], [idParam.names[1]]: params[idParam.names[1]], cfg: params.cfg, tenantId }
           : idParam?.kind === 'cfg'
             ? { cfg: params.cfg, tenantId }
-            : { [singleName]: params[singleName], cfg: params.cfg, tenantId };
+            : { id: params[singleName], cfg: params.cfg, tenantId };
       return id as unknown as TId;
     };
 


### PR DESCRIPTION
…t tests.

# SPDX-License-Identifier: Apache-2.0

## What did we change?
* Added ability to search for Rule and Typology by ID & CFG instead of just CFG;
* Fixed missing unit tests to get better function coverage.

## Why are we doing this?
Networkmap doesn't have an ID, so previous tickets mentioned (wrongly) to search for all config items by CFG only - this is incorrect, Rule and Typology config has an composite primary key ID+CFG, so you should do all interactions by ID + CFG

## How was it tested?
- [X] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [X] Husky successfully run
- [X] Unit tests passing and Documentation done

<img width="678" height="439" alt="image" src="https://github.com/user-attachments/assets/7a0266d5-f0b1-4f65-a59d-7537c1e1bf45" />
<img width="820" height="608" alt="image" src="https://github.com/user-attachments/assets/82905fda-6c1d-47a5-a6c0-7689d0fe7ea4" />
<img width="817" height="532" alt="image" src="https://github.com/user-attachments/assets/04fec12c-2735-4f93-8b7b-8d28f88d0cb6" />
<img width="678" height="439" alt="image" src="https://github.com/user-attachments/assets/06827276-4176-4f12-81f7-4486088f69e4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended test coverage for rule configuration, typology configuration, and network map repository operations, including `list`, `get`, `update`, and `remove` workflows.

* **Refactor**
  * Updated rule and typology configuration endpoints to use unified identifier parameters, improving consistency across administrative configuration routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->