### PR TITLE
build: bump version to 4.0.0-rc.3, upgrade frms-coe-lib to 8.1.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fastify/swagger-ui": "^5.2.3",
         "@sinclair/typebox": "^0.34.41",
         "@tazama-lf/auth-lib": "4.0.0-rc.4",
-        "@tazama-lf/frms-coe-lib": "8.0.0-psl.2",
+        "@tazama-lf/frms-coe-lib": "8.1.0-rc.1",
         "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.5",
         "@tazama-lf/tcs-lib": "1.0.156-rc.2",
         "ajv": "^8.17.1",
@@ -99,6 +99,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2090,6 +2091,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2358,9 +2360,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.0.0-psl.2",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-psl.2/cf4e5c4a476a1777a33920c3c4835fdf55b5e1b8",
-      "integrity": "sha512-ycNl8WrIMnbQk8I+aVVuG7W7OPNdiz8xS19FoZUMlyISYjOLxLU09VYYskRpXSY0FgEl+SydJcoKIS9NSvbbYA==",
+      "version": "8.1.0-rc.1",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.1.0-rc.1/a051e709458faa3c7adf3d2249e7c9cab99c6f20",
+      "integrity": "sha512-34pEP7fBMzVBNB903+7DXMTDsaKUrvNnQ/acO+cB/m5AkIv6bZxQ5MbBfDH6Uw7QcAWs2pFoS8Q3TgxHVk9g/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2756,6 +2758,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2861,6 +2864,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3349,6 +3353,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3981,6 +3986,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5188,6 +5194,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5288,6 +5295,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5980,6 +5988,7 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -6760,6 +6769,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -7339,6 +7349,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8068,6 +8079,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9307,6 +9319,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9622,6 +9635,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11182,6 +11196,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11424,6 +11439,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-service",
-  "version": "4.0.0-rc.2",
+  "version": "4.0.0-rc.3",
   "description": "admin service",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -33,7 +33,7 @@
     "@fastify/swagger-ui": "^5.2.3",
     "@sinclair/typebox": "^0.34.41",
     "@tazama-lf/auth-lib": "4.0.0-rc.4",
-    "@tazama-lf/frms-coe-lib": "8.0.0-psl.2",
+    "@tazama-lf/frms-coe-lib": "8.1.0-rc.1",
     "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.5",
     "@tazama-lf/tcs-lib": "1.0.156-rc.2",
     "ajv": "^8.17.1",


### PR DESCRIPTION
## Summary

Bumps `@tazama-lf/frms-coe-lib` from `8.1.0-rc.0` to `8.1.0-rc.1` and increments the package version to `4.0.0-rc.3`.

## Changes

- `package.json`: upgrade `frms-coe-lib` dependency to `8.1.0-rc.1`, bump package version to `4.0.0-rc.3`
- `package-lock.json`: updated to resolve new dependency

## Dependency change

`frms-coe-lib@8.1.0-rc.1` adds the simulation builder and makes `SIMULATION_DATABASE` optional in `CreateStorageManager`. When the env var is absent, the simulation database is silently skipped at startup - preventing the crashloop that occurred with `8.0.0-psl.2`.

`Database.SIMULATION` is already present in the `CreateStorageManager` call in `src/index.ts` (merged in a prior PR). Since `SIMULATION_DATABASE` is not provisioned in deployments yet, startup will succeed and simulation features will be unavailable until the schema is provisioned.

## Dependency PR

tazama-lf/frms-coe-lib#413