### PR TITLE
fix: payload not fetching

### DIFF
--- a/__tests__/unit/trs-suite-generation.logic.service.test.ts
+++ b/__tests__/unit/trs-suite-generation.logic.service.test.ts
@@ -131,7 +131,7 @@ describe('createContextTxtpConfig', () => {
   it('fetches schema from tcs_config and inserts context config row', async () => {
     (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({
       schema: { type: 'object' },
-      content_type: 'JSON',
+      content_type: 'application/json',
       payload_json: { test: 'payload' },
     });
     (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
@@ -153,10 +153,10 @@ describe('createContextTxtpConfig', () => {
     expect(result).toBeNull();
   });
 
-  it('uses payload_xml branch when content_type is not JSON', async () => {
+  it('uses payload_xml branch when content_type is application/xml', async () => {
     (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({
       schema: { type: 'object' },
-      content_type: 'XML',
+      content_type: 'application/xml',
       payload_xml: { xml: 'data' },
     });
     (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
@@ -171,7 +171,7 @@ describe('createContextTxtpConfig', () => {
   it('wraps createContextTxtpConfigInDb error in HttpException', async () => {
     (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({
       schema: {},
-      content_type: 'JSON',
+      content_type: 'application/json',
       payload_json: {},
     });
     (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('insert failed'));
@@ -332,7 +332,7 @@ describe('error propagation', () => {
   });
 
   it('createContextTxtpConfig wraps non-Error thrown value from insert', async () => {
-    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({ schema: {}, content_type: 'JSON', payload_json: {} });
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({ schema: {}, content_type: 'application/json', payload_json: {} });
     (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
 
     await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });

--- a/src/services/trs-suite-generation.logic.service.ts
+++ b/src/services/trs-suite-generation.logic.service.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { ContentType } from '@tazama-lf/tcs-lib';
 import type {
   SuiteGeneration,
   SuiteContextTxtpConfig,
@@ -75,7 +76,9 @@ export const createContextTxtpConfig = async (
     try {
       const row = await getSchemaByTransactionType(txtp, txtpVersion, tenantId);
       schema = row.schema as Record<string, unknown>;
-      samplePayload = (row.content_type === 'JSON' ? row.payload_json : row.payload_xml) as Record<string, unknown> | undefined;
+      samplePayload = (row.content_type === (ContentType.XML as string) ? row.payload_xml : row.payload_json) as
+        | Record<string, unknown>
+        | undefined;
     } catch {
       return null;
     }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
This pull request standardizes the handling of content types for transaction schemas in both the implementation and unit tests, ensuring consistent use of MIME types (`application/json` and `application/xml`) instead of generic strings like `JSON` and `XML`. It also updates the logic for selecting payloads based on these standardized content types.

**Content type standardization and logic update:**

* Updated all references to content types in tests from `'JSON'`/`'XML'` to `'application/json'`/`'application/xml'` for consistency with MIME standards. [[1]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782L134-R134) [[2]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782L156-R159) [[3]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782L174-R174) [[4]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782L335-R335)
* Changed the logic in `createContextTxtpConfig` (in `trs-suite-generation.logic.service.ts`) to check for `ContentType.XML` (i.e., `'application/xml'`) when selecting between `payload_xml` and `payload_json`, ensuring correct payload selection based on standardized content types.
* Imported `ContentType` from `@tazama-lf/tcs-lib` to use as the source of truth for content type values.
## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
