### PR TITLE
feat: Simulation studio step 2 APIs

### DIFF
--- a/__tests__/unit/context-txtp-config.logic.service.test.ts
+++ b/__tests__/unit/context-txtp-config.logic.service.test.ts
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/context-txtp-configs.repository', () => ({
+  createContextTxtpConfigInDb: jest.fn(),
+  updateContextTxtpConfigInDb: jest.fn(),
+  getContextTxtpConfigsByGenerationId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/context-field-strategies.repository', () => ({
+  upsertFieldStrategyInDb: jest.fn(),
+  getFieldStrategiesByContextConfigId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
+  getSchemaByTransactionType: jest.fn(),
+}));
+
+jest.mock('@tazama-lf/tcs-lib', () => ({
+  ContentType: { XML: 'application/xml', JSON: 'application/json' },
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import { HttpException } from '../../src/utils/error';
+import * as contextConfigRepo from '../../src/repositories/simulation-studio/context-txtp-configs.repository';
+import * as fieldStrategyRepo from '../../src/repositories/simulation-studio/context-field-strategies.repository';
+import * as tcsRepo from '../../src/repositories/configuration/tcs.config.repository';
+import {
+  createConfigWithDefaultStrategies,
+  createContextTxtpConfig,
+  addContextTxtpConfig,
+  getContextConfigsWithStrategies,
+  bulkUpdateContextConfigs,
+  getFieldStrategiesForContextConfig,
+} from '../../src/services/context-txtp-config.logic.service';
+import type { SuiteContextTxtpConfig, ContextFieldStrategy } from '../../src/interface/suite-generation.interface';
+
+const mockContextConfig: SuiteContextTxtpConfig = {
+  id: 10,
+  generation_id: 1,
+  txtp: 'pacs.008',
+  txtp_version: '001.08',
+  display_order: 1,
+  message_count: 100,
+  schema_snapshot: { type: 'object', properties: { amount: {}, currency: {} } },
+  generator_profile: {},
+  created_at: new Date(),
+};
+
+const mockFieldStrategy: ContextFieldStrategy = {
+  id: 1,
+  context_txtp_config_id: 10,
+  field_path: 'amount',
+  strategy_code: 'keep_sample',
+  generator_options: {},
+  created_at: new Date(),
+};
+
+const tcsRowJson = {
+  schema: { type: 'object', properties: { amount: {}, currency: {} } },
+  content_type: 'application/json',
+  payload_json: { amount: 100, currency: 'USD' },
+  payload_xml: null,
+};
+
+const tcsRowXml = {
+  schema: { type: 'object', properties: { amount: {} } },
+  content_type: 'application/xml',
+  payload_xml: { amount: '<xml>' },
+  payload_json: null,
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── createConfigWithDefaultStrategies ────────────────────────────────────────
+
+describe('createConfigWithDefaultStrategies', () => {
+  it('fetches schema, inserts config, seeds keep_sample for each payload field path', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(tcsRepo.getSchemaByTransactionType).toHaveBeenCalledWith('pacs.008', '001.08', 'tenant-001');
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation_id: 1,
+        txtp: 'pacs.008',
+        txtp_version: '001.08',
+        display_order: 1,
+        message_count: 100,
+        schema_snapshot: tcsRowJson.schema,
+        sample_payload_snapshot: tcsRowJson.payload_json,
+      }),
+    );
+    // payload has 2 leaf fields: amount, currency
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(2);
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledWith(10, expect.objectContaining({ strategy_code: 'keep_sample' }));
+    expect(result.context_txtp_config_id).toBe(10);
+    expect(result.field_strategies).toHaveLength(2);
+  });
+
+  it('uses payload_xml when content_type is XML', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowXml);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ sample_payload_snapshot: tcsRowXml.payload_xml }),
+    );
+  });
+
+  it('falls back to schema paths when payload is null', async () => {
+    const tcsNoPayload = { ...tcsRowJson, payload_json: null };
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsNoPayload);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    // schema has amount and currency — still seeds 2 strategies
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when tcs_config row not found', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('Not found'));
+    await expect(
+      createConfigWithDefaultStrategies({
+        generationId: 1,
+        txtp: 'x',
+        txtpVersion: '1',
+        messageCount: 100,
+        displayOrder: 1,
+        tenantId: 'tenant',
+      }),
+    ).rejects.toThrow('Not found');
+  });
+
+  it('seeds no strategies when schema has no leaf paths', async () => {
+    const emptySchema = { ...tcsRowJson, schema: {}, payload_json: {} };
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(emptySchema);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue({ ...mockContextConfig, schema_snapshot: {} });
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).not.toHaveBeenCalled();
+    expect(result.field_strategies).toHaveLength(0);
+  });
+});
+
+// ── createContextTxtpConfig ──────────────────────────────────────────────────
+
+describe('createContextTxtpConfig', () => {
+  it('calls createConfigWithDefaultStrategies with display_order=1 and message_count=100', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001');
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 1, message_count: 100 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('bad', 404);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(err);
+    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toBe(err);
+  });
+});
+
+// ── addContextTxtpConfig ─────────────────────────────────────────────────────
+
+describe('addContextTxtpConfig', () => {
+  it('sets display_order = existing count + 1', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue({ ...mockContextConfig, id: 20, display_order: 2 });
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await addContextTxtpConfig(1, { txtp: 'pacs.002', txtp_version: '001.08', message_count: 50 }, 'tenant-001');
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 2, message_count: 50 }),
+    );
+    expect(result.context_txtp_config_id).toBe(20);
+  });
+
+  it('defaults message_count to 100 when not provided', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([]);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await addContextTxtpConfig(1, { txtp: 'pacs.008', txtp_version: '001.08' }, 'tenant-001');
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ message_count: 100, display_order: 1 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(addContextTxtpConfig(1, { txtp: 'x', txtp_version: '1' }, 'tenant')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('conflict', 409);
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(err);
+    await expect(addContextTxtpConfig(1, { txtp: 'x', txtp_version: '1' }, 'tenant')).rejects.toBe(err);
+  });
+});
+
+// ── getContextConfigsWithStrategies ──────────────────────────────────────────
+
+describe('getContextConfigsWithStrategies', () => {
+  it('returns all configs with their field strategies', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+
+    const result = await getContextConfigsWithStrategies(1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].context_txtp_config_id).toBe(10);
+    expect(result[0].txtp).toBe('pacs.008');
+    expect(result[0].field_strategies).toEqual([mockFieldStrategy]);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(10);
+  });
+
+  it('returns empty array when no configs exist', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([]);
+    const result = await getContextConfigsWithStrategies(1);
+    expect(result).toEqual([]);
+  });
+
+  it('handles multiple configs, fetches strategies for each', async () => {
+    const config2 = { ...mockContextConfig, id: 11, txtp: 'pacs.002' };
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig, config2]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+
+    const result = await getContextConfigsWithStrategies(1);
+
+    expect(result).toHaveLength(2);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledTimes(2);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(10);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(11);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(getContextConfigsWithStrategies(1)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue('string error');
+    await expect(getContextConfigsWithStrategies(1)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── bulkUpdateContextConfigs ─────────────────────────────────────────────────
+
+describe('bulkUpdateContextConfigs', () => {
+  beforeEach(() => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+  });
+
+  it('updates message_count and upserts strategies, returns updated configs', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await bulkUpdateContextConfigs(1, [
+      { context_txtp_config_id: 10, message_count: 50, field_strategies: [{ field_path: 'amount', strategy_code: 'keep_sample' }] },
+    ]);
+
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledWith(10, { message_count: 50 });
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledWith(10, { field_path: 'amount', strategy_code: 'keep_sample' });
+    expect(result).toHaveLength(1);
+    expect(result[0].context_txtp_config_id).toBe(10);
+  });
+
+  it('skips updateContextTxtpConfigInDb when no updateable scalar fields', async () => {
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await bulkUpdateContextConfigs(1, [
+      { context_txtp_config_id: 10, field_strategies: [{ field_path: 'amount', strategy_code: 'skip' }] },
+    ]);
+
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).not.toHaveBeenCalled();
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips upsertFieldStrategyInDb when field_strategies is empty array', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+
+    await bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5, field_strategies: [] }]);
+
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).not.toHaveBeenCalled();
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledWith(10, { message_count: 5 });
+  });
+
+  it('skips upsertFieldStrategyInDb when field_strategies absent', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+
+    await bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }]);
+
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).not.toHaveBeenCalled();
+  });
+
+  it('processes multiple items in parallel', async () => {
+    const config2 = { ...mockContextConfig, id: 11 };
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig, config2]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await bulkUpdateContextConfigs(1, [
+      { context_txtp_config_id: 10, message_count: 50 },
+      {
+        context_txtp_config_id: 11,
+        message_count: 200,
+        field_strategies: [{ field_path: 'amount', strategy_code: 'static', static_value: 'x' }],
+      },
+    ]);
+
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }])).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue(err);
+    await expect(bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }])).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }])).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── getFieldStrategiesForContextConfig ───────────────────────────────────────
+
+describe('getFieldStrategiesForContextConfig', () => {
+  it('returns field strategies for a config', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+
+    const result = await getFieldStrategiesForContextConfig(10);
+
+    expect(result).toEqual([mockFieldStrategy]);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(10);
+  });
+
+  it('returns empty array when no strategies', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([]);
+    expect(await getFieldStrategiesForContextConfig(10)).toEqual([]);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getFieldStrategiesForContextConfig(10)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockRejectedValue('string error');
+    await expect(getFieldStrategiesForContextConfig(10)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/__tests__/unit/simulation-suites.logic.service.test.ts
+++ b/__tests__/unit/simulation-suites.logic.service.test.ts
@@ -37,8 +37,8 @@ describe('Simulation Suites Logic Service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (trsGenService.createSuiteGeneration as jest.Mock).mockResolvedValue({ id: 1, suite_id: 1 });
-    (trsGenService.createContextTxtpConfig as jest.Mock).mockResolvedValue(null);
+    (trsGenService.createSuiteGeneration as jest.Mock).mockResolvedValue({ id: 7, suite_id: 1 });
+    (trsGenService.createContextTxtpConfig as jest.Mock).mockResolvedValue({ context_txtp_config_id: 1, field_strategies: [] });
   });
 
   describe('getSimulationSuites', () => {
@@ -93,7 +93,7 @@ describe('Simulation Suites Logic Service', () => {
 
       const result = await simulationSuitesService.createSimulationSuite(payload as any, mockTenantId, mockUserId, mockUserEmail);
 
-      expect(result).toEqual(mockSuite);
+      expect(result).toEqual({ ...mockSuite, generation_id: 7 });
       expect(simulationSuitesRepository.createSimulationSuiteInDb).toHaveBeenCalledWith(payload, mockTenantId, mockUserId, mockUserEmail);
     });
 

--- a/__tests__/unit/trs-suite-generation.logic.service.test.ts
+++ b/__tests__/unit/trs-suite-generation.logic.service.test.ts
@@ -24,6 +24,10 @@ jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
   getSchemaByTransactionType: jest.fn(),
 }));
 
+jest.mock('@tazama-lf/tcs-lib', () => ({
+  ContentType: { XML: 'application/xml', JSON: 'application/json' },
+}));
+
 jest.mock('../../src', () => ({
   loggerService: { log: jest.fn(), error: jest.fn() },
   configuration: {},
@@ -31,21 +35,13 @@ jest.mock('../../src', () => ({
 
 import { HttpException } from '../../src/utils/error';
 import * as generationsRepo from '../../src/repositories/simulation-studio/suite-generations.repository';
-import * as contextConfigRepo from '../../src/repositories/simulation-studio/context-txtp-configs.repository';
-import * as fieldStrategyRepo from '../../src/repositories/simulation-studio/context-field-strategies.repository';
-import * as tcsRepo from '../../src/repositories/configuration/tcs.config.repository';
 import {
   createSuiteGeneration,
-  createContextTxtpConfig,
-  updateContextTxtpConfig,
-  upsertContextFieldStrategies,
   getGenerationsForSuite,
   getLatestGenerationForSuite,
-  getContextConfigsForGeneration,
-  getFieldStrategiesForContextConfig,
 } from '../../src/services/trs-suite-generation.logic.service';
 import type { SimulationSuite } from '../../src/interface/simulation-suites.interface';
-import type { SuiteGeneration, SuiteContextTxtpConfig, ContextFieldStrategy } from '../../src/interface/suite-generation.interface';
+import type { SuiteGeneration } from '../../src/interface/suite-generation.interface';
 
 const mockSuite: SimulationSuite = {
   id: 42,
@@ -79,29 +75,9 @@ const mockGeneration: SuiteGeneration = {
   updated_at: new Date(),
 };
 
-const mockContextConfig: SuiteContextTxtpConfig = {
-  id: 1,
-  generation_id: 1,
-  txtp: 'pacs.008',
-  txtp_version: '001.08',
-  display_order: 1,
-  message_count: 1,
-  schema_snapshot: {},
-  created_at: new Date(),
-  updated_at: new Date(),
-};
-
-const mockFieldStrategy: ContextFieldStrategy = {
-  id: 1,
-  context_txtp_config_id: 1,
-  field_path: 'CdtTrfTxInf.IntrBkSttlmAmt.value',
-  strategy_code: 'static',
-  static_value: 999,
-  created_at: new Date(),
-  updated_at: new Date(),
-};
-
 beforeEach(() => jest.clearAllMocks());
+
+// ── createSuiteGeneration ────────────────────────────────────────────────────
 
 describe('createSuiteGeneration', () => {
   it('fetches next generation number and inserts row', async () => {
@@ -120,257 +96,95 @@ describe('createSuiteGeneration', () => {
     );
   });
 
-  it('wraps unknown errors in HttpException', async () => {
-    (generationsRepo.getNextGenerationNumber as jest.Mock).mockRejectedValue(new Error('DB down'));
+  it('works without userEmail', async () => {
+    (generationsRepo.getNextGenerationNumber as jest.Mock).mockResolvedValue(2);
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockResolvedValue({ ...mockGeneration, generation_number: 2 });
 
+    const result = await createSuiteGeneration(mockSuite, 'user-1');
+
+    expect(result.generation_number).toBe(2);
+    expect(generationsRepo.createSuiteGenerationInDb).toHaveBeenCalledWith(expect.anything(), 2, 'user-1', undefined);
+  });
+
+  it('passes wizard_progress as wizard_snapshot', async () => {
+    (generationsRepo.getNextGenerationNumber as jest.Mock).mockResolvedValue(1);
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockResolvedValue(mockGeneration);
+    const suiteWithProgress = { ...mockSuite, wizard_progress: { currentStep: 1, completedSteps: [1] } };
+
+    await createSuiteGeneration(suiteWithProgress, 'user-1');
+
+    expect(generationsRepo.createSuiteGenerationInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ wizard_snapshot: { currentStep: 1, completedSteps: [1] } }),
+      expect.any(Number),
+      expect.any(String),
+      undefined,
+    );
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const httpErr = new HttpException('conflict', 409);
+    (generationsRepo.getNextGenerationNumber as jest.Mock).mockRejectedValue(httpErr);
+    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toBe(httpErr);
+  });
+
+  it('wraps unknown Error in HttpException 500', async () => {
+    (generationsRepo.getNextGenerationNumber as jest.Mock).mockRejectedValue(new Error('DB down'));
+    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (generationsRepo.getNextGenerationNumber as jest.Mock).mockRejectedValue('string error');
     await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toMatchObject({ status: 500 });
   });
 });
 
-describe('createContextTxtpConfig', () => {
-  it('fetches schema from tcs_config and inserts context config row', async () => {
-    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({
-      schema: { type: 'object' },
-      content_type: 'application/json',
-      payload_json: { test: 'payload' },
-    });
-    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
-
-    const result = await createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001');
-
-    expect(result).toEqual(mockContextConfig);
-    expect(tcsRepo.getSchemaByTransactionType).toHaveBeenCalledWith('pacs.008', '001.08', 'tenant-001');
-    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
-      expect.objectContaining({ generation_id: 1, txtp: 'pacs.008', txtp_version: '001.08' }),
-    );
-  });
-
-  it('returns null silently when tcs_config row not found', async () => {
-    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('Not found'));
-
-    const result = await createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001');
-
-    expect(result).toBeNull();
-  });
-
-  it('uses payload_xml branch when content_type is application/xml', async () => {
-    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({
-      schema: { type: 'object' },
-      content_type: 'application/xml',
-      payload_xml: { xml: 'data' },
-    });
-    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
-
-    await createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001');
-
-    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
-      expect.objectContaining({ sample_payload_snapshot: { xml: 'data' } }),
-    );
-  });
-
-  it('wraps createContextTxtpConfigInDb error in HttpException', async () => {
-    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({
-      schema: {},
-      content_type: 'application/json',
-      payload_json: {},
-    });
-    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('insert failed'));
-
-    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });
-  });
-});
-
-describe('updateContextTxtpConfig', () => {
-  it('calls updateContextTxtpConfigInDb and returns updated row', async () => {
-    const updated = { ...mockContextConfig, message_count: 5 };
-    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(updated);
-
-    const result = await updateContextTxtpConfig(1, { message_count: 5 });
-
-    expect(result).toEqual(updated);
-    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledWith(1, { message_count: 5 });
-  });
-
-  it('throws 404 when config not found', async () => {
-    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(null);
-
-    await expect(updateContextTxtpConfig(99, { message_count: 5 })).rejects.toMatchObject({ status: 404 });
-  });
-});
-
-describe('upsertContextFieldStrategies', () => {
-  it('upserts all strategies and returns array', async () => {
-    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
-
-    const result = await upsertContextFieldStrategies(1, [
-      { field_path: 'CdtTrfTxInf.IntrBkSttlmAmt.value', strategy_code: 'static', static_value: 999 },
-    ]);
-
-    expect(result).toEqual([mockFieldStrategy]);
-    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(1);
-  });
-
-  it('upserts multiple strategies in parallel', async () => {
-    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
-
-    const strategies = [
-      { field_path: 'field.a', strategy_code: 'keep_sample' as const },
-      { field_path: 'field.b', strategy_code: 'null' as const },
-      { field_path: 'field.c', strategy_code: 'skip' as const },
-    ];
-    await upsertContextFieldStrategies(1, strategies);
-
-    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(3);
-  });
-});
+// ── getGenerationsForSuite ───────────────────────────────────────────────────
 
 describe('getGenerationsForSuite', () => {
   it('returns generations array', async () => {
     (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockResolvedValue([mockGeneration]);
-
     const result = await getGenerationsForSuite(42);
-
     expect(result).toEqual([mockGeneration]);
     expect(generationsRepo.getGenerationsBySuiteId).toHaveBeenCalledWith(42);
   });
 
-  it('wraps error in HttpException', async () => {
-    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockRejectedValue(new Error('fail'));
+  it('returns empty array when no generations', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockResolvedValue([]);
+    expect(await getGenerationsForSuite(42)).toEqual([]);
+  });
 
+  it('wraps error in HttpException 500', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getGenerationsForSuite(42)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockRejectedValue('string error');
     await expect(getGenerationsForSuite(42)).rejects.toMatchObject({ status: 500 });
   });
 });
+
+// ── getLatestGenerationForSuite ──────────────────────────────────────────────
 
 describe('getLatestGenerationForSuite', () => {
   it('returns latest generation', async () => {
     (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockResolvedValue(mockGeneration);
-
-    const result = await getLatestGenerationForSuite(42);
-
-    expect(result).toEqual(mockGeneration);
+    expect(await getLatestGenerationForSuite(42)).toEqual(mockGeneration);
+    expect(generationsRepo.getLatestGenerationBySuiteId).toHaveBeenCalledWith(42);
   });
 
   it('returns null when no generations exist', async () => {
     (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockResolvedValue(null);
-
-    const result = await getLatestGenerationForSuite(42);
-
-    expect(result).toBeNull();
-  });
-});
-
-describe('getContextConfigsForGeneration', () => {
-  it('returns context configs array', async () => {
-    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
-
-    const result = await getContextConfigsForGeneration(1);
-
-    expect(result).toEqual([mockContextConfig]);
-  });
-});
-
-describe('getFieldStrategiesForContextConfig', () => {
-  it('returns field strategies array', async () => {
-    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
-
-    const result = await getFieldStrategiesForContextConfig(1);
-
-    expect(result).toEqual([mockFieldStrategy]);
-    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(1);
+    expect(await getLatestGenerationForSuite(42)).toBeNull();
   });
 
-  it('wraps error in HttpException', async () => {
-    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockRejectedValue(new Error('fail'));
-
-    await expect(getFieldStrategiesForContextConfig(1)).rejects.toMatchObject({ status: 500 });
-  });
-});
-
-describe('error propagation', () => {
-  it('createSuiteGeneration rethrows HttpException as-is', async () => {
-    const httpErr = new HttpException('already thrown', 409);
-    (generationsRepo.getNextGenerationNumber as jest.Mock).mockRejectedValue(httpErr);
-
-    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toBe(httpErr);
-  });
-
-  it('updateContextTxtpConfig rethrows HttpException as-is', async () => {
-    const httpErr = new HttpException('already thrown', 409);
-    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue(httpErr);
-
-    await expect(updateContextTxtpConfig(1, { message_count: 5 })).rejects.toBe(httpErr);
-  });
-
-  it('updateContextTxtpConfig wraps non-HttpException error', async () => {
-    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('plain error'));
-
-    await expect(updateContextTxtpConfig(1, { message_count: 5 })).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('upsertContextFieldStrategies wraps error in HttpException', async () => {
-    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockRejectedValue(new Error('DB error'));
-
-    await expect(upsertContextFieldStrategies(1, [{ field_path: 'a', strategy_code: 'null' }])).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('getContextConfigsForGeneration wraps error in HttpException', async () => {
-    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('fail'));
-
-    await expect(getContextConfigsForGeneration(1)).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('getLatestGenerationForSuite wraps error in HttpException', async () => {
+  it('wraps error in HttpException 500', async () => {
     (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockRejectedValue(new Error('fail'));
-
     await expect(getLatestGenerationForSuite(42)).rejects.toMatchObject({ status: 500 });
   });
 
-  it('createSuiteGeneration wraps non-Error thrown value', async () => {
-    (generationsRepo.getNextGenerationNumber as jest.Mock).mockRejectedValue('string error');
-
-    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('createContextTxtpConfig wraps non-Error thrown value from insert', async () => {
-    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue({ schema: {}, content_type: 'application/json', payload_json: {} });
-    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
-
-    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('updateContextTxtpConfig wraps non-Error thrown value', async () => {
-    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
-
-    await expect(updateContextTxtpConfig(1, { message_count: 5 })).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('upsertContextFieldStrategies wraps non-Error thrown value', async () => {
-    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockRejectedValue('string error');
-
-    await expect(upsertContextFieldStrategies(1, [{ field_path: 'a', strategy_code: 'null' }])).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('getGenerationsForSuite wraps non-Error thrown value', async () => {
-    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockRejectedValue('string error');
-
-    await expect(getGenerationsForSuite(42)).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('getContextConfigsForGeneration wraps non-Error thrown value', async () => {
-    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue('string error');
-
-    await expect(getContextConfigsForGeneration(1)).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('getLatestGenerationForSuite wraps non-Error thrown value', async () => {
+  it('wraps non-Error thrown value', async () => {
     (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockRejectedValue('string error');
-
     await expect(getLatestGenerationForSuite(42)).rejects.toMatchObject({ status: 500 });
-  });
-
-  it('getFieldStrategiesForContextConfig wraps non-Error thrown value', async () => {
-    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockRejectedValue('string error');
-
-    await expect(getFieldStrategiesForContextConfig(1)).rejects.toMatchObject({ status: 500 });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -89,15 +89,13 @@ import {
 import {
   getGenerationsForSuite,
   getLatestGenerationForSuite,
-  getContextConfigsForGeneration,
-  updateContextTxtpConfig,
-  upsertContextFieldStrategies,
-  getFieldStrategiesForContextConfig,
+  addContextTxtpConfig,
+  getContextConfigsWithStrategies,
+  bulkUpdateContextConfigs,
 } from './services/trs-suite-generation.logic.service';
-import type { UpdateContextTxtpConfigDto, UpsertFieldStrategyDto } from './interface/suite-generation.interface';
+import type { AddContextTxtpConfigDto, BulkConfigItemDto } from './interface/suite-generation.interface';
 import type { EvaluationRow } from './repositories/configuration/evaluation.repository';
 import { decodeInnerToken } from './utils/decode-token';
-import { assertPreviousStepComplete } from './utils/wizard-step-guard';
 import type { ISimulationBody } from './interface/simulattionLogs.interface';
 import type {
   SimulationSuitesQueryDto,
@@ -2038,7 +2036,7 @@ export const getGenerationContextConfigsHandler = async (req: FastifyRequest, re
       return;
     }
 
-    const configs = await getContextConfigsForGeneration(genId);
+    const configs = await getContextConfigsWithStrategies(genId);
 
     reply.status(200).send({ success: true, data: configs });
     loggerService.log('End - Get generation context txtp configs');
@@ -2049,98 +2047,57 @@ export const getGenerationContextConfigsHandler = async (req: FastifyRequest, re
   }
 };
 
-// ── Step 2 helpers ────────────────────────────────────────────────────────────
+// ── Step 2: POST new context txtp config (Add TXTP) ─────────────────────────
 
-const parseStep2Params = (params: { suiteId: string; configId: string }): { suiteId: number; configId: number } | null => {
-  const suiteId = parseInt(params.suiteId, 10);
-  const configId = parseInt(params.configId, 10);
-  if (isNaN(suiteId) || isNaN(configId)) return null;
-  return { suiteId, configId };
+export const addContextTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Add context txtp config');
+    const { tenantId } = req as ITenantRequest;
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const dto = req.body as AddContextTxtpConfigDto;
+    const created = await addContextTxtpConfig(generationId, dto, tenantId);
+
+    reply.status(201).send({ success: true, data: created });
+    loggerService.log('End - Add context txtp config');
+  } catch (err) {
+    loggerService.error(`Failed to add context txtp config. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to add context txtp config');
+  }
 };
 
-// ── Step 2: PATCH context txtp config (message_count, faker_seed, generator_profile) ──
+// ── Step 2: PATCH bulk update context configs (message_count + field strategies) ──
 
 export const updateContextTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
   try {
-    loggerService.log('Start - Update context txtp config');
-    const { tenantId } = req as ITenantRequest;
-    const parsed = parseStep2Params(req.params as { suiteId: string; configId: string });
+    loggerService.log('Start - Bulk update context txtp configs');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
 
-    if (!parsed) {
-      reply.status(400).send({ success: false, message: 'Invalid suite ID or context config ID' });
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
       return;
     }
 
-    const suite = await getSimulationSuiteById(parsed.suiteId, tenantId);
-    assertPreviousStepComplete(suite!.wizard_progress, 1);
+    const items = req.body as BulkConfigItemDto[];
+    if (!Array.isArray(items) || items.length === 0) {
+      reply.status(400).send({ success: false, message: 'Request body must be a non-empty array' });
+      return;
+    }
 
-    const dto = req.body as UpdateContextTxtpConfigDto;
-    const updated = await updateContextTxtpConfig(parsed.configId, dto);
+    const updated = await bulkUpdateContextConfigs(generationId, items);
 
     reply.status(200).send({ success: true, data: updated });
-    loggerService.log('End - Update context txtp config');
+    loggerService.log('End - Bulk update context txtp configs');
   } catch (err) {
-    loggerService.error(`Failed to update context txtp config. \n${util.inspect(err)}`);
-    ErrorHandler.sendError(reply, err, 'Failed to update context txtp config');
-  }
-};
-
-// ── Step 2: PUT field strategies (upsert array) ──────────────────────────────
-
-export const upsertFieldStrategiesHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
-  try {
-    loggerService.log('Start - Upsert field strategies');
-    const { tenantId } = req as ITenantRequest;
-    const parsed = parseStep2Params(req.params as { suiteId: string; configId: string });
-
-    if (!parsed) {
-      reply.status(400).send({ success: false, message: 'Invalid suite ID or context config ID' });
-      return;
-    }
-
-    const suite = await getSimulationSuiteById(parsed.suiteId, tenantId);
-    assertPreviousStepComplete(suite!.wizard_progress, 1);
-
-    const { strategies } = req.body as { strategies: UpsertFieldStrategyDto[] };
-
-    if (!Array.isArray(strategies) || strategies.length === 0) {
-      reply.status(400).send({ success: false, message: 'strategies array is required and cannot be empty' });
-      return;
-    }
-
-    const result = await upsertContextFieldStrategies(parsed.configId, strategies);
-
-    reply.status(200).send({ success: true, data: result });
-    loggerService.log('End - Upsert field strategies');
-  } catch (err) {
-    loggerService.error(`Failed to upsert field strategies. \n${util.inspect(err)}`);
-    ErrorHandler.sendError(reply, err, 'Failed to upsert field strategies');
-  }
-};
-
-// ── Step 2: GET field strategies for a context config ────────────────────────
-
-export const getFieldStrategiesHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
-  try {
-    loggerService.log('Start - Get field strategies');
-    const { tenantId } = req as ITenantRequest;
-    const parsed = parseStep2Params(req.params as { suiteId: string; configId: string });
-
-    if (!parsed) {
-      reply.status(400).send({ success: false, message: 'Invalid suite ID or context config ID' });
-      return;
-    }
-
-    const suite = await getSimulationSuiteById(parsed.suiteId, tenantId);
-    assertPreviousStepComplete(suite!.wizard_progress, 1);
-
-    const strategies = await getFieldStrategiesForContextConfig(parsed.configId);
-
-    reply.status(200).send({ success: true, data: strategies });
-    loggerService.log('End - Get field strategies');
-  } catch (err) {
-    loggerService.error(`Failed to retrieve field strategies. \n${util.inspect(err)}`);
-    ErrorHandler.sendError(reply, err, 'Failed to retrieve field strategies');
+    loggerService.error(`Failed to bulk update context txtp configs. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to bulk update context txtp configs');
   }
 };
 

--- a/src/interface/simulation-suites.interface.ts
+++ b/src/interface/simulation-suites.interface.ts
@@ -48,6 +48,7 @@ export interface SimulationSuite {
   created_by_email?: string;
   created_at: Date;
   updated_at: Date;
+  generation_id?: number;
 }
 
 /**

--- a/src/interface/suite-generation.interface.ts
+++ b/src/interface/suite-generation.interface.ts
@@ -83,6 +83,12 @@ export interface UpdateContextTxtpConfigDto {
   generator_profile?: Record<string, unknown>;
 }
 
+export interface AddContextTxtpConfigDto {
+  txtp: string;
+  txtp_version: string;
+  message_count?: number;
+}
+
 // ── Context Field Strategies ─────────────────────────────────────────────────
 
 export interface ContextFieldStrategy {
@@ -108,4 +114,23 @@ export interface UpsertFieldStrategyDto {
   generator_type?: string;
   generator_options?: Record<string, unknown>;
   is_required_override?: boolean;
+}
+
+export interface ContextTxtpConfigWithStrategies {
+  context_txtp_config_id: number;
+  txtp: string;
+  txtp_version: string;
+  message_count: number;
+  display_order: number;
+  schema_snapshot: Record<string, unknown>;
+  sample_payload_snapshot?: Record<string, unknown>;
+  field_strategies: ContextFieldStrategy[];
+}
+
+export interface BulkConfigItemDto {
+  context_txtp_config_id: number;
+  message_count?: number;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+  field_strategies?: UpsertFieldStrategyDto[];
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -80,11 +80,9 @@ import {
   getSimulationByIdHandler,
   getSimulationsHandler,
   getSuiteGenerationsHandler,
-  getLatestSuiteGenerationHandler,
   getGenerationContextConfigsHandler,
+  addContextTxtpConfigHandler,
   updateContextTxtpConfigHandler,
-  upsertFieldStrategiesHandler,
-  getFieldStrategiesHandler,
   getAllSimulationsHandler,
   createTrsSimulationHandler,
   getSimulationStatsHandler,
@@ -178,11 +176,9 @@ const routePrivilege = {
   getSimulationSuiteById: ['editor', 'approver'],
   updateSimulationSuite: ['editor', 'approver'],
   getSuiteGenerations: ['editor', 'approver'],
-  getLatestSuiteGeneration: ['editor', 'approver'],
   getGenerationContextConfigs: ['editor', 'approver'],
+  addContextTxtpConfig: ['editor', 'approver'],
   updateContextTxtpConfig: ['editor', 'approver'],
-  upsertFieldStrategies: ['editor', 'approver'],
-  getFieldStrategies: ['editor', 'approver'],
   getSimulations: ['editor', 'approver'],
   createSimulation: ['editor', 'approver'],
   getSimulationStats: ['editor', 'approver'],
@@ -543,24 +539,16 @@ function Routes(fastify: FastifyInstance): void {
     ...SetOptionsBodyAndParams(getSuiteGenerationsHandler, routePrivilege.getSuiteGenerations),
   });
 
-  fastify.get('/v1/admin/trs/simulation-studio/suites/:id/generations/latest', {
-    ...SetOptionsBodyAndParams(getLatestSuiteGenerationHandler, routePrivilege.getLatestSuiteGeneration),
-  });
-
   fastify.get('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs', {
     ...SetOptionsBodyAndParams(getGenerationContextConfigsHandler, routePrivilege.getGenerationContextConfigs),
   });
 
-  fastify.patch('/v1/admin/trs/simulation-studio/suites/:suiteId/context-configs/:configId', {
+  fastify.post('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs', {
+    ...SetOptionsBodyAndParams(addContextTxtpConfigHandler, routePrivilege.addContextTxtpConfig),
+  });
+
+  fastify.patch('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs', {
     ...SetOptionsBodyAndParams(updateContextTxtpConfigHandler, routePrivilege.updateContextTxtpConfig),
-  });
-
-  fastify.put('/v1/admin/trs/simulation-studio/suites/:suiteId/context-configs/:configId/field-strategies', {
-    ...SetOptionsBodyAndParams(upsertFieldStrategiesHandler, routePrivilege.upsertFieldStrategies),
-  });
-
-  fastify.get('/v1/admin/trs/simulation-studio/suites/:suiteId/context-configs/:configId/field-strategies', {
-    ...SetOptionsBodyAndParams(getFieldStrategiesHandler, routePrivilege.getFieldStrategies),
   });
   fastify.get('/v1/admin/simulation/messages', {
     ...SetOptionsBodyAndParams(getSimulationMessagesHandler, routePrivilege.getSimulationMessages),

--- a/src/services/context-txtp-config.logic.service.ts
+++ b/src/services/context-txtp-config.logic.service.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+import type {
+  ContextFieldStrategy,
+  AddContextTxtpConfigDto,
+  BulkConfigItemDto,
+  ContextTxtpConfigWithStrategies,
+} from '../interface/suite-generation.interface';
+import {
+  createContextTxtpConfigInDb,
+  updateContextTxtpConfigInDb,
+  getContextTxtpConfigsByGenerationId,
+} from '../repositories/simulation-studio/context-txtp-configs.repository';
+import {
+  upsertFieldStrategyInDb,
+  getFieldStrategiesByContextConfigId,
+} from '../repositories/simulation-studio/context-field-strategies.repository';
+import { getSchemaByTransactionType } from '../repositories/configuration/tcs.config.repository';
+import { ContentType } from '@tazama-lf/tcs-lib';
+import { HttpException, HttpStatus } from '../utils/error';
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+const flattenSchemaPaths = (obj: unknown, prefix = ''): string[] => {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return prefix ? [prefix] : [];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, val]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'object' && val !== null && !Array.isArray(val) && Object.keys(val).length > 0) {
+      return flattenSchemaPaths(val, path);
+    }
+    return [path];
+  });
+};
+
+// ── Shared factory ───────────────────────────────────────────────────────────
+
+/**
+ * Creates a context txtp config row and seeds all field paths with strategy_code = 'keep_sample'.
+ * Used by Step 1 (suite creation) and Step 2 (Add TXTP button).
+ * Throws HttpException if tcs_config row not found.
+ */
+interface CreateConfigOptions {
+  generationId: number;
+  txtp: string;
+  txtpVersion: string;
+  messageCount: number;
+  displayOrder: number;
+  tenantId: string;
+}
+
+export const createConfigWithDefaultStrategies = async (opts: CreateConfigOptions): Promise<ContextTxtpConfigWithStrategies> => {
+  const { generationId, txtp, txtpVersion, messageCount, displayOrder, tenantId } = opts;
+  const tcsRow = await getSchemaByTransactionType(txtp, txtpVersion, tenantId);
+
+  const schema = tcsRow.schema as Record<string, unknown>;
+  const samplePayload = (tcsRow.content_type === (ContentType.XML as string) ? tcsRow.payload_xml : tcsRow.payload_json) as
+    | Record<string, unknown>
+    | undefined;
+
+  const config = await createContextTxtpConfigInDb({
+    generation_id: generationId,
+    txtp,
+    txtp_version: txtpVersion,
+    display_order: displayOrder,
+    message_count: messageCount,
+    schema_snapshot: schema,
+    sample_payload_snapshot: samplePayload,
+  });
+
+  const schemaFallback = (schema.properties as Record<string, unknown> | undefined) ?? schema;
+  const fieldPaths = flattenSchemaPaths(samplePayload ?? schemaFallback);
+  const fieldStrategies = await Promise.all(
+    fieldPaths.map(async (path) => await upsertFieldStrategyInDb(config.id, { field_path: path, strategy_code: 'keep_sample' })),
+  );
+
+  return {
+    context_txtp_config_id: config.id,
+    txtp: config.txtp,
+    txtp_version: config.txtp_version,
+    message_count: config.message_count,
+    display_order: config.display_order,
+    schema_snapshot: config.schema_snapshot,
+    sample_payload_snapshot: config.sample_payload_snapshot,
+    field_strategies: fieldStrategies,
+  };
+};
+
+// ── Step 1 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Called during suite creation. Creates the primary context txtp config with default strategies.
+ */
+export const createContextTxtpConfig = async (
+  generationId: number,
+  txtp: string,
+  txtpVersion: string,
+  tenantId: string,
+): Promise<ContextTxtpConfigWithStrategies> => {
+  try {
+    return await createConfigWithDefaultStrategies({ generationId, txtp, txtpVersion, messageCount: 100, displayOrder: 1, tenantId });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to create context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 2: Add TXTP ─────────────────────────────────────────────────────────
+
+/**
+ * Called when user clicks "Add TXTP". display_order = existing count + 1.
+ */
+export const addContextTxtpConfig = async (
+  generationId: number,
+  dto: AddContextTxtpConfigDto,
+  tenantId: string,
+): Promise<ContextTxtpConfigWithStrategies> => {
+  try {
+    const existing = await getContextTxtpConfigsByGenerationId(generationId);
+    const displayOrder = existing.length + 1;
+    return await createConfigWithDefaultStrategies({
+      generationId,
+      txtp: dto.txtp,
+      txtpVersion: dto.txtp_version,
+      messageCount: dto.message_count ?? 100,
+      displayOrder,
+      tenantId,
+    });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to add context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 2: GET all ──────────────────────────────────────────────────────────
+
+/**
+ * Returns all context configs with field strategies for a generation.
+ */
+export const getContextConfigsWithStrategies = async (generationId: number): Promise<ContextTxtpConfigWithStrategies[]> => {
+  try {
+    const configs = await getContextTxtpConfigsByGenerationId(generationId);
+    return await Promise.all(
+      configs.map(async (config) => {
+        const fieldStrategies = await getFieldStrategiesByContextConfigId(config.id);
+        return {
+          context_txtp_config_id: config.id,
+          txtp: config.txtp,
+          txtp_version: config.txtp_version,
+          message_count: config.message_count,
+          display_order: config.display_order,
+          schema_snapshot: config.schema_snapshot,
+          sample_payload_snapshot: config.sample_payload_snapshot,
+          field_strategies: fieldStrategies,
+        };
+      }),
+    );
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to retrieve context configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 2: Bulk update ──────────────────────────────────────────────────────
+
+/**
+ * Bulk update message_count + field strategies for all provided configs.
+ * Silently skips missing context_txtp_config_id entries.
+ * Returns full updated state for the generation.
+ */
+export const bulkUpdateContextConfigs = async (
+  generationId: number,
+  items: BulkConfigItemDto[],
+): Promise<ContextTxtpConfigWithStrategies[]> => {
+  try {
+    await Promise.all(
+      items.map(async (item) => {
+        const { context_txtp_config_id: contextTxtpConfigId, field_strategies: fieldStrategies, ...updateFields } = item;
+        if (Object.keys(updateFields).length > 0) {
+          await updateContextTxtpConfigInDb(contextTxtpConfigId, updateFields);
+        }
+        if (Array.isArray(fieldStrategies) && fieldStrategies.length > 0) {
+          await Promise.all(fieldStrategies.map(async (s) => await upsertFieldStrategyInDb(contextTxtpConfigId, s)));
+        }
+      }),
+    );
+    return await getContextConfigsWithStrategies(generationId);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to bulk update context configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Read helper ──────────────────────────────────────────────────────────────
+
+export const getFieldStrategiesForContextConfig = async (contextTxtpConfigId: number): Promise<ContextFieldStrategy[]> => {
+  try {
+    return await getFieldStrategiesByContextConfigId(contextTxtpConfigId);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to retrieve field strategies: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/services/simulation-suites.logic.service.ts
+++ b/src/services/simulation-suites.logic.service.ts
@@ -71,7 +71,7 @@ export const createSimulationSuite = async (
       await createContextTxtpConfig(generation.id, suite.primary_txtp, suite.primary_txtp_version, tenantId);
     }
 
-    return suite;
+    return { ...suite, generation_id: generation.id };
   } catch (error) {
     if (error instanceof HttpException) throw error;
     throw new HttpException(

--- a/src/services/trs-suite-generation.logic.service.ts
+++ b/src/services/trs-suite-generation.logic.service.ts
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType } from '@tazama-lf/tcs-lib';
-import type {
-  SuiteGeneration,
-  SuiteContextTxtpConfig,
-  ContextFieldStrategy,
-  UpdateContextTxtpConfigDto,
-  UpsertFieldStrategyDto,
-} from '../interface/suite-generation.interface';
+import type { SuiteGeneration } from '../interface/suite-generation.interface';
 import type { SimulationSuite } from '../interface/simulation-suites.interface';
 import {
   createSuiteGenerationInDb,
@@ -14,28 +7,23 @@ import {
   getGenerationsBySuiteId,
   getLatestGenerationBySuiteId,
 } from '../repositories/simulation-studio/suite-generations.repository';
-import {
-  createContextTxtpConfigInDb,
-  updateContextTxtpConfigInDb,
-  getContextTxtpConfigsByGenerationId,
-} from '../repositories/simulation-studio/context-txtp-configs.repository';
-import {
-  upsertFieldStrategyInDb,
-  getFieldStrategiesByContextConfigId,
-} from '../repositories/simulation-studio/context-field-strategies.repository';
-import { getSchemaByTransactionType } from '../repositories/configuration/tcs.config.repository';
 import { HttpException, HttpStatus } from '../utils/error';
 
-// ── Suite Creation flow ──────────────────────────────────────────────────────
+// Re-export context config service for app.controller consumers
+export {
+  createConfigWithDefaultStrategies,
+  createContextTxtpConfig,
+  addContextTxtpConfig,
+  getContextConfigsWithStrategies,
+  bulkUpdateContextConfigs,
+  getFieldStrategiesForContextConfig,
+} from './context-txtp-config.logic.service';
 
-/**
- * Step 1 — called from createSimulationSuite.
- * INSERTs trs_suite_generations with generation_number=1, status=DRAFT.
- */
+// ── Suite Generation ─────────────────────────────────────────────────────────
+
 export const createSuiteGeneration = async (suite: SimulationSuite, userId: string, userEmail?: string): Promise<SuiteGeneration> => {
   try {
     const generationNumber = await getNextGenerationNumber(suite.id);
-
     return await createSuiteGenerationInDb(
       {
         suite_id: suite.id,
@@ -58,90 +46,6 @@ export const createSuiteGeneration = async (suite: SimulationSuite, userId: stri
   }
 };
 
-/**
- * Step 1 — called from createSimulationSuite after generation is created.
- * Fetches schema + sample_payload from tcs_config, then INSERTs trs_suite_context_txtp_configs.
- * Returns null silently if no tcs_config row exists for the txtp+version yet.
- */
-export const createContextTxtpConfig = async (
-  generationId: number,
-  txtp: string,
-  txtpVersion: string,
-  tenantId: string,
-): Promise<SuiteContextTxtpConfig | null> => {
-  try {
-    let schema: Record<string, unknown>;
-    let samplePayload: Record<string, unknown> | undefined;
-
-    try {
-      const row = await getSchemaByTransactionType(txtp, txtpVersion, tenantId);
-      schema = row.schema as Record<string, unknown>;
-      samplePayload = (row.content_type === (ContentType.XML as string) ? row.payload_xml : row.payload_json) as
-        | Record<string, unknown>
-        | undefined;
-    } catch {
-      return null;
-    }
-
-    return await createContextTxtpConfigInDb({
-      generation_id: generationId,
-      txtp,
-      txtp_version: txtpVersion,
-      display_order: 1,
-      message_count: 1,
-      schema_snapshot: schema,
-      sample_payload_snapshot: samplePayload,
-    });
-  } catch (error) {
-    if (error instanceof HttpException) throw error;
-    throw new HttpException(
-      `Failed to create context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
-  }
-};
-
-// ── Step 2 — Context Config update ──────────────────────────────────────────
-
-/**
- * Step 2 — update message_count / faker_seed / generator_profile on an existing
- * trs_suite_context_txtp_configs row.
- */
-export const updateContextTxtpConfig = async (configId: number, dto: UpdateContextTxtpConfigDto): Promise<SuiteContextTxtpConfig> => {
-  try {
-    const updated = await updateContextTxtpConfigInDb(configId, dto);
-    if (updated == null) throw new HttpException(`Context txtp config ${configId} not found`, HttpStatus.NOT_FOUND);
-    return updated;
-  } catch (error) {
-    if (error instanceof HttpException) throw error;
-    throw new HttpException(
-      `Failed to update context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
-  }
-};
-
-/**
- * Step 2 — upsert one or many field strategies for a context_txtp_config row.
- * ON CONFLICT (context_txtp_config_id, field_path) → update strategy columns.
- */
-export const upsertContextFieldStrategies = async (
-  contextTxtpConfigId: number,
-  strategies: UpsertFieldStrategyDto[],
-): Promise<ContextFieldStrategy[]> => {
-  try {
-    return await Promise.all(strategies.map(async (s) => await upsertFieldStrategyInDb(contextTxtpConfigId, s)));
-  } catch (error) {
-    if (error instanceof HttpException) throw error;
-    throw new HttpException(
-      `Failed to upsert field strategies: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
-  }
-};
-
-// ── Read helpers ─────────────────────────────────────────────────────────────
-
 export const getGenerationsForSuite = async (suiteId: number): Promise<SuiteGeneration[]> => {
   try {
     return await getGenerationsBySuiteId(suiteId);
@@ -159,28 +63,6 @@ export const getLatestGenerationForSuite = async (suiteId: number): Promise<Suit
   } catch (error) {
     throw new HttpException(
       `Failed to retrieve latest generation: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
-  }
-};
-
-export const getContextConfigsForGeneration = async (generationId: number): Promise<SuiteContextTxtpConfig[]> => {
-  try {
-    return await getContextTxtpConfigsByGenerationId(generationId);
-  } catch (error) {
-    throw new HttpException(
-      `Failed to retrieve context configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
-  }
-};
-
-export const getFieldStrategiesForContextConfig = async (contextTxtpConfigId: number): Promise<ContextFieldStrategy[]> => {
-  try {
-    return await getFieldStrategiesByContextConfigId(contextTxtpConfigId);
-  } catch (error) {
-    throw new HttpException(
-      `Failed to retrieve field strategies: ${error instanceof Error ? error.message : 'Unknown error'}`,
       HttpStatus.INTERNAL_SERVER_ERROR,
     );
   }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
This pull request refactors and simplifies the test suite for the TRS suite generation logic, removes several context config and field strategy tests, and updates controller imports to match new service method names. The main focus is on improving error handling, cleaning up unused code, and aligning the test and controller code with recent changes in the service layer.

**Test suite refactoring and cleanup:**

* Removed tests for `createContextTxtpConfig`, `updateContextTxtpConfig`, `upsertContextFieldStrategies`, `getContextConfigsForGeneration`, and `getFieldStrategiesForContextConfig`, focusing the test suite on core generation logic and error handling for `createSuiteGeneration`, `getGenerationsForSuite`, and `getLatestGenerationForSuite` (`__tests__/unit/trs-suite-generation.logic.service.test.ts`) [[1]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782R27-R44) [[2]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782L82-R81) [[3]](diffhunk://#diff-3157a69e7da3d2c95e4b0fcfd51563e75a2e358d7939e87e580a65a8b2fe9782L123-L375).
* Added and improved tests for error handling, including wrapping unknown errors and non-Error thrown values in `HttpException` with status 500, and rethrowing `HttpException` as-is (`__tests__/unit/trs-suite-generation.logic.service.test.ts`).

**Test and mock updates:**

* Updated mocks in `simulation-suites.logic.service.test.ts` to reflect new return values for `trsGenService.createSuiteGeneration` and `trsGenService.createContextTxtpConfig`, and adjusted expectations to include `generation_id` (`__tests__/unit/simulation-suites.logic.service.test.ts`) [[1]](diffhunk://#diff-23b84edb1e0a6800bb2b5a4c6aa45e47f4e9e3ff39a5584130c2b5652b1544d1L40-R41) [[2]](diffhunk://#diff-23b84edb1e0a6800bb2b5a4c6aa45e47f4e9e3ff39a5584130c2b5652b1544d1L96-R96).

**Controller and service alignment:**

* Updated controller imports to use new service method names: `addContextTxtpConfig`, `getContextConfigsWithStrategies`, and `bulkUpdateContextConfigs`, replacing the old context config and field strategy methods (`src/app.controller.ts`).
* Changed the implementation of the handler for fetching generation context configs to use `getContextConfigsWithStrategies` instead of `getContextConfigsForGeneration` (`src/app.controller.ts`).

These changes help keep the codebase consistent with recent service layer updates, improve test coverage for error cases, and remove obsolete or redundant tests and code.
## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
