### PR TITLE
fix: an issue occured during saving of mapping - query was breaking (…

### DIFF
--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -298,7 +298,7 @@ export const updateConfig = async (
   setClauses.push('updated_at = NOW()');
 
   // Optimistic lock: update only when updated_at still matches the token returned by the previous read.
-  const whereClause = `WHERE id = $${paramIndex} AND tenant_id = $${paramIndex + 1} AND updated_at = $${paramIndex + 2}::timestamptz`;
+  const whereClause = `WHERE id = $${paramIndex} AND tenant_id = $${paramIndex + 1}`;
 
   const query = `
     UPDATE tcs_config

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -297,7 +297,6 @@ export const updateConfig = async (
 
   setClauses.push('updated_at = NOW()');
 
-  // Optimistic lock: update only when updated_at still matches the token returned by the previous read.
   const whereClause = `WHERE id = $${paramIndex} AND tenant_id = $${paramIndex + 1}`;
 
   const query = `


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
There was some leftover code from removing optimistic locking. 
A query was breaking (it required timestamp as the 4th param, but we were passing only 3)

## Why are we doing this?
So that the processes that were breaking (save mapping for example) can now be back to normal. That is crucial and most essential part of using TCS.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration updates now complete successfully regardless of concurrent modifications, ensuring consistent behavior in multi-user environments without race condition failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->