### PR TITLE
feat: simulation studio APIs

### DIFF
--- a/__tests__/unit/app.faker-semantic-data.test.ts
+++ b/__tests__/unit/app.faker-semantic-data.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { getFakerSemanticDataHandler } from '../../src/app.controller';
+import * as fakerSemanticService from '../../src/services/faker-semantic-data.logic.service';
+import { ErrorHandler } from '../../src/handlers/errorHandler';
+
+jest.mock('../../src/services/faker-semantic-data.logic.service', () => ({
+  getFakerSemanticData: jest.fn(),
+}));
+
+jest.mock('../../src/handlers/errorHandler', () => ({
+  ErrorHandler: {
+    sendError: jest.fn(),
+  },
+}));
+
+jest.mock('../../src', () => ({
+  configuration: {},
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('Faker Semantic Data API Handler', () => {
+  const buildReply = (): Partial<FastifyReply> => ({
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 with faker semantic data list', async () => {
+    const rows = [
+      { id: 1, name: 'name' },
+      { id: 2, name: 'address' },
+    ];
+    (fakerSemanticService.getFakerSemanticData as jest.Mock).mockResolvedValue(rows as never);
+
+    const req = {} as FastifyRequest;
+    const reply = buildReply();
+
+    await getFakerSemanticDataHandler(req, reply as FastifyReply);
+
+    expect(fakerSemanticService.getFakerSemanticData).toHaveBeenCalledTimes(1);
+    expect(reply.status).toHaveBeenCalledWith(200);
+    expect(reply.send).toHaveBeenCalledWith({ success: true, data: rows });
+  });
+
+  it('should return 200 with empty list', async () => {
+    (fakerSemanticService.getFakerSemanticData as jest.Mock).mockResolvedValue([] as never);
+
+    const req = {} as FastifyRequest;
+    const reply = buildReply();
+
+    await getFakerSemanticDataHandler(req, reply as FastifyReply);
+
+    expect(reply.status).toHaveBeenCalledWith(200);
+    expect(reply.send).toHaveBeenCalledWith({ success: true, data: [] });
+  });
+
+  it('should delegate errors to ErrorHandler', async () => {
+    const error = new Error('db failed');
+    (fakerSemanticService.getFakerSemanticData as jest.Mock).mockRejectedValue(error as never);
+
+    const req = {} as FastifyRequest;
+    const reply = buildReply();
+
+    await getFakerSemanticDataHandler(req, reply as FastifyReply);
+
+    expect(ErrorHandler.sendError).toHaveBeenCalledWith(reply, error, 'Failed to get faker semantic data');
+  });
+});

--- a/__tests__/unit/app.simulation-suites.test.ts
+++ b/__tests__/unit/app.simulation-suites.test.ts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/services/simulation-suites.logic.service', () => ({
+  createSimulationSuite: jest.fn(),
+  getSimulationSuites: jest.fn(),
+  getSimulationSuiteById: jest.fn(),
+  updateSimulationSuite: jest.fn(),
+}));
+
+jest.mock('../../src/services/trs-suite-generation.logic.service', () => ({
+  resumeGeneration: jest.fn(),
+}));
+
+jest.mock('../../src/handlers/errorHandler', () => ({
+  ErrorHandler: {
+    sendError: jest.fn(),
+  },
+}));
+
+jest.mock('../../src', () => ({
+  configuration: {},
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import {
+  createSimulationHandler,
+  getSimulationsHandler,
+  getSimulationByIdHandler,
+  updateSimulationHandler,
+  resumeGenerationHandler,
+} from '../../src/app.controller';
+import * as simulationSuitesService from '../../src/services/simulation-suites.logic.service';
+import * as trsSuiteGenerationService from '../../src/services/trs-suite-generation.logic.service';
+import { ErrorHandler } from '../../src/handlers/errorHandler';
+
+describe('Simulation Suites API Handlers', () => {
+  const mockTenantId = 'tenant-123';
+
+  const mockSuite = {
+    id: 101,
+    tenant_id: mockTenantId,
+    name: 'Q3 Edge Cases',
+    status: 'DRAFT',
+    wizard_progress: { currentStep: 1, completedSteps: [1] },
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    updated_at: new Date('2026-05-01T00:00:00.000Z'),
+  };
+
+  const buildReply = (): Partial<FastifyReply> => ({
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createSimulationHandler', () => {
+    it('should create simulation suite and return 201', async () => {
+      (simulationSuitesService.createSimulationSuite as jest.Mock).mockResolvedValue(mockSuite);
+
+      const req = {
+        tenantId: mockTenantId,
+        user: {
+          clientId: 'client-001',
+          preferred_username: 'creator@example.com',
+        },
+        body: {
+          name: 'Q3 Edge Cases',
+          description: 'Initial step data',
+          rule_name: 'Rule 002',
+        },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await createSimulationHandler(req, reply as FastifyReply);
+
+      expect(simulationSuitesService.createSimulationSuite).toHaveBeenCalledWith(
+        req.body,
+        mockTenantId,
+        'client-001',
+        'creator@example.com',
+      );
+      expect(reply.status).toHaveBeenCalledWith(201);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          message: 'Simulation suite created successfully',
+          data: mockSuite,
+        }),
+      );
+    });
+
+    it('should delegate errors to ErrorHandler', async () => {
+      const error = new Error('Create failed');
+      (simulationSuitesService.createSimulationSuite as jest.Mock).mockRejectedValue(error);
+
+      const req = {
+        tenantId: mockTenantId,
+        user: {
+          sub: 'user-123',
+        },
+        body: {
+          name: 'Q3 Edge Cases',
+        },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await createSimulationHandler(req, reply as FastifyReply);
+
+      expect(ErrorHandler.sendError).toHaveBeenCalledWith(reply, error, 'Failed to create simulation suite');
+    });
+  });
+
+  describe('getSimulationsHandler', () => {
+    it('should return list with pagination and mapped query options', async () => {
+      const result = { data: [mockSuite], total: 1, limit: 10, offset: 0 };
+      (simulationSuitesService.getSimulationSuites as jest.Mock).mockResolvedValue(result);
+
+      const req = {
+        tenantId: mockTenantId,
+        query: {
+          search: 'edge',
+          status: 'DRAFT',
+          rule_name: 'Rule 002',
+          txtp: 'pacs.008',
+          updated_from: '2026-05-01',
+          updated_to: '2026-05-31',
+          limit: 10,
+          offset: 0,
+        },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await getSimulationsHandler(req, reply as FastifyReply);
+
+      expect(simulationSuitesService.getSimulationSuites).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: mockTenantId,
+          search: 'edge',
+          status: 'DRAFT',
+          ruleName: 'Rule 002',
+          txtp: 'pacs.008',
+          limit: 10,
+          offset: 0,
+        }),
+      );
+
+      const calledWith = (simulationSuitesService.getSimulationSuites as jest.Mock).mock.calls[0][0];
+      expect(calledWith.updatedFrom).toBeInstanceOf(Date);
+      expect(calledWith.updatedTo).toBeInstanceOf(Date);
+
+      expect(reply.status).toHaveBeenCalledWith(200);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          suites: result.data,
+          total: 1,
+        }),
+      );
+    });
+  });
+
+  describe('getSimulationByIdHandler', () => {
+    it('should return 400 for invalid id', async () => {
+      const req = {
+        tenantId: mockTenantId,
+        params: { id: 'abc' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await getSimulationByIdHandler(req, reply as FastifyReply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ success: false, message: 'Invalid simulation suite ID' });
+      expect(simulationSuitesService.getSimulationSuiteById).not.toHaveBeenCalled();
+    });
+
+    it('should return simulation suite for valid id', async () => {
+      (simulationSuitesService.getSimulationSuiteById as jest.Mock).mockResolvedValue(mockSuite);
+
+      const req = {
+        tenantId: mockTenantId,
+        params: { id: '101' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await getSimulationByIdHandler(req, reply as FastifyReply);
+
+      expect(simulationSuitesService.getSimulationSuiteById).toHaveBeenCalledWith(101, mockTenantId);
+      expect(reply.status).toHaveBeenCalledWith(200);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          suite: mockSuite,
+        }),
+      );
+    });
+  });
+
+  describe('updateSimulationHandler', () => {
+    it('should return 400 for invalid id', async () => {
+      const req = {
+        tenantId: mockTenantId,
+        params: { id: '' },
+        body: { description: 'Updated' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await updateSimulationHandler(req, reply as FastifyReply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ success: false, message: 'Invalid simulation suite ID' });
+      expect(simulationSuitesService.updateSimulationSuite).not.toHaveBeenCalled();
+    });
+
+    it('should update suite and return 200', async () => {
+      const updatedSuite = {
+        ...mockSuite,
+        description: 'Step 2 saved',
+      };
+      (simulationSuitesService.updateSimulationSuite as jest.Mock).mockResolvedValue(updatedSuite);
+
+      const req = {
+        tenantId: mockTenantId,
+        params: { id: '101' },
+        body: {
+          wizard_progress: { currentStep: 2, completedSteps: [1] },
+          description: 'Step 2 saved',
+        },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await updateSimulationHandler(req, reply as FastifyReply);
+
+      expect(simulationSuitesService.updateSimulationSuite).toHaveBeenCalledWith(101, mockTenantId, req.body);
+      expect(reply.status).toHaveBeenCalledWith(200);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          message: 'Simulation suite updated successfully',
+          suite: updatedSuite,
+        }),
+      );
+    });
+
+    it('should delegate update errors to ErrorHandler', async () => {
+      const error = new Error('Update failed');
+      (simulationSuitesService.updateSimulationSuite as jest.Mock).mockRejectedValue(error);
+
+      const req = {
+        tenantId: mockTenantId,
+        params: { id: '101' },
+        body: { status: 'COMPLETED' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await updateSimulationHandler(req, reply as FastifyReply);
+
+      expect(ErrorHandler.sendError).toHaveBeenCalledWith(reply, error, 'Failed to update simulation suite');
+    });
+  });
+
+  describe('resumeGenerationHandler', () => {
+    it('should return 400 for invalid suiteId', async () => {
+      const req = {
+        params: { suiteId: 'abc' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await resumeGenerationHandler(req, reply as FastifyReply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ success: false, message: 'Invalid suite ID' });
+      expect(trsSuiteGenerationService.resumeGeneration).not.toHaveBeenCalled();
+    });
+
+    it('should resume generation and return 200', async () => {
+      const resumeResult = {
+        generation_id: 10,
+        generation_number: 2,
+        status: 'IN_PROGRESS',
+      };
+      (trsSuiteGenerationService.resumeGeneration as jest.Mock).mockResolvedValue(resumeResult);
+
+      const req = {
+        params: { suiteId: '101' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await resumeGenerationHandler(req, reply as FastifyReply);
+
+      expect(trsSuiteGenerationService.resumeGeneration).toHaveBeenCalledWith(101);
+      expect(reply.status).toHaveBeenCalledWith(200);
+      expect(reply.send).toHaveBeenCalledWith({ success: true, message: 'Generation resumed', data: resumeResult });
+    });
+
+    it('should delegate errors to ErrorHandler', async () => {
+      const error = new Error('Resume failed');
+      (trsSuiteGenerationService.resumeGeneration as jest.Mock).mockRejectedValue(error);
+
+      const req = {
+        params: { suiteId: '101' },
+      } as unknown as FastifyRequest;
+      const reply = buildReply();
+
+      await resumeGenerationHandler(req, reply as FastifyReply);
+
+      expect(ErrorHandler.sendError).toHaveBeenCalledWith(reply, error, 'Failed to resume generation');
+    });
+  });
+});

--- a/__tests__/unit/context-txtp-config.logic.service.test.ts
+++ b/__tests__/unit/context-txtp-config.logic.service.test.ts
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/context-txtp-configs.repository', () => ({
+  createContextTxtpConfigInDb: jest.fn(),
+  updateContextTxtpConfigInDb: jest.fn(),
+  getContextTxtpConfigsByGenerationId: jest.fn(),
+  deleteContextTxtpConfigInDb: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/context-field-strategies.repository', () => ({
+  upsertFieldStrategyInDb: jest.fn(),
+  getFieldStrategiesByContextConfigId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
+  getSchemaByTransactionType: jest.fn(),
+}));
+
+jest.mock('@tazama-lf/tcs-lib', () => ({
+  ContentType: { XML: 'application/xml', JSON: 'application/json' },
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import { HttpException } from '../../src/utils/error';
+import * as contextConfigRepo from '../../src/repositories/simulation-studio/context-txtp-configs.repository';
+import * as fieldStrategyRepo from '../../src/repositories/simulation-studio/context-field-strategies.repository';
+import * as tcsRepo from '../../src/repositories/configuration/tcs.config.repository';
+import {
+  createConfigWithDefaultStrategies,
+  createContextTxtpConfig,
+  addContextTxtpConfig,
+  getContextConfigsWithStrategies,
+  bulkUpdateContextConfigs,
+  getFieldStrategiesForContextConfig,
+  deleteContextTxtpConfig,
+} from '../../src/services/context-txtp-config.logic.service';
+import type { SuiteContextTxtpConfig, ContextFieldStrategy } from '../../src/interface/suite-generation.interface';
+
+const mockContextConfig: SuiteContextTxtpConfig = {
+  id: 10,
+  generation_id: 1,
+  txtp: 'pacs.008',
+  txtp_version: '001.08',
+  display_order: 1,
+  message_count: 100,
+  schema_snapshot: { type: 'object', properties: { amount: {}, currency: {} } },
+  generator_profile: {},
+  created_at: new Date(),
+};
+
+const mockFieldStrategy: ContextFieldStrategy = {
+  id: 1,
+  context_txtp_config_id: 10,
+  field_path: 'amount',
+  strategy_code: 'keep_sample',
+  generator_options: {},
+  created_at: new Date(),
+};
+
+const tcsRowJson = {
+  schema: { type: 'object', properties: { amount: {}, currency: {} } },
+  content_type: 'application/json',
+  payload_json: { amount: 100, currency: 'USD' },
+  payload_xml: null,
+};
+
+const tcsRowXml = {
+  schema: { type: 'object', properties: { amount: {} } },
+  content_type: 'application/xml',
+  payload_xml: { amount: '<xml>' },
+  payload_json: null,
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── createConfigWithDefaultStrategies ────────────────────────────────────────
+
+describe('createConfigWithDefaultStrategies', () => {
+  it('fetches schema, inserts config, seeds keep_sample for each payload field path', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(tcsRepo.getSchemaByTransactionType).toHaveBeenCalledWith('pacs.008', '001.08', 'tenant-001');
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation_id: 1,
+        txtp: 'pacs.008',
+        txtp_version: '001.08',
+        display_order: 1,
+        message_count: 100,
+        schema_snapshot: tcsRowJson.schema,
+        sample_payload_snapshot: tcsRowJson.payload_json,
+      }),
+    );
+    // payload has 2 leaf fields: amount, currency
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(2);
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledWith(10, expect.objectContaining({ strategy_code: 'keep_sample' }));
+    expect(result.context_txtp_config_id).toBe(10);
+    expect(result.field_strategies).toHaveLength(2);
+  });
+
+  it('uses payload_xml when content_type is XML', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowXml);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ sample_payload_snapshot: tcsRowXml.payload_xml }),
+    );
+  });
+
+  it('falls back to schema paths when payload is null', async () => {
+    const tcsNoPayload = { ...tcsRowJson, payload_json: null };
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsNoPayload);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    // schema has amount and currency — still seeds 2 strategies
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when tcs_config row not found', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('Not found'));
+    await expect(
+      createConfigWithDefaultStrategies({
+        generationId: 1,
+        txtp: 'x',
+        txtpVersion: '1',
+        messageCount: 100,
+        displayOrder: 1,
+        tenantId: 'tenant',
+      }),
+    ).rejects.toThrow('Not found');
+  });
+
+  it('seeds no strategies when schema has no leaf paths', async () => {
+    const emptySchema = { ...tcsRowJson, schema: {}, payload_json: {} };
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(emptySchema);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue({ ...mockContextConfig, schema_snapshot: {} });
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await createConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 100,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).not.toHaveBeenCalled();
+    expect(result.field_strategies).toHaveLength(0);
+  });
+});
+
+// ── createContextTxtpConfig ──────────────────────────────────────────────────
+
+describe('createContextTxtpConfig', () => {
+  it('calls createConfigWithDefaultStrategies with display_order=1 and message_count=100', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001');
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 1, message_count: 100 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('maps missing tcs_config to HttpException 404', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('Configuration not found'));
+    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('bad', 404);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(err);
+    await expect(createContextTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toBe(err);
+  });
+});
+
+// ── addContextTxtpConfig ─────────────────────────────────────────────────────
+
+describe('addContextTxtpConfig', () => {
+  it('sets display_order = existing count + 1', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue({ ...mockContextConfig, id: 20, display_order: 2 });
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await addContextTxtpConfig(1, { txtp: 'pacs.002', txtp_version: '001.08', message_count: 50 }, 'tenant-001');
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 2, message_count: 50 }),
+    );
+    expect(result.context_txtp_config_id).toBe(20);
+  });
+
+  it('defaults message_count to 100 when not provided', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([]);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (contextConfigRepo.createContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await addContextTxtpConfig(1, { txtp: 'pacs.008', txtp_version: '001.08' }, 'tenant-001');
+
+    expect(contextConfigRepo.createContextTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ message_count: 100, display_order: 1 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(addContextTxtpConfig(1, { txtp: 'x', txtp_version: '1' }, 'tenant')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('conflict', 409);
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(err);
+    await expect(addContextTxtpConfig(1, { txtp: 'x', txtp_version: '1' }, 'tenant')).rejects.toBe(err);
+  });
+});
+
+// ── getContextConfigsWithStrategies ──────────────────────────────────────────
+
+describe('getContextConfigsWithStrategies', () => {
+  it('returns all configs with their field strategies', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+
+    const result = await getContextConfigsWithStrategies(1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].context_txtp_config_id).toBe(10);
+    expect(result[0].txtp).toBe('pacs.008');
+    expect(result[0].field_strategies).toEqual([mockFieldStrategy]);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(10);
+  });
+
+  it('returns empty array when no configs exist', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([]);
+    const result = await getContextConfigsWithStrategies(1);
+    expect(result).toEqual([]);
+  });
+
+  it('handles multiple configs, fetches strategies for each', async () => {
+    const config2 = { ...mockContextConfig, id: 11, txtp: 'pacs.002' };
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig, config2]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+
+    const result = await getContextConfigsWithStrategies(1);
+
+    expect(result).toHaveLength(2);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledTimes(2);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(10);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(11);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(getContextConfigsWithStrategies(1)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue('string error');
+    await expect(getContextConfigsWithStrategies(1)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── bulkUpdateContextConfigs ─────────────────────────────────────────────────
+
+describe('bulkUpdateContextConfigs', () => {
+  beforeEach(() => {
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+  });
+
+  it('updates message_count and upserts strategies, returns updated configs', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await bulkUpdateContextConfigs(1, [
+      { context_txtp_config_id: 10, message_count: 50, field_strategies: [{ field_path: 'amount', strategy_code: 'keep_sample' }] },
+    ]);
+
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledWith(10, { message_count: 50 });
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledWith(10, { field_path: 'amount', strategy_code: 'keep_sample' });
+    expect(result).toHaveLength(1);
+    expect(result[0].context_txtp_config_id).toBe(10);
+  });
+
+  it('skips updateContextTxtpConfigInDb when no updateable scalar fields', async () => {
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    await bulkUpdateContextConfigs(1, [
+      { context_txtp_config_id: 10, field_strategies: [{ field_path: 'amount', strategy_code: 'skip' }] },
+    ]);
+
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).not.toHaveBeenCalled();
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips upsertFieldStrategyInDb when field_strategies is empty array', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+
+    await bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5, field_strategies: [] }]);
+
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).not.toHaveBeenCalled();
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledWith(10, { message_count: 5 });
+  });
+
+  it('skips upsertFieldStrategyInDb when field_strategies absent', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+
+    await bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }]);
+
+    expect(fieldStrategyRepo.upsertFieldStrategyInDb).not.toHaveBeenCalled();
+  });
+
+  it('processes multiple items in parallel', async () => {
+    const config2 = { ...mockContextConfig, id: 11 };
+    (contextConfigRepo.getContextTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockContextConfig, config2]);
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockResolvedValue(mockContextConfig);
+    (fieldStrategyRepo.upsertFieldStrategyInDb as jest.Mock).mockResolvedValue(mockFieldStrategy);
+
+    const result = await bulkUpdateContextConfigs(1, [
+      { context_txtp_config_id: 10, message_count: 50 },
+      {
+        context_txtp_config_id: 11,
+        message_count: 200,
+        field_strategies: [{ field_path: 'amount', strategy_code: 'static', static_value: 'x' }],
+      },
+    ]);
+
+    expect(contextConfigRepo.updateContextTxtpConfigInDb).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }])).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue(err);
+    await expect(bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }])).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (contextConfigRepo.updateContextTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(bulkUpdateContextConfigs(1, [{ context_txtp_config_id: 10, message_count: 5 }])).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── getFieldStrategiesForContextConfig ───────────────────────────────────────
+
+describe('getFieldStrategiesForContextConfig', () => {
+  it('returns field strategies for a config', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([mockFieldStrategy]);
+
+    const result = await getFieldStrategiesForContextConfig(10);
+
+    expect(result).toEqual([mockFieldStrategy]);
+    expect(fieldStrategyRepo.getFieldStrategiesByContextConfigId).toHaveBeenCalledWith(10);
+  });
+
+  it('returns empty array when no strategies', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockResolvedValue([]);
+    expect(await getFieldStrategiesForContextConfig(10)).toEqual([]);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getFieldStrategiesForContextConfig(10)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (fieldStrategyRepo.getFieldStrategiesByContextConfigId as jest.Mock).mockRejectedValue('string error');
+    await expect(getFieldStrategiesForContextConfig(10)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── deleteContextTxtpConfig ───────────────────────────────────────────────────
+
+describe('deleteContextTxtpConfig', () => {
+  it('deletes context config successfully (field strategies cascade via FK)', async () => {
+    (contextConfigRepo.deleteContextTxtpConfigInDb as jest.Mock).mockResolvedValue(true);
+    await expect(deleteContextTxtpConfig(10)).resolves.toBeUndefined();
+    expect(contextConfigRepo.deleteContextTxtpConfigInDb).toHaveBeenCalledWith(10);
+  });
+
+  it('throws 404 when config not found', async () => {
+    (contextConfigRepo.deleteContextTxtpConfigInDb as jest.Mock).mockResolvedValue(false);
+    await expect(deleteContextTxtpConfig(999)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('wraps DB error in HttpException 500', async () => {
+    (contextConfigRepo.deleteContextTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(deleteContextTxtpConfig(10)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('forbidden', 403);
+    (contextConfigRepo.deleteContextTxtpConfigInDb as jest.Mock).mockRejectedValue(err);
+    await expect(deleteContextTxtpConfig(10)).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (contextConfigRepo.deleteContextTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(deleteContextTxtpConfig(10)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/__tests__/unit/enrichment-table.logic.service.test.ts
+++ b/__tests__/unit/enrichment-table.logic.service.test.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/enrichment-tables.repository', () => ({
+  createEnrichmentTableInDb: jest.fn(),
+  getNextEnrichmentTableOrderInDb: jest.fn(),
+  updateEnrichmentTableInDb: jest.fn(),
+  getEnrichmentTablesByGenerationId: jest.fn(),
+  deleteEnrichmentTableInDb: jest.fn(),
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import { HttpException } from '../../src/utils/error';
+import * as enrichmentTableRepo from '../../src/repositories/simulation-studio/enrichment-tables.repository';
+import {
+  createEnrichmentTable,
+  getEnrichmentTables,
+  bulkUpdateEnrichmentTables,
+  deleteEnrichmentTable,
+} from '../../src/services/enrichment-table.logic.service';
+import type { SuiteEnrichmentTable } from '../../src/interface/suite-generation.interface';
+
+const mockTable: SuiteEnrichmentTable = {
+  id: 30,
+  generation_id: 1,
+  table_name: 'account_enrichment',
+  table_order: 1,
+  row_count: 13,
+  payload_template_json: { name: 'feeba', country: 'Pak' },
+  faker_profile: {},
+  created_at: new Date(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── createEnrichmentTable ────────────────────────────────────────────────────
+
+describe('createEnrichmentTable', () => {
+  it('inserts table and returns SuiteEnrichmentTable', async () => {
+    (enrichmentTableRepo.getNextEnrichmentTableOrderInDb as jest.Mock).mockResolvedValue(1);
+    (enrichmentTableRepo.createEnrichmentTableInDb as jest.Mock).mockResolvedValue(mockTable);
+
+    const result = await createEnrichmentTable(1, 'account_enrichment', 13, { name: 'feeba', country: 'Pak' });
+
+    expect(enrichmentTableRepo.createEnrichmentTableInDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation_id: 1,
+        table_name: 'account_enrichment',
+        table_order: 1,
+        row_count: 13,
+        payload_template_json: { name: 'feeba', country: 'Pak' },
+      }),
+    );
+    expect(result.id).toBe(30);
+    expect(result.table_name).toBe('account_enrichment');
+    expect(result.row_count).toBe(13);
+  });
+
+  it('passes schema_template_json to createEnrichmentTableInDb', async () => {
+    (enrichmentTableRepo.getNextEnrichmentTableOrderInDb as jest.Mock).mockResolvedValue(1);
+    (enrichmentTableRepo.createEnrichmentTableInDb as jest.Mock).mockResolvedValue(mockTable);
+
+    await createEnrichmentTable(1, 'cnic', 5, { id: '123' }, { col: 'VARCHAR' });
+
+    expect(enrichmentTableRepo.createEnrichmentTableInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ schema_template_json: { col: 'VARCHAR' } }),
+    );
+  });
+
+  it('omits optional fields when not provided', async () => {
+    (enrichmentTableRepo.getNextEnrichmentTableOrderInDb as jest.Mock).mockResolvedValue(1);
+    (enrichmentTableRepo.createEnrichmentTableInDb as jest.Mock).mockResolvedValue(mockTable);
+
+    await createEnrichmentTable(1, 'bare', 1);
+
+    expect(enrichmentTableRepo.createEnrichmentTableInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ generation_id: 1, table_name: 'bare', row_count: 1 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (enrichmentTableRepo.getNextEnrichmentTableOrderInDb as jest.Mock).mockResolvedValue(1);
+    (enrichmentTableRepo.createEnrichmentTableInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(createEnrichmentTable(1, 'cnic', 1)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    (enrichmentTableRepo.getNextEnrichmentTableOrderInDb as jest.Mock).mockResolvedValue(1);
+    const err = new HttpException('conflict', 409);
+    (enrichmentTableRepo.createEnrichmentTableInDb as jest.Mock).mockRejectedValue(err);
+    await expect(createEnrichmentTable(1, 'cnic', 1)).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (enrichmentTableRepo.getNextEnrichmentTableOrderInDb as jest.Mock).mockResolvedValue(1);
+    (enrichmentTableRepo.createEnrichmentTableInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(createEnrichmentTable(1, 'cnic', 1)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── getEnrichmentTables ──────────────────────────────────────────────────────
+
+describe('getEnrichmentTables', () => {
+  it('returns all tables for a generation', async () => {
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockResolvedValue([mockTable]);
+
+    const result = await getEnrichmentTables(1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(30);
+    expect(result[0].table_name).toBe('account_enrichment');
+    expect(result[0].row_count).toBe(13);
+    expect(enrichmentTableRepo.getEnrichmentTablesByGenerationId).toHaveBeenCalledWith(1);
+  });
+
+  it('returns empty array when no tables', async () => {
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockResolvedValue([]);
+    expect(await getEnrichmentTables(1)).toEqual([]);
+  });
+
+  it('returns multiple tables', async () => {
+    const table2 = { ...mockTable, id: 31, table_name: 'cnic' };
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockResolvedValue([mockTable, table2]);
+
+    const result = await getEnrichmentTables(1);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe(31);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getEnrichmentTables(1)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockRejectedValue('string error');
+    await expect(getEnrichmentTables(1)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── bulkUpdateEnrichmentTables ───────────────────────────────────────────────
+
+describe('bulkUpdateEnrichmentTables', () => {
+  beforeEach(() => {
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockResolvedValue([mockTable]);
+  });
+
+  it('calls updateEnrichmentTableInDb with id and update fields, returns updated list', async () => {
+    (enrichmentTableRepo.updateEnrichmentTableInDb as jest.Mock).mockResolvedValue(mockTable);
+
+    const result = await bulkUpdateEnrichmentTables(1, [{ id: 30, row_count: 5 }]);
+
+    expect(enrichmentTableRepo.updateEnrichmentTableInDb).toHaveBeenCalledWith(30, 1, { row_count: 5 });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(30);
+  });
+
+  it('skips updateEnrichmentTableInDb when no scalar update fields provided', async () => {
+    await bulkUpdateEnrichmentTables(1, [{ id: 30 }]);
+
+    expect(enrichmentTableRepo.updateEnrichmentTableInDb).not.toHaveBeenCalled();
+  });
+
+  it('processes multiple items in parallel', async () => {
+    (enrichmentTableRepo.updateEnrichmentTableInDb as jest.Mock).mockResolvedValue(mockTable);
+    (enrichmentTableRepo.getEnrichmentTablesByGenerationId as jest.Mock).mockResolvedValue([mockTable, { ...mockTable, id: 31 }]);
+
+    await bulkUpdateEnrichmentTables(1, [
+      { id: 30, row_count: 5 },
+      { id: 31, row_count: 10 },
+    ]);
+
+    expect(enrichmentTableRepo.updateEnrichmentTableInDb).toHaveBeenCalledTimes(2);
+    expect(enrichmentTableRepo.updateEnrichmentTableInDb).toHaveBeenCalledWith(30, 1, { row_count: 5 });
+    expect(enrichmentTableRepo.updateEnrichmentTableInDb).toHaveBeenCalledWith(31, 1, { row_count: 10 });
+  });
+
+  it('throws 404 when an update target is outside the generation', async () => {
+    (enrichmentTableRepo.updateEnrichmentTableInDb as jest.Mock).mockResolvedValue(null);
+    await expect(bulkUpdateEnrichmentTables(1, [{ id: 30, row_count: 5 }])).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (enrichmentTableRepo.updateEnrichmentTableInDb as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(bulkUpdateEnrichmentTables(1, [{ id: 30, row_count: 5 }])).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (enrichmentTableRepo.updateEnrichmentTableInDb as jest.Mock).mockRejectedValue(err);
+    await expect(bulkUpdateEnrichmentTables(1, [{ id: 30, row_count: 5 }])).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (enrichmentTableRepo.updateEnrichmentTableInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(bulkUpdateEnrichmentTables(1, [{ id: 30, row_count: 5 }])).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── deleteEnrichmentTable ────────────────────────────────────────────────────
+
+describe('deleteEnrichmentTable', () => {
+  it('deletes table successfully (field strategies cascade via FK)', async () => {
+    (enrichmentTableRepo.deleteEnrichmentTableInDb as jest.Mock).mockResolvedValue(true);
+    await expect(deleteEnrichmentTable(30)).resolves.toBeUndefined();
+    expect(enrichmentTableRepo.deleteEnrichmentTableInDb).toHaveBeenCalledWith(30);
+  });
+
+  it('throws 404 when table not found', async () => {
+    (enrichmentTableRepo.deleteEnrichmentTableInDb as jest.Mock).mockResolvedValue(false);
+    await expect(deleteEnrichmentTable(999)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('wraps DB error in HttpException 500', async () => {
+    (enrichmentTableRepo.deleteEnrichmentTableInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(deleteEnrichmentTable(30)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('forbidden', 403);
+    (enrichmentTableRepo.deleteEnrichmentTableInDb as jest.Mock).mockRejectedValue(err);
+    await expect(deleteEnrichmentTable(30)).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (enrichmentTableRepo.deleteEnrichmentTableInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(deleteEnrichmentTable(30)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/__tests__/unit/faker-semantic-data.logic.service.test.ts
+++ b/__tests__/unit/faker-semantic-data.logic.service.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/faker-semantic-data.repository', () => ({
+  getFakerSemanticDataFromDb: jest.fn(),
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import * as fakerRepo from '../../src/repositories/simulation-studio/faker-semantic-data.repository';
+import { getFakerSemanticData } from '../../src/services/faker-semantic-data.logic.service';
+
+describe('faker-semantic-data.logic.service', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns rows from repository', async () => {
+    (fakerRepo.getFakerSemanticDataFromDb as jest.Mock).mockResolvedValue([{ id: 1, name: 'full_name' }]);
+
+    await expect(getFakerSemanticData()).resolves.toEqual([{ id: 1, name: 'full_name' }]);
+    expect(fakerRepo.getFakerSemanticDataFromDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array when no data', async () => {
+    (fakerRepo.getFakerSemanticDataFromDb as jest.Mock).mockResolvedValue([]);
+    await expect(getFakerSemanticData()).resolves.toEqual([]);
+  });
+
+  it('wraps repository errors in HttpException 500', async () => {
+    (fakerRepo.getFakerSemanticDataFromDb as jest.Mock).mockRejectedValue(new Error('db failed'));
+    await expect(getFakerSemanticData()).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (fakerRepo.getFakerSemanticDataFromDb as jest.Mock).mockRejectedValue('string error');
+    await expect(getFakerSemanticData()).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/__tests__/unit/faker-semantic-data.repository.test.ts
+++ b/__tests__/unit/faker-semantic-data.repository.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: jest.fn(),
+}));
+
+import * as db from '../../src/services/database.logic.service';
+import { getFakerSemanticDataFromDb } from '../../src/repositories/simulation-studio/faker-semantic-data.repository';
+
+const mockDb = db.handlePostExecuteSqlStatement as jest.Mock;
+
+describe('faker-semantic-data.repository', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns mapped faker semantic data rows', async () => {
+    mockDb.mockResolvedValue({ rows: [{ id: 1, name: 'full_name' }] });
+
+    const result = await getFakerSemanticDataFromDb();
+
+    expect(result).toEqual([{ id: 1, name: 'full_name' }]);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('trs_faker_semantic_data_types') }),
+      'simulation',
+    );
+  });
+
+  it('returns empty array when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await expect(getFakerSemanticDataFromDb()).resolves.toEqual([]);
+  });
+});

--- a/__tests__/unit/node.logic.service.test.ts
+++ b/__tests__/unit/node.logic.service.test.ts
@@ -26,9 +26,14 @@ jest.mock('../../src/utils/validateQuery', () => ({
   validateSelectQuery: jest.fn(),
 }));
 
+jest.mock('../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: jest.fn(),
+}));
+
 import * as nodeLogicService from '../../src/services/node.logic.service';
 import * as nodeRepository from '../../src/repositories/configuration/node.repository';
 import * as validateQuery from '../../src/utils/validateQuery';
+import { handlePostExecuteSqlStatement } from '../../src/services/database.logic.service';
 
 describe('Node Logic Service', () => {
   const mockTenantId = 'tenant-123';
@@ -467,8 +472,8 @@ describe('Node Logic Service', () => {
 
       const mockDb = nodeRepository.executeQueryNodeInDb as jest.MockedFunction<() => Promise<Array<Record<string, unknown>>>>;
       mockDb.mockResolvedValueOnce([{ column_name: 'tenant_id' }]); // resolveTenantColumn for 'users'
-      mockDb.mockResolvedValueOnce([]);                              // resolveTenantColumn for 'active_users' (CTE alias)
-      mockDb.mockResolvedValueOnce(mockResult);                      // actual query
+      mockDb.mockResolvedValueOnce([]); // resolveTenantColumn for 'active_users' (CTE alias)
+      mockDb.mockResolvedValueOnce(mockResult); // actual query
 
       const result = await nodeLogicService.executeSelectQuery({ query: mockQuery, dbName: 'configuration' }, mockTenantId);
 
@@ -477,11 +482,9 @@ describe('Node Logic Service', () => {
         'configuration',
         ['users'],
       );
-      expect(nodeRepository.executeQueryNodeInDb).toHaveBeenLastCalledWith(
-        expect.stringContaining('SELECT * FROM ('),
-        'configuration',
-        [mockTenantId],
-      );
+      expect(nodeRepository.executeQueryNodeInDb).toHaveBeenLastCalledWith(expect.stringContaining('SELECT * FROM ('), 'configuration', [
+        mockTenantId,
+      ]);
       expect(result).toEqual(mockResult);
     });
 
@@ -577,6 +580,114 @@ describe('Node Logic Service', () => {
         [],
       );
       expect(result).toEqual(mockResult);
+    });
+
+    it('throws 403 when table name is a reserved keyword', async () => {
+      // 'user' is in RESERVED_KEYWORDS — validateTableName throws, executeSelectQuery wraps as 403
+      const mockQuery = 'SELECT * FROM "user"';
+
+      await expect(nodeLogicService.executeSelectQuery({ query: mockQuery, dbName: 'configuration' }, mockTenantId)).rejects.toMatchObject({
+        status: HttpStatus.FORBIDDEN,
+      });
+    });
+
+    it('injects tenant filter before HAVING clause', async () => {
+      // Real SQL with HAVING — real parser produces AST with _location offsets for having
+      const mockQuery = 'SELECT name FROM orders GROUP BY name HAVING COUNT(*) > 1';
+      const mockResult = [{ name: 'alice' }];
+
+      (nodeRepository.executeQueryNodeInDb as jest.Mock)
+        .mockResolvedValueOnce([{ column_name: 'tenant_id' }])
+        .mockResolvedValueOnce(mockResult);
+
+      const result = await nodeLogicService.executeSelectQuery({ query: mockQuery, dbName: 'configuration' }, mockTenantId);
+      expect(result).toEqual(mockResult);
+    });
+
+    it('injects tenant filter before LIMIT clause', async () => {
+      // Real SQL with LIMIT — real parser produces AST with _location offsets for limit
+      const mockQuery = 'SELECT id FROM products LIMIT 5';
+      const mockResult = [{ id: 1 }];
+
+      (nodeRepository.executeQueryNodeInDb as jest.Mock)
+        .mockResolvedValueOnce([{ column_name: 'tenant_id' }])
+        .mockResolvedValueOnce(mockResult);
+
+      const result = await nodeLogicService.executeSelectQuery({ query: mockQuery, dbName: 'configuration' }, mockTenantId);
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('extractTablesFromAST', () => {
+    it('handles node.name.name pattern (nested name object)', () => {
+      const ast = [
+        {
+          type: 'select',
+          from: [{ type: 'table', name: { name: 'orders' } }],
+        },
+      ];
+      const result = nodeLogicService.extractTablesFromAST(ast);
+      expect(result).toContain('orders');
+    });
+
+    it('handles string node.name pattern', () => {
+      const ast = [
+        {
+          type: 'select',
+          from: [{ type: 'table', name: 'products' }],
+        },
+      ];
+      const result = nodeLogicService.extractTablesFromAST(ast);
+      expect(result).toContain('products');
+    });
+  });
+
+  describe('resolveSortColumn', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns null when sortBy is empty', async () => {
+      const result = await nodeLogicService.resolveSortColumn(['users'], '', 'configuration');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when sortBy has invalid characters', async () => {
+      const result = await nodeLogicService.resolveSortColumn(['users'], 'col; DROP TABLE', 'configuration');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when sortBy not in ORDER BY of AST', async () => {
+      const ast = [{ type: 'select', orderBy: [{ name: 'created_at' }] }];
+      const result = await nodeLogicService.resolveSortColumn(['users'], 'name', 'configuration', ast);
+      expect(result).toBeNull();
+    });
+
+    it('returns sortBy when column exists in table', async () => {
+      (handlePostExecuteSqlStatement as jest.Mock).mockResolvedValue({ rows: [{ column_name: 'name' }] });
+      const result = await nodeLogicService.resolveSortColumn(['users'], 'name', 'configuration');
+      expect(result).toBe('name');
+    });
+
+    it('returns null when column not found in any table', async () => {
+      (handlePostExecuteSqlStatement as jest.Mock).mockResolvedValue({ rows: [] });
+      const result = await nodeLogicService.resolveSortColumn(['users'], 'nonexistent', 'configuration');
+      expect(result).toBeNull();
+    });
+
+    it('skips table and continues when DB throws during column lookup', async () => {
+      (handlePostExecuteSqlStatement as jest.Mock)
+        .mockRejectedValueOnce(new Error('DB error'))
+        .mockResolvedValueOnce({ rows: [{ column_name: 'name' }] });
+      const result = await nodeLogicService.resolveSortColumn(['bad_table', 'users'], 'name', 'configuration');
+      expect(result).toBe('name');
+    });
+
+    it('skips AST ORDER BY check when orderByCols is empty', async () => {
+      const ast = [{ type: 'select', orderBy: [] }];
+      (handlePostExecuteSqlStatement as jest.Mock).mockResolvedValue({ rows: [{ column_name: 'name' }] });
+      const result = await nodeLogicService.resolveSortColumn(['users'], 'name', 'configuration', ast);
+      expect(result).toBe('name');
     });
   });
 });

--- a/__tests__/unit/repositories/simulation-logs.repository.test.ts
+++ b/__tests__/unit/repositories/simulation-logs.repository.test.ts
@@ -15,6 +15,27 @@ jest.mock('../../../src', () => ({
 
 import { getSimulationLogsFromDb, createSimulationLogsInDb } from '../../../src/repositories/configuration/simulation-logs.repository';
 
+const createSimulationLogsLegacy = async (
+  userId: string,
+  tenantId: string,
+  ruleId: string,
+  oldData: Record<string, unknown>,
+  newData: Record<string, unknown>,
+  description: string,
+  category: string,
+  createdByEmail?: string,
+) =>
+  createSimulationLogsInDb({
+    userId,
+    tenantId,
+    ruleId,
+    oldData,
+    newData,
+    description,
+    category,
+    createdByEmail,
+  });
+
 describe('Simulation Logs Repository', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -168,7 +189,7 @@ describe('Simulation Logs Repository', () => {
       expect(callArg.text).toContain('ORDER BY created_at');
     });
 
-    it('should default to created_at for invalid sortBy field', async () => {
+    it('should reflect undefined sort field for invalid sortBy input', async () => {
       mockHandlePostExecuteSqlStatement.mockResolvedValue({
         rows: [],
         rowCount: 0,
@@ -181,7 +202,7 @@ describe('Simulation Logs Repository', () => {
       });
 
       const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[0][0] as { text: string };
-      expect(callArg.text).toContain('ORDER BY created_at');
+      expect(callArg.text).toContain('ORDER BY created_at DESC');
     });
 
     it('should get simulation logs with limit', async () => {
@@ -403,7 +424,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -438,7 +459,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -474,7 +495,7 @@ describe('Simulation Logs Repository', () => {
       const oldData = { status: 'old', count: 1 };
       const newData = { status: 'new', count: 2 };
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         'rule-789',
@@ -496,7 +517,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '12345',
@@ -518,7 +539,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -539,7 +560,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -569,7 +590,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -591,7 +612,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -622,7 +643,7 @@ describe('Simulation Logs Repository', () => {
         boolean: false,
       };
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',
@@ -644,7 +665,7 @@ describe('Simulation Logs Repository', () => {
         rowCount: 1,
       });
 
-      await createSimulationLogsInDb(
+      await createSimulationLogsLegacy(
         'user-123',
         'tenant-456',
         '789',

--- a/__tests__/unit/repositories/suites.repository.test.ts
+++ b/__tests__/unit/repositories/suites.repository.test.ts
@@ -1,0 +1,582 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockHandlePostExecuteSqlStatement = jest.fn();
+
+jest.mock('../../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: (...args: unknown[]) => mockHandlePostExecuteSqlStatement(...args),
+}));
+
+import {
+  getSimulationSuitesFromDb,
+  getSimulationSuiteByIdFromDb,
+  createSimulationSuiteInDb,
+  updateSimulationSuiteInDb,
+} from '../../../src/repositories/simulation-studio/suites.repository';
+
+describe('Suites Repository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getSimulationSuitesFromDb should apply all filters and return parsed data', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ total: '1' }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          tenant_id: 'tenant-a',
+          name: 'Suite A',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: '{"currentStep":1}',
+          metadata: '{"source":"ui"}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    });
+
+    const result = await getSimulationSuitesFromDb({
+      tenantId: 'tenant-a',
+      search: 'suite',
+      status: 'DRAFT' as any,
+      ruleName: 'Rule 1',
+      txtp: 'pacs.008',
+      updatedFrom: new Date('2026-05-01'),
+      updatedTo: new Date('2026-05-31'),
+      limit: 10,
+      offset: 5,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].wizard_progress).toEqual({ currentStep: 1, completedSteps: [1] });
+    expect(result.data[0].metadata).toEqual({ source: 'ui' });
+
+    const countQuery = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { text: string };
+    expect(countQuery.text).toContain('COUNT(*)');
+    const dataQuery = mockHandlePostExecuteSqlStatement.mock.calls[1][0] as { text: string };
+    expect(dataQuery.text).toContain('ORDER BY updated_at DESC');
+  });
+
+  it('getSimulationSuiteByIdFromDb should return null when missing', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({ rows: [] });
+
+    const result = await getSimulationSuiteByIdFromDb(99, 'tenant-a');
+
+    expect(result).toBeNull();
+  });
+
+  it('getSimulationSuiteByIdFromDb should parse row when found', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          tenant_id: 'tenant-a',
+          name: 'Suite A',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+          last_run_at: '2026-05-02T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await getSimulationSuiteByIdFromDb(1, 'tenant-a');
+
+    expect(result?.id).toBe(1);
+    expect(result?.last_run_at).toBeInstanceOf(Date);
+  });
+
+  it('getSimulationSuiteByIdFromDb should preserve object fields and undefined last_run_at', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 2,
+          tenant_id: 'tenant-a',
+          name: 'Suite B',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: { currentStep: 1 },
+          metadata: { source: 'api' },
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    });
+
+    const result = await getSimulationSuiteByIdFromDb(2, 'tenant-a');
+
+    expect(result?.wizard_progress).toEqual({ currentStep: 1, completedSteps: [1] });
+    expect(result?.metadata).toEqual({ source: 'api' });
+    expect(result?.last_run_at).toBeUndefined();
+  });
+
+  it('createSimulationSuiteInDb should apply defaults and initialize wizard progress', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          tenant_id: 'tenant-a',
+          name: 'Suite A',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: '{"currentStep":1,"completedSteps":[1]}',
+          metadata: '{}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await createSimulationSuiteInDb({ name: 'Suite A' } as any, 'tenant-a', 'user-a');
+
+    expect(result.name).toBe('Suite A');
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { values: unknown[] };
+    expect(callArg.values[3]).toBe('SINGLE_RULE');
+    expect(callArg.values[4]).toBe('DRAFT');
+    expect(callArg.values[14]).toBe(JSON.stringify({ currentStep: 1, completedSteps: [1] }));
+  });
+
+  it('createSimulationSuiteInDb should keep provided wizard progress and user email', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 2,
+          tenant_id: 'tenant-a',
+          name: 'Suite B',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: '{"currentStep":2}',
+          metadata: '{}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await createSimulationSuiteInDb(
+      {
+        name: 'Suite B',
+        wizard_progress: { currentStep: 2, completedSteps: [1, 2] },
+        metadata: { channel: 'wizard' },
+      } as any,
+      'tenant-a',
+      'user-a',
+      'user-a@example.com',
+    );
+
+    expect(result.name).toBe('Suite B');
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { values: unknown[] };
+    expect(callArg.values[14]).toBe(JSON.stringify({ currentStep: 2, completedSteps: [1, 2] }));
+    expect(callArg.values[15]).toBe(JSON.stringify({ channel: 'wizard' }));
+    expect(callArg.values[17]).toBe('user-a@example.com');
+  });
+
+  it('updateSimulationSuiteInDb should return existing record when payload has no updates', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          tenant_id: 'tenant-a',
+          name: 'Suite A',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await updateSimulationSuiteInDb(1, 'tenant-a', {} as any);
+
+    expect(result?.id).toBe(1);
+    const queryArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { text: string };
+    expect(queryArg.text).toContain('WHERE id = $1 AND tenant_id = $2');
+  });
+
+  it('updateSimulationSuiteInDb should apply dynamic updates and return parsed result', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          tenant_id: 'tenant-a',
+          name: 'Suite Updated',
+          simulation_type: 'SINGLE_RULE',
+          status: 'RUNNING',
+          wizard_progress: '{"currentStep":2}',
+          metadata: '{"step":2}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-02T00:00:00.000Z',
+          last_run_at: '2026-05-02T10:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await updateSimulationSuiteInDb(1, 'tenant-a', {
+      name: 'Suite Updated',
+      description: '',
+      status: 'RUNNING' as any,
+      primary_txtp: '',
+      wizard_progress: { currentStep: 2 },
+      metadata: { step: 2 },
+    } as any);
+
+    expect(result?.name).toBe('Suite Updated');
+    expect(result?.wizard_progress).toEqual({ currentStep: 2 });
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('updated_at = NOW()');
+    expect(callArg.values).toContain(1);
+    expect(callArg.values).toContain('tenant-a');
+  });
+
+  it('updateSimulationSuiteInDb should return null when update returns no rows', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({ rows: [] });
+
+    const result = await updateSimulationSuiteInDb(1, 'tenant-a', { status: 'FAILED' as any } as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('getSimulationSuitesFromDb should preserve object JSON fields without parsing', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ total: '1' }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 10,
+          tenant_id: 'tenant-a',
+          name: 'Suite C',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: { currentStep: 3 },
+          metadata: { updatedBy: 'svc' },
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-03T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    });
+
+    const result = await getSimulationSuitesFromDb({ tenantId: 'tenant-a' } as any);
+
+    expect(result.total).toBe(1);
+    expect(result.data[0].wizard_progress).toEqual({ currentStep: 3, completedSteps: [1, 2, 3] });
+    expect(result.data[0].metadata).toEqual({ updatedBy: 'svc' });
+    expect(result.data[0].last_run_at).toBeUndefined();
+  });
+
+  it('getSimulationSuitesFromDb should map last_run_at to Date when present', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ total: '1' }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 11,
+          tenant_id: 'tenant-a',
+          name: 'Suite D',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-03T00:00:00.000Z',
+          last_run_at: '2026-05-03T10:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await getSimulationSuitesFromDb({ tenantId: 'tenant-a' } as any);
+
+    expect(result.data[0].last_run_at).toBeInstanceOf(Date);
+  });
+
+  it('getSimulationSuitesFromDb should fallback total to 0 when count row is missing', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
+
+    const result = await getSimulationSuitesFromDb({ tenantId: 'tenant-a' } as any);
+
+    expect(result.total).toBe(0);
+    expect(result.data).toEqual([]);
+  });
+
+  it('createSimulationSuiteInDb passes rule_config as JSON string and returns it parsed', async () => {
+    const ruleConfig = { threshold: 1000, band: 'high' };
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 5,
+          tenant_id: 'tenant-a',
+          name: 'Suite E',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: JSON.stringify(ruleConfig),
+          wizard_progress: '{"currentStep":1,"completedSteps":[1]}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await createSimulationSuiteInDb({ name: 'Suite E', rule_config: ruleConfig } as any, 'tenant-a', 'user-a');
+
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { values: unknown[] };
+    // rule_config is at index 8 (0-based) in the INSERT values
+    expect(callArg.values[8]).toBe(JSON.stringify(ruleConfig));
+    expect(result.rule_config).toEqual(ruleConfig);
+  });
+
+  it('createSimulationSuiteInDb returns empty object rule_config when column is null', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 6,
+          tenant_id: 'tenant-a',
+          name: 'Suite F',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: null,
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await createSimulationSuiteInDb({ name: 'Suite F' } as any, 'tenant-a', 'user-a');
+
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { values: unknown[] };
+    expect(callArg.values[8]).toBeNull(); // no rule_config passed
+    expect(result.rule_config).toEqual({});
+  });
+
+  it('updateSimulationSuiteInDb updates rule_config and returns it parsed', async () => {
+    const ruleConfig = { limit: 500 };
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          tenant_id: 'tenant-a',
+          name: 'Suite A',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: JSON.stringify(ruleConfig),
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await updateSimulationSuiteInDb(1, 'tenant-a', { rule_config: ruleConfig } as any);
+
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('rule_config');
+    expect(callArg.values).toContain(JSON.stringify(ruleConfig));
+    expect(result!.rule_config).toEqual(ruleConfig);
+  });
+
+  it('getSimulationSuiteByIdFromDb returns rule_config parsed from string', async () => {
+    const ruleConfig = { mode: 'strict' };
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 3,
+          tenant_id: 'tenant-a',
+          name: 'Suite G',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: JSON.stringify(ruleConfig),
+          wizard_progress: '{"currentStep":1,"completedSteps":[1]}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    });
+
+    const result = await getSimulationSuiteByIdFromDb(3, 'tenant-a');
+
+    expect(result?.rule_config).toEqual(ruleConfig);
+  });
+
+  it('getSimulationSuitesFromDb returns rule_config parsed from string', async () => {
+    const ruleConfig = { velocity: 10 };
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ total: '1' }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 12,
+          tenant_id: 'tenant-a',
+          name: 'Suite H',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: JSON.stringify(ruleConfig),
+          wizard_progress: { currentStep: 1, completedSteps: [1] },
+          metadata: {},
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    });
+
+    const result = await getSimulationSuitesFromDb({ tenantId: 'tenant-a' } as any);
+
+    expect(result.data[0].rule_config).toEqual(ruleConfig);
+  });
+
+  it('createSimulationSuiteInDb should preserve object wizard and metadata in returned row', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 3,
+          tenant_id: 'tenant-a',
+          name: 'Suite Obj',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: { currentStep: 4 },
+          metadata: { owner: 'qa' },
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await createSimulationSuiteInDb({ name: 'Suite Obj' } as any, 'tenant-a', 'user-a');
+
+    expect(result.wizard_progress).toEqual({ currentStep: 4 });
+    expect(result.metadata).toEqual({ owner: 'qa' });
+  });
+
+  it('updateSimulationSuiteInDb should map object fields and null last_run_at in response', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 4,
+          tenant_id: 'tenant-a',
+          name: 'Suite Obj Updated',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          wizard_progress: { currentStep: 5 },
+          metadata: { phase: 'done' },
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-02T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    });
+
+    const result = await updateSimulationSuiteInDb(4, 'tenant-a', {
+      description: null,
+      rule_repo: null,
+      rule_name: null,
+      rule_version: null,
+      primary_txtp: null,
+      primary_txtp_version: null,
+      last_run_at: null,
+    } as any);
+
+    expect(result?.wizard_progress).toEqual({ currentStep: 5 });
+    expect(result?.metadata).toEqual({ phase: 'done' });
+    expect(result?.last_run_at).toBeUndefined();
+
+    const callArg = mockHandlePostExecuteSqlStatement.mock.calls[0][0] as { values: unknown[] };
+    expect(callArg.values).toContain(null);
+  });
+
+  it('createSimulationSuiteInDb returns rule_config unchanged when already object', async () => {
+    const ruleConfig = { threshold: 500 };
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 7,
+          tenant_id: 'tenant-a',
+          name: 'X',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: ruleConfig,
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    } as never);
+    const result = await createSimulationSuiteInDb({ name: 'X' } as any, 'tenant-a', 'user-a');
+    expect(result.rule_config).toEqual(ruleConfig);
+  });
+
+  it('getSimulationSuiteByIdFromDb returns rule_config unchanged when already object', async () => {
+    const ruleConfig = { mode: 'fast' };
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 8,
+          tenant_id: 'tenant-a',
+          name: 'Y',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: ruleConfig,
+          wizard_progress: '{"currentStep":1,"completedSteps":[1]}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    } as never);
+    const result = await getSimulationSuiteByIdFromDb(8, 'tenant-a');
+    expect(result?.rule_config).toEqual(ruleConfig);
+  });
+
+  it('getSimulationSuitesFromDb returns rule_config unchanged when already object', async () => {
+    const ruleConfig = { cap: 999 };
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ total: '1' }] } as never).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 13,
+          tenant_id: 'tenant-a',
+          name: 'Z',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: ruleConfig,
+          wizard_progress: { currentStep: 1, completedSteps: [1] },
+          metadata: {},
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+          last_run_at: null,
+        },
+      ],
+    } as never);
+    const result = await getSimulationSuitesFromDb({ tenantId: 'tenant-a' } as any);
+    expect(result.data[0].rule_config).toEqual(ruleConfig);
+  });
+
+  it('updateSimulationSuiteInDb returns rule_config unchanged when already object', async () => {
+    const ruleConfig = { version: 2 };
+    mockHandlePostExecuteSqlStatement.mockResolvedValue({
+      rows: [
+        {
+          id: 9,
+          tenant_id: 'tenant-a',
+          name: 'W',
+          simulation_type: 'SINGLE_RULE',
+          status: 'DRAFT',
+          rule_config: ruleConfig,
+          wizard_progress: '{}',
+          metadata: '{}',
+          created_at: '2026-06-01T00:00:00.000Z',
+          updated_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    } as never);
+    const result = await updateSimulationSuiteInDb(9, 'tenant-a', { name: 'W' } as any);
+    expect(result?.rule_config).toEqual(ruleConfig);
+  });
+});

--- a/__tests__/unit/simulation-logs.logic.service.test.ts
+++ b/__tests__/unit/simulation-logs.logic.service.test.ts
@@ -50,16 +50,16 @@ describe('Simulation Logs Logic Service', () => {
         createdByEmail: mockEmail,
       });
 
-      expect(simulationLogsRepository.createSimulationLogsInDb).toHaveBeenCalledWith(
-        mockUserId,
-        mockTenantId,
-        mockRuleId,
-        { config: 'old' },
-        { config: 'new' },
-        'Test log',
-        'rule',
-        mockEmail,
-      );
+      expect(simulationLogsRepository.createSimulationLogsInDb).toHaveBeenCalledWith({
+        userId: mockUserId,
+        tenantId: mockTenantId,
+        ruleId: mockRuleId,
+        oldData: { config: 'old' },
+        newData: { config: 'new' },
+        description: 'Test log',
+        category: 'rule',
+        createdByEmail: mockEmail,
+      });
     });
 
     it('should create log with empty description when not provided', async () => {
@@ -75,16 +75,16 @@ describe('Simulation Logs Logic Service', () => {
         createdByEmail: mockEmail,
       });
 
-      expect(simulationLogsRepository.createSimulationLogsInDb).toHaveBeenCalledWith(
-        mockUserId,
-        mockTenantId,
-        mockRuleId,
-        { config: 'old' },
-        { config: 'new' },
-        '',
-        'rule',
-        mockEmail,
-      );
+      expect(simulationLogsRepository.createSimulationLogsInDb).toHaveBeenCalledWith({
+        userId: mockUserId,
+        tenantId: mockTenantId,
+        ruleId: mockRuleId,
+        oldData: { config: 'old' },
+        newData: { config: 'new' },
+        description: '',
+        category: 'rule',
+        createdByEmail: mockEmail,
+      });
     });
 
     it('should throw error when log creation fails', async () => {

--- a/__tests__/unit/simulation-studio.repositories.test.ts
+++ b/__tests__/unit/simulation-studio.repositories.test.ts
@@ -1,0 +1,1053 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: jest.fn(),
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import * as db from '../../src/services/database.logic.service';
+import {
+  createSuiteGenerationInDb,
+  getNextGenerationNumber,
+  getGenerationsBySuiteId,
+  getLatestGenerationBySuiteId,
+  updateGenerationCountsInDb,
+  getGenerationSummaryFromDb,
+  updateWizardProgressInDb,
+  resumeGenerationInDb,
+} from '../../src/repositories/simulation-studio/suite-generations.repository';
+import {
+  createContextTxtpConfigInDb,
+  updateContextTxtpConfigInDb,
+  getContextTxtpConfigsByGenerationId,
+  deleteContextTxtpConfigInDb,
+} from '../../src/repositories/simulation-studio/context-txtp-configs.repository';
+import {
+  upsertFieldStrategyInDb,
+  getFieldStrategiesByContextConfigId,
+} from '../../src/repositories/simulation-studio/context-field-strategies.repository';
+import {
+  createTriggerTxtpConfigInDb,
+  updateTriggerTxtpConfigInDb,
+  getTriggerTxtpConfigsByGenerationId,
+  deleteTriggerTxtpConfigInDb,
+} from '../../src/repositories/simulation-studio/trigger-txtp-configs.repository';
+import {
+  upsertTriggerFieldOverrideInDb,
+  getTriggerFieldOverridesByConfigId,
+} from '../../src/repositories/simulation-studio/trigger-field-strategies.repository';
+import {
+  createEnrichmentTableInDb,
+  getNextEnrichmentTableOrderInDb,
+  updateEnrichmentTableInDb,
+  getEnrichmentTablesByGenerationId,
+  deleteEnrichmentTableInDb,
+} from '../../src/repositories/simulation-studio/enrichment-tables.repository';
+
+const mockDb = db.handlePostExecuteSqlStatement as jest.Mock;
+
+const generationRow = {
+  id: 1,
+  suite_id: 42,
+  generation_number: 1,
+  status: 'DRAFT',
+  simulation_type: 'SINGLE_RULE',
+  rule_repo: null,
+  rule_version: null,
+  context_count: 0,
+  trigger_count: 0,
+  enrichment_table_count: 0,
+  generated_context_count: 0,
+  generated_trigger_count: 0,
+  generated_enrichment_row_count: 0,
+  context_field_config_count: 0,
+  trigger_field_config_count: 0,
+  enrichment_field_config_count: 0,
+  wizard_snapshot: '{}',
+  generation_metadata: '{}',
+  created_by: 'user-1',
+  created_by_email: null,
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+};
+
+const contextConfigRow = {
+  id: 1,
+  generation_id: 1,
+  txtp: 'pacs.008',
+  txtp_version: '001.08',
+  display_order: 1,
+  message_count: 1,
+  schema_snapshot: '{"type":"object"}',
+  sample_payload_snapshot: '{"test":"payload"}',
+  faker_seed: null,
+  generator_profile: '{}',
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+};
+
+const fieldStrategyRow = {
+  id: 1,
+  context_txtp_config_id: 1,
+  field_path: 'CdtTrfTxInf.IntrBkSttlmAmt.value',
+  strategy_code: 'static',
+  static_value: '999',
+  range_min: null,
+  range_max: null,
+  faker_semantic_type: null,
+  generator_options: '{}',
+  is_required_override: null,
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── suite-generations.repository ─────────────────────────────────────────────
+
+describe('createSuiteGenerationInDb', () => {
+  it('inserts row and returns mapped generation', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+
+    const result = await createSuiteGenerationInDb(
+      { suite_id: 42, simulation_type: 'SINGLE_RULE' as any, wizard_snapshot: {}, generation_metadata: {} },
+      'user-1',
+      'user@test.com',
+    );
+
+    expect(result.id).toBe(1);
+    expect(result.suite_id).toBe(42);
+    expect(result.wizard_snapshot).toEqual({});
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('INSERT') }), 'simulation');
+  });
+
+  it('parses wizard_snapshot as object when already object', async () => {
+    const rowWithObj = { ...generationRow, wizard_snapshot: { step: 1 }, generation_metadata: {} };
+    mockDb.mockResolvedValue({ rows: [rowWithObj] });
+
+    const result = await createSuiteGenerationInDb(
+      { suite_id: 42, simulation_type: 'SINGLE_RULE' as any, wizard_snapshot: {}, generation_metadata: {} },
+      'user-1',
+    );
+
+    expect(result.wizard_snapshot).toEqual({ step: 1 });
+  });
+});
+
+describe('getNextGenerationNumber', () => {
+  it('returns next generation number', async () => {
+    mockDb.mockResolvedValue({ rows: [{ next_num: 3 }] });
+
+    const result = await getNextGenerationNumber(42);
+
+    expect(result).toBe(3);
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ values: [42] }), 'simulation');
+  });
+});
+
+describe('getGenerationsBySuiteId', () => {
+  it('returns mapped array', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow, generationRow] });
+
+    const result = await getGenerationsBySuiteId(42);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].suite_id).toBe(42);
+  });
+
+  it('returns empty array when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await getGenerationsBySuiteId(42)).toEqual([]);
+  });
+});
+
+describe('getLatestGenerationBySuiteId', () => {
+  it('returns mapped generation when found', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+
+    const result = await getLatestGenerationBySuiteId(42);
+
+    expect(result).not.toBeNull();
+    expect(result!.generation_number).toBe(1);
+  });
+
+  it('returns null when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await getLatestGenerationBySuiteId(42)).toBeNull();
+  });
+});
+
+// ── suite-generations.repository — optional fields branches ──────────────────
+
+describe('createSuiteGenerationInDb — optional fields', () => {
+  it('uses SINGLE_RULE default when simulation_type absent', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+    await createSuiteGenerationInDb({ suite_id: 42 } as any, 'user-1');
+    const callValues = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callValues[1]).toBe('SINGLE_RULE');
+  });
+
+  it('uses provided simulation_type when given', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+    await createSuiteGenerationInDb({ suite_id: 42, simulation_type: 'INTEGRATION_TESTING' as any }, 'user-1');
+    const callValues = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callValues[1]).toBe('INTEGRATION_TESTING');
+  });
+
+  it('passes non-null rule_repo and rule_version when provided', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+    await createSuiteGenerationInDb(
+      { suite_id: 42, simulation_type: 'SINGLE_RULE' as any, rule_repo: 'repo-a', rule_version: 'v1' },
+      'user-1',
+    );
+    const callValues = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callValues[2]).toBe('repo-a');
+    expect(callValues[3]).toBe('v1');
+  });
+
+  it('passes null for optional rule_repo and rule_version when absent', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+    await createSuiteGenerationInDb({ suite_id: 42, simulation_type: 'INTEGRATION_TESTING' as any }, 'user-1');
+    const callValues = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callValues[2]).toBeNull();
+    expect(callValues[3]).toBeNull();
+    expect(callValues[7]).toBeNull();
+  });
+});
+
+// ── context-txtp-configs.repository ──────────────────────────────────────────
+
+describe('createContextTxtpConfigInDb', () => {
+  it('inserts row and returns mapped config', async () => {
+    mockDb.mockResolvedValue({ rows: [contextConfigRow] });
+
+    const result = await createContextTxtpConfigInDb({
+      generation_id: 1,
+      txtp: 'pacs.008',
+      txtp_version: '001.08',
+      display_order: 1,
+      message_count: 1,
+      schema_snapshot: { type: 'object' },
+      sample_payload_snapshot: { test: 'payload' },
+    });
+
+    expect(result.id).toBe(1);
+    expect(result.txtp).toBe('pacs.008');
+    expect(result.schema_snapshot).toEqual({ type: 'object' });
+    expect(result.sample_payload_snapshot).toEqual({ test: 'payload' });
+  });
+
+  it('handles null sample_payload_snapshot', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...contextConfigRow, sample_payload_snapshot: null }] });
+
+    const result = await createContextTxtpConfigInDb({
+      generation_id: 1,
+      txtp: 'pacs.008',
+      txtp_version: '001.08',
+      display_order: 1,
+      message_count: 1,
+      schema_snapshot: {},
+    });
+
+    expect(result.sample_payload_snapshot).toBeUndefined();
+  });
+});
+
+describe('updateContextTxtpConfigInDb', () => {
+  it('updates message_count and returns updated row', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...contextConfigRow, message_count: 5 }] });
+
+    const result = await updateContextTxtpConfigInDb(1, { message_count: 5 });
+
+    expect(result!.message_count).toBe(5);
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('UPDATE') }), 'simulation');
+  });
+
+  it('updates faker_seed', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...contextConfigRow, faker_seed: 42 }] });
+
+    const result = await updateContextTxtpConfigInDb(1, { faker_seed: 42 });
+
+    expect(result!.faker_seed).toBe(42);
+  });
+
+  it('updates generator_profile', async () => {
+    const profile = { type: 'bic' };
+    mockDb.mockResolvedValue({ rows: [{ ...contextConfigRow, generator_profile: JSON.stringify(profile) }] });
+
+    const result = await updateContextTxtpConfigInDb(1, { generator_profile: profile });
+
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('UPDATE') }), 'simulation');
+    expect(result).not.toBeNull();
+  });
+
+  it('fetches existing row when no fields to update', async () => {
+    mockDb.mockResolvedValue({ rows: [contextConfigRow] });
+
+    const result = await updateContextTxtpConfigInDb(1, {});
+
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('SELECT') }), 'simulation');
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null when no fields and row not found', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await updateContextTxtpConfigInDb(99, {})).toBeNull();
+  });
+
+  it('returns null when UPDATE finds no row', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await updateContextTxtpConfigInDb(99, { message_count: 5 })).toBeNull();
+  });
+});
+
+describe('getContextTxtpConfigsByGenerationId', () => {
+  it('returns mapped configs array', async () => {
+    mockDb.mockResolvedValue({ rows: [contextConfigRow] });
+
+    const result = await getContextTxtpConfigsByGenerationId(1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].generation_id).toBe(1);
+  });
+});
+
+describe('deleteContextTxtpConfigInDb', () => {
+  it('returns true when row deleted', async () => {
+    mockDb.mockResolvedValue({ rows: [{ id: 10 }] } as never);
+    expect(await deleteContextTxtpConfigInDb(10)).toBe(true);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('DELETE FROM trs_suite_context_txtp_configs') }),
+      'simulation',
+    );
+  });
+
+  it('returns false when row not found', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+    expect(await deleteContextTxtpConfigInDb(999)).toBe(false);
+  });
+});
+
+describe('deleteTriggerTxtpConfigInDb', () => {
+  it('returns true when row deleted', async () => {
+    mockDb.mockResolvedValue({ rows: [{ id: 20 }] } as never);
+    expect(await deleteTriggerTxtpConfigInDb(20)).toBe(true);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('DELETE FROM trs_suite_trigger_txtp_configs') }),
+      'simulation',
+    );
+  });
+
+  it('returns false when row not found', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+    expect(await deleteTriggerTxtpConfigInDb(999)).toBe(false);
+  });
+});
+
+// ── context-field-strategies.repository ──────────────────────────────────────
+
+describe('upsertFieldStrategyInDb', () => {
+  it('upserts row and returns mapped strategy', async () => {
+    mockDb.mockResolvedValue({ rows: [fieldStrategyRow] });
+
+    const result = await upsertFieldStrategyInDb(1, {
+      field_path: 'CdtTrfTxInf.IntrBkSttlmAmt.value',
+      strategy_code: 'static',
+      static_value: 999,
+    });
+
+    expect(result.id).toBe(1);
+    expect(result.strategy_code).toBe('static');
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('ON CONFLICT') }), 'simulation');
+  });
+
+  it('handles range strategy fields', async () => {
+    const rangeRow = { ...fieldStrategyRow, strategy_code: 'range', range_min: 1, range_max: 100, static_value: null };
+    mockDb.mockResolvedValue({ rows: [rangeRow] });
+
+    const result = await upsertFieldStrategyInDb(1, {
+      field_path: 'amount',
+      strategy_code: 'range',
+      range_min: 1,
+      range_max: 100,
+    });
+
+    expect(result.strategy_code).toBe('range');
+  });
+
+  it('handles generator_options as object (not string)', async () => {
+    const rowWithObjOptions = { ...fieldStrategyRow, generator_options: { type: 'bic' } };
+    mockDb.mockResolvedValue({ rows: [rowWithObjOptions] });
+
+    const result = await upsertFieldStrategyInDb(1, {
+      field_path: 'bic',
+      strategy_code: 'generated',
+      faker_semantic_type: 'iso20022.bic',
+      generator_options: { type: 'bic' },
+    });
+
+    expect(result.generator_options).toEqual({ type: 'bic' });
+  });
+});
+
+describe('getFieldStrategiesByContextConfigId', () => {
+  it('returns mapped strategies array', async () => {
+    mockDb.mockResolvedValue({ rows: [fieldStrategyRow] });
+
+    const result = await getFieldStrategiesByContextConfigId(1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].field_path).toBe('CdtTrfTxInf.IntrBkSttlmAmt.value');
+  });
+
+  it('returns empty array when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await getFieldStrategiesByContextConfigId(1)).toEqual([]);
+  });
+});
+
+// ── createSuiteGenerationInDb — optional fields branch ───────────────────────
+
+describe('createSuiteGenerationInDb — optional fields', () => {
+  it('uses SINGLE_RULE default when simulation_type absent', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+
+    await createSuiteGenerationInDb({ suite_id: 42 } as any, 'user-1');
+
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ values: expect.arrayContaining(['SINGLE_RULE']) }), 'simulation');
+  });
+
+  it('passes null for optional rule_repo, rule_version, userEmail when absent', async () => {
+    mockDb.mockResolvedValue({ rows: [generationRow] });
+
+    await createSuiteGenerationInDb({ suite_id: 42, simulation_type: 'INTEGRATION_TESTING' as any }, 'user-1');
+
+    const callValues = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callValues[2]).toBeNull(); // rule_repo
+    expect(callValues[3]).toBeNull(); // rule_version
+    expect(callValues[7]).toBeNull(); // userEmail
+  });
+});
+
+// ── trigger-txtp-configs.repository ─────────────────────────────────────────
+
+const triggerConfigRow = {
+  id: 20,
+  generation_id: 1,
+  txtp: 'pacs.008',
+  txtp_version: '001.08',
+  display_order: 1,
+  message_count: 1,
+  link_to_context_pairs: false,
+  payload_template_json: JSON.stringify({ amount: 100 }),
+  expected_independent_variable: null,
+  expected_result_band: null,
+  notes: null,
+  faker_seed: null,
+  generator_profile: '{}',
+  created_at: '2026-05-01T00:00:00.000Z',
+};
+
+const triggerOverrideRow = {
+  id: 1,
+  trigger_txtp_config_id: 20,
+  field_path: 'amount',
+  override_type: 'null',
+  static_value: null,
+  range_min: null,
+  range_max: null,
+  faker_semantic_type: null,
+  generator_options: '{}',
+  created_at: '2026-05-01T00:00:00.000Z',
+};
+
+describe('createTriggerTxtpConfigInDb', () => {
+  it('inserts row and returns mapped trigger config', async () => {
+    mockDb.mockResolvedValue({ rows: [triggerConfigRow] });
+
+    const result = await createTriggerTxtpConfigInDb({
+      generation_id: 1,
+      txtp: 'pacs.008',
+      txtp_version: '001.08',
+      display_order: 1,
+      message_count: 1,
+      payload_template_json: { amount: 100 },
+    });
+
+    expect(result.id).toBe(20);
+    expect(result.txtp).toBe('pacs.008');
+    expect(result.payload_template_json).toEqual({ amount: 100 });
+    expect(result.link_to_context_pairs).toBe(false);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('INSERT INTO trs_suite_trigger_txtp_configs') }),
+      'simulation',
+    );
+  });
+
+  it('parses payload_template_json when stored as object (not string)', async () => {
+    const rowWithObj = { ...triggerConfigRow, payload_template_json: { amount: 100 } };
+    mockDb.mockResolvedValue({ rows: [rowWithObj] });
+
+    const result = await createTriggerTxtpConfigInDb({
+      generation_id: 1,
+      txtp: 'pacs.008',
+      txtp_version: '001.08',
+      display_order: 1,
+      message_count: 1,
+      payload_template_json: { amount: 100 },
+    });
+
+    expect(result.payload_template_json).toEqual({ amount: 100 });
+  });
+
+  it('handles optional fields: expected_result_band, notes, faker_seed', async () => {
+    const rowWithOptionals = {
+      ...triggerConfigRow,
+      expected_result_band: 'good',
+      notes: 'boundary case',
+      faker_seed: 42,
+    };
+    mockDb.mockResolvedValue({ rows: [rowWithOptionals] });
+
+    const result = await createTriggerTxtpConfigInDb({
+      generation_id: 1,
+      txtp: 'pacs.008',
+      txtp_version: '001.08',
+      display_order: 1,
+      message_count: 1,
+      payload_template_json: {},
+      expected_result_band: 'good',
+      notes: 'boundary case',
+      faker_seed: 42,
+    });
+
+    expect(result.expected_result_band).toBe('good');
+    expect(result.notes).toBe('boundary case');
+    expect(result.faker_seed).toBe(42);
+  });
+});
+
+describe('updateTriggerTxtpConfigInDb', () => {
+  it('updates message_count and returns updated row', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerConfigRow, message_count: 3 }] });
+
+    const result = await updateTriggerTxtpConfigInDb(20, { message_count: 3 });
+
+    expect(result!.message_count).toBe(3);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('UPDATE trs_suite_trigger_txtp_configs') }),
+      'simulation',
+    );
+  });
+
+  it('updates link_to_context_pairs', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerConfigRow, link_to_context_pairs: true }] });
+    const result = await updateTriggerTxtpConfigInDb(20, { link_to_context_pairs: true });
+    expect(result!.link_to_context_pairs).toBe(true);
+  });
+
+  it('updates payload_template_json', async () => {
+    const updated = { ...triggerConfigRow, payload_template_json: JSON.stringify({ amount: 999 }) };
+    mockDb.mockResolvedValue({ rows: [updated] });
+    const result = await updateTriggerTxtpConfigInDb(20, { payload_template_json: { amount: 999 } });
+    expect(result!.payload_template_json).toEqual({ amount: 999 });
+  });
+
+  it('updates expected_result_band and notes', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerConfigRow, expected_result_band: 'bad', notes: 'edge' }] });
+    const result = await updateTriggerTxtpConfigInDb(20, { expected_result_band: 'bad', notes: 'edge' });
+    expect(result!.expected_result_band).toBe('bad');
+    expect(result!.notes).toBe('edge');
+  });
+
+  it('updates faker_seed and generator_profile', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerConfigRow, faker_seed: 99 }] });
+    const result = await updateTriggerTxtpConfigInDb(20, { faker_seed: 99, generator_profile: { type: 'bic' } });
+    expect(result!.faker_seed).toBe(99);
+  });
+
+  it('fetches existing row when no fields to update', async () => {
+    mockDb.mockResolvedValue({ rows: [triggerConfigRow] });
+    const result = await updateTriggerTxtpConfigInDb(20, {});
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('SELECT') }), 'simulation');
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null when no fields and row not found', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await updateTriggerTxtpConfigInDb(99, {})).toBeNull();
+  });
+
+  it('returns null when UPDATE finds no row', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await updateTriggerTxtpConfigInDb(99, { message_count: 5 })).toBeNull();
+  });
+});
+
+describe('getTriggerTxtpConfigsByGenerationId', () => {
+  it('returns mapped trigger configs array', async () => {
+    mockDb.mockResolvedValue({ rows: [triggerConfigRow] });
+    const result = await getTriggerTxtpConfigsByGenerationId(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].generation_id).toBe(1);
+  });
+
+  it('returns empty array when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await getTriggerTxtpConfigsByGenerationId(1)).toEqual([]);
+  });
+});
+
+// ── trigger-field-strategies.repository ─────────────────────────────────────
+
+describe('upsertTriggerFieldOverrideInDb', () => {
+  it('upserts row and returns mapped override', async () => {
+    mockDb.mockResolvedValue({ rows: [triggerOverrideRow] });
+
+    const result = await upsertTriggerFieldOverrideInDb(20, {
+      field_path: 'amount',
+      override_type: 'null',
+    });
+
+    expect(result.id).toBe(1);
+    expect(result.trigger_txtp_config_id).toBe(20);
+    expect(result.override_type).toBe('null');
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('ON CONFLICT') }), 'simulation');
+  });
+
+  it('handles static override type', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerOverrideRow, override_type: 'static', static_value: '"999"' }] });
+
+    const result = await upsertTriggerFieldOverrideInDb(20, {
+      field_path: 'amount',
+      override_type: 'static',
+      static_value: '999',
+    });
+
+    expect(result.override_type).toBe('static');
+  });
+
+  it('handles range override type', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerOverrideRow, override_type: 'range', range_min: 1, range_max: 100 }] });
+
+    const result = await upsertTriggerFieldOverrideInDb(20, {
+      field_path: 'amount',
+      override_type: 'range',
+      range_min: 1,
+      range_max: 100,
+    });
+
+    expect(result.range_min).toBe(1);
+    expect(result.range_max).toBe(100);
+  });
+
+  it('handles generator_options as object (not string)', async () => {
+    const rowWithObj = { ...triggerOverrideRow, generator_options: { type: 'bic' } };
+    mockDb.mockResolvedValue({ rows: [rowWithObj] });
+
+    const result = await upsertTriggerFieldOverrideInDb(20, {
+      field_path: 'bic',
+      override_type: 'generated',
+      faker_semantic_type: 'iso20022.bic',
+      generator_options: { type: 'bic' },
+    });
+
+    expect(result.generator_options).toEqual({ type: 'bic' });
+  });
+
+  it('handles remove override type', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...triggerOverrideRow, override_type: 'remove' }] });
+    const result = await upsertTriggerFieldOverrideInDb(20, { field_path: 'field.a', override_type: 'remove' });
+    expect(result.override_type).toBe('remove');
+  });
+});
+
+describe('getTriggerFieldOverridesByConfigId', () => {
+  it('returns mapped overrides array', async () => {
+    mockDb.mockResolvedValue({ rows: [triggerOverrideRow] });
+
+    const result = await getTriggerFieldOverridesByConfigId(20);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].field_path).toBe('amount');
+    expect(result[0].override_type).toBe('null');
+  });
+
+  it('returns empty array when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await getTriggerFieldOverridesByConfigId(20)).toEqual([]);
+  });
+});
+
+// ── enrichment-tables.repository ─────────────────────────────────────────────
+
+const enrichmentTableRow = {
+  id: 30,
+  generation_id: 1,
+  table_name: 'account_enrichment',
+  table_order: 1,
+  row_count: 13,
+  payload_template_json: JSON.stringify({ name: 'feeba', country: 'Pak' }),
+  schema_template_json: null,
+  faker_profile: '{}',
+  created_at: '2026-06-01T00:00:00.000Z',
+};
+
+describe('createEnrichmentTableInDb', () => {
+  it('inserts row and returns mapped enrichment table', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+
+    const result = await createEnrichmentTableInDb({
+      generation_id: 1,
+      table_name: 'account_enrichment',
+      row_count: 13,
+      payload_template_json: { name: 'feeba', country: 'Pak' },
+    });
+
+    expect(result.id).toBe(30);
+    expect(result.table_name).toBe('account_enrichment');
+    expect(result.row_count).toBe(13);
+    expect(result.payload_template_json).toEqual({ name: 'feeba', country: 'Pak' });
+    expect(result.faker_profile).toEqual({});
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('INSERT INTO trs_suite_enrichment_tables') }),
+      'simulation',
+    );
+  });
+
+  it('uses default table_order=1 when not provided', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+    await createEnrichmentTableInDb({ generation_id: 1, table_name: 'cnic', row_count: 5 });
+    const callValues = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callValues[2]).toBe(1); // table_order default
+  });
+
+  it('handles null payload_template_json', async () => {
+    const rowNoPayload = { ...enrichmentTableRow, payload_template_json: null };
+    mockDb.mockResolvedValue({ rows: [rowNoPayload] });
+    const result = await createEnrichmentTableInDb({ generation_id: 1, table_name: 'x', row_count: 1 });
+    expect(result.payload_template_json).toBeUndefined();
+  });
+
+  it('parses payload_template_json when already an object', async () => {
+    const rowObjPayload = { ...enrichmentTableRow, payload_template_json: { name: 'feeba' } };
+    mockDb.mockResolvedValue({ rows: [rowObjPayload] });
+    const result = await createEnrichmentTableInDb({ generation_id: 1, table_name: 'x', row_count: 1 });
+    expect(result.payload_template_json).toEqual({ name: 'feeba' });
+  });
+
+  it('parses faker_profile when already an object', async () => {
+    const rowObjFaker = { ...enrichmentTableRow, faker_profile: { locale: 'ur' } };
+    mockDb.mockResolvedValue({ rows: [rowObjFaker] });
+    const result = await createEnrichmentTableInDb({ generation_id: 1, table_name: 'x', row_count: 1 });
+    expect(result.faker_profile).toEqual({ locale: 'ur' });
+  });
+
+  it('defaults faker_profile to {} when null', async () => {
+    const rowNullFaker = { ...enrichmentTableRow, faker_profile: null };
+    mockDb.mockResolvedValue({ rows: [rowNullFaker] });
+    const result = await createEnrichmentTableInDb({ generation_id: 1, table_name: 'x', row_count: 1 });
+    expect(result.faker_profile).toEqual({});
+  });
+});
+
+describe('updateEnrichmentTableInDb', () => {
+  it('updates row_count and returns mapped row', async () => {
+    mockDb.mockResolvedValue({ rows: [{ ...enrichmentTableRow, row_count: 5 }] });
+    const result = await updateEnrichmentTableInDb(30, 1, { row_count: 5 });
+    expect(result!.row_count).toBe(5);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('UPDATE trs_suite_enrichment_tables') }),
+      'simulation',
+    );
+  });
+
+  it('updates payload_template_json', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+    await updateEnrichmentTableInDb(30, 1, { payload_template_json: { city: 'Karachi' } });
+    const callArg = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callArg).toContain(JSON.stringify({ city: 'Karachi' }));
+  });
+
+  it('updates schema_template_json', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+    await updateEnrichmentTableInDb(30, 1, { schema_template_json: { col: 'VARCHAR' } });
+    const callArg = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callArg).toContain(JSON.stringify({ col: 'VARCHAR' }));
+  });
+
+  it('updates faker_profile', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+    await updateEnrichmentTableInDb(30, 1, { faker_profile: { locale: 'ur' } });
+    const callArg = (mockDb.mock.calls[0][0] as { values: unknown[] }).values;
+    expect(callArg).toContain(JSON.stringify({ locale: 'ur' }));
+  });
+
+  it('fetches existing row when no fields to update', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+    const result = await updateEnrichmentTableInDb(30, 1, {});
+    expect(mockDb).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('SELECT') }), 'simulation');
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null when no fields and row not found', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await updateEnrichmentTableInDb(99, 1, {})).toBeNull();
+  });
+
+  it('returns null when UPDATE finds no row', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await updateEnrichmentTableInDb(99, 1, { row_count: 5 })).toBeNull();
+  });
+});
+
+describe('getNextEnrichmentTableOrderInDb', () => {
+  it('returns next table order for a generation', async () => {
+    mockDb.mockResolvedValue({ rows: [{ next_order: '4' }] });
+    await expect(getNextEnrichmentTableOrderInDb(1)).resolves.toBe(4);
+  });
+
+  it('defaults to 1 when query has no row', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await expect(getNextEnrichmentTableOrderInDb(1)).resolves.toBe(1);
+  });
+});
+
+describe('getEnrichmentTablesByGenerationId', () => {
+  it('returns mapped array ordered by table_order', async () => {
+    mockDb.mockResolvedValue({ rows: [enrichmentTableRow] });
+    const result = await getEnrichmentTablesByGenerationId(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].generation_id).toBe(1);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('ORDER BY table_order ASC') }),
+      'simulation',
+    );
+  });
+
+  it('returns empty array when no rows', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await getEnrichmentTablesByGenerationId(1)).toEqual([]);
+  });
+});
+
+describe('deleteEnrichmentTableInDb', () => {
+  it('returns true when row deleted', async () => {
+    mockDb.mockResolvedValue({ rows: [{ id: 30 }] });
+    expect(await deleteEnrichmentTableInDb(30)).toBe(true);
+    expect(mockDb).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('DELETE FROM trs_suite_enrichment_tables') }),
+      'simulation',
+    );
+  });
+
+  it('returns false when row not found', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    expect(await deleteEnrichmentTableInDb(999)).toBe(false);
+  });
+});
+
+// ── updateGenerationCountsInDb ────────────────────────────────────────────────
+
+describe('updateGenerationCountsInDb', () => {
+  it('updates context_count only', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await updateGenerationCountsInDb(1, { context_count: 100 });
+    const callArg = mockDb.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('context_count');
+    expect(callArg.text).not.toContain('trigger_count');
+    expect(callArg.values).toContain(100);
+    expect(callArg.values).toContain(1);
+  });
+
+  it('updates trigger_count only', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await updateGenerationCountsInDb(1, { trigger_count: 10 });
+    const callArg = mockDb.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('trigger_count');
+    expect(callArg.values).toContain(10);
+  });
+
+  it('updates enrichment_table_count only', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await updateGenerationCountsInDb(1, { enrichment_table_count: 3 });
+    const callArg = mockDb.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('enrichment_table_count');
+    expect(callArg.values).toContain(3);
+  });
+
+  it('updates all three counts in one call', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await updateGenerationCountsInDb(7, { context_count: 100, trigger_count: 10, enrichment_table_count: 2 });
+    const callArg = mockDb.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('context_count');
+    expect(callArg.text).toContain('trigger_count');
+    expect(callArg.text).toContain('enrichment_table_count');
+    expect(callArg.values).toContain(7);
+  });
+
+  it('does nothing when counts object is empty', async () => {
+    await updateGenerationCountsInDb(1, {});
+    expect(mockDb).not.toHaveBeenCalled();
+  });
+
+  it('includes updated_at = NOW() in SET clause', async () => {
+    mockDb.mockResolvedValue({ rows: [] });
+    await updateGenerationCountsInDb(1, { context_count: 5 });
+    const callArg = mockDb.mock.calls[0][0] as { text: string };
+    expect(callArg.text).toContain('updated_at = NOW()');
+  });
+});
+
+// ── getGenerationSummaryFromDb ────────────────────────────────────────────────
+
+describe('getGenerationSummaryFromDb', () => {
+  const summaryGenRow = {
+    generation_id: 7,
+    generation_number: 1,
+    status: 'DRAFT',
+    context_count: 100,
+    trigger_count: 10,
+    enrichment_table_count: 1,
+    suite_name: 'Q3 Edge Cases',
+    associated_rule: 'Rule 001',
+    primary_txtp: 'pacs.008',
+    iteration_number: 0,
+  };
+
+  it('returns null when generation not found', async () => {
+    mockDb.mockResolvedValueOnce({ rows: [] } as never);
+    const result = await getGenerationSummaryFromDb(999);
+    expect(result).toBeNull();
+  });
+
+  it('returns summary with context configs and enrichment table names', async () => {
+    mockDb
+      .mockResolvedValueOnce({ rows: [summaryGenRow] } as never)
+      .mockResolvedValueOnce({ rows: [{ txtp: 'pacs.008', txtp_version: '001.08', message_count: 100 }] } as never)
+      .mockResolvedValueOnce({ rows: [{ table_name: 'account_enrichment' }] } as never);
+
+    const result = await getGenerationSummaryFromDb(7);
+
+    expect(result).not.toBeNull();
+    expect(result!.generation_id).toBe(7);
+    expect(result!.suite_name).toBe('Q3 Edge Cases');
+    expect(result!.associated_rule).toBe('Rule 001');
+    expect(result!.primary_txtp).toBe('pacs.008');
+    expect(result!.context_txtp_configs).toHaveLength(1);
+    expect(result!.context_txtp_configs[0]).toEqual({ txtp: 'pacs.008', txtp_version: '001.08', message_count: 100 });
+    expect(result!.enrichment_table_names).toEqual(['account_enrichment']);
+    expect(result!.context_count).toBe(100);
+    expect(result!.trigger_count).toBe(10);
+    expect(result!.enrichment_table_count).toBe(1);
+  });
+
+  it('returns empty arrays when no context configs or enrichment tables', async () => {
+    mockDb
+      .mockResolvedValueOnce({ rows: [summaryGenRow] } as never)
+      .mockResolvedValueOnce({ rows: [] } as never)
+      .mockResolvedValueOnce({ rows: [] } as never);
+
+    const result = await getGenerationSummaryFromDb(7);
+
+    expect(result!.context_txtp_configs).toEqual([]);
+    expect(result!.enrichment_table_names).toEqual([]);
+  });
+
+  it('handles null associated_rule and primary_txtp', async () => {
+    const rowNoRule = { ...summaryGenRow, associated_rule: null, primary_txtp: null };
+    mockDb
+      .mockResolvedValueOnce({ rows: [rowNoRule] } as never)
+      .mockResolvedValueOnce({ rows: [] } as never)
+      .mockResolvedValueOnce({ rows: [] } as never);
+
+    const result = await getGenerationSummaryFromDb(7);
+
+    expect(result!.associated_rule).toBeNull();
+    expect(result!.primary_txtp).toBeNull();
+  });
+});
+
+// ── updateWizardProgressInDb ─────────────────────────────────────────────────
+
+describe('updateWizardProgressInDb', () => {
+  it('updates wizard_snapshot with currentStep and completedSteps array', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+
+    await updateWizardProgressInDb(7, 3, [1, 2, 3]);
+
+    const callArg = mockDb.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('UPDATE trs_suite_generations');
+    expect(callArg.text).toContain('wizard_snapshot');
+    expect(callArg.text).toContain('currentStep');
+    expect(callArg.text).toContain('completedSteps');
+    expect(callArg.values[0]).toBe(3);
+    expect(callArg.values[1]).toBe(JSON.stringify([1, 2, 3]));
+    expect(callArg.values[2]).toBe(7);
+  });
+
+  it('serializes completedSteps array as JSON', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+
+    await updateWizardProgressInDb(7, 5, [1, 2, 3, 4, 5]);
+
+    const callArg = mockDb.mock.calls[0][0] as { values: unknown[] };
+    expect(callArg.values[1]).toBe('[1,2,3,4,5]');
+  });
+
+  it('handles step 1 with single completed step', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+
+    await updateWizardProgressInDb(7, 1, [1]);
+
+    const callArg = mockDb.mock.calls[0][0] as { values: unknown[] };
+    expect(callArg.values[0]).toBe(1);
+    expect(callArg.values[1]).toBe('[1]');
+    expect(callArg.values[2]).toBe(7);
+  });
+
+  it('includes updated_at = NOW() in SET clause', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+    await updateWizardProgressInDb(7, 2, [1, 2]);
+    const callArg = mockDb.mock.calls[0][0] as { text: string };
+    expect(callArg.text).toContain('updated_at = NOW()');
+  });
+});
+
+describe('resumeGenerationInDb', () => {
+  it('returns latest DRAFT generation when found', async () => {
+    const row = {
+      id: 1,
+      suite_id: 42,
+      generation_number: 2,
+      status: 'DRAFT',
+      simulation_type: 'SINGLE_RULE',
+      wizard_snapshot: {},
+      generation_metadata: {},
+      created_by: 'user-1',
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    mockDb.mockResolvedValue({ rows: [row] } as never);
+
+    const result = await resumeGenerationInDb(42);
+
+    expect(result).not.toBeNull();
+    expect(result?.suite_id).toBe(42);
+    const callArg = mockDb.mock.calls[0][0] as { text: string; values: unknown[] };
+    expect(callArg.text).toContain('DRAFT');
+    expect(callArg.values[0]).toBe(42);
+  });
+
+  it('returns null when no DRAFT generation exists', async () => {
+    mockDb.mockResolvedValue({ rows: [] } as never);
+    const result = await resumeGenerationInDb(99);
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/unit/simulation-suites.logic.service.test.ts
+++ b/__tests__/unit/simulation-suites.logic.service.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+process.env.PORT = '3000';
+process.env.ACTIVE_CONDITIONS_ONLY = 'true';
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import * as simulationSuitesService from '../../src/services/simulation-suites.logic.service';
+import * as simulationSuitesRepository from '../../src/repositories/simulation-studio/suites.repository';
+import * as trsGenService from '../../src/services/trs-suite-generation.logic.service';
+import * as triggerService from '../../src/services/trigger-txtp-config.logic.service';
+
+jest.mock('../../src/repositories/simulation-studio/suites.repository', () => ({
+  getSimulationSuitesFromDb: jest.fn(),
+  getSimulationSuiteByIdFromDb: jest.fn(),
+  createSimulationSuiteInDb: jest.fn(),
+  updateSimulationSuiteInDb: jest.fn(),
+}));
+
+jest.mock('../../src/services/trs-suite-generation.logic.service', () => ({
+  createSuiteGeneration: jest.fn(),
+  createContextTxtpConfig: jest.fn(),
+}));
+
+jest.mock('../../src/services/trigger-txtp-config.logic.service', () => ({
+  createTriggerTxtpConfig: jest.fn(),
+}));
+
+describe('Simulation Suites Logic Service', () => {
+  const mockTenantId = 'tenant-123';
+  const mockUserId = 'user-456';
+  const mockUserEmail = 'test@example.com';
+
+  const mockSuite = {
+    id: 1,
+    tenant_id: mockTenantId,
+    name: 'Q3 Edge Cases',
+    description: 'Suite for regression tests',
+    simulation_type: 'SINGLE_RULE',
+    status: 'DRAFT',
+    rule_name: 'Rule 002',
+    rule_version: 'v1.0',
+    primary_txtp: 'pacs.008',
+    primary_txtp_version: 'v1.0',
+    iteration_count: 0,
+    run_count: 0,
+    wizard_progress: { currentStep: 1, completedSteps: [1] },
+    metadata: {},
+    created_by: mockUserId,
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    updated_at: new Date('2026-05-01T00:00:00.000Z'),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (trsGenService.createSuiteGeneration as jest.Mock).mockResolvedValue({ id: 7, suite_id: 1 });
+    (trsGenService.createContextTxtpConfig as jest.Mock).mockResolvedValue({ context_txtp_config_id: 1, field_strategies: [] });
+    (triggerService.createTriggerTxtpConfig as jest.Mock).mockResolvedValue({ trigger_txtp_config_id: 1, field_overrides: [] });
+  });
+
+  describe('getSimulationSuites', () => {
+    it('should return simulation suites list', async () => {
+      const options = { tenantId: mockTenantId, limit: 20, offset: 0 };
+      const response = { data: [mockSuite], total: 1, limit: 20, offset: 0 };
+      (simulationSuitesRepository.getSimulationSuitesFromDb as jest.Mock).mockResolvedValue(response);
+
+      const result = await simulationSuitesService.getSimulationSuites(options as any);
+
+      expect(result).toEqual(response);
+      expect(simulationSuitesRepository.getSimulationSuitesFromDb).toHaveBeenCalledWith(options);
+    });
+
+    it('should wrap repository errors', async () => {
+      (simulationSuitesRepository.getSimulationSuitesFromDb as jest.Mock).mockRejectedValue(new Error('DB failure'));
+
+      await expect(simulationSuitesService.getSimulationSuites({ tenantId: mockTenantId } as any)).rejects.toThrow(
+        'Failed to retrieve simulation suites: DB failure',
+      );
+    });
+  });
+
+  describe('getSimulationSuiteById', () => {
+    it('should return suite when found', async () => {
+      (simulationSuitesRepository.getSimulationSuiteByIdFromDb as jest.Mock).mockResolvedValue(mockSuite);
+
+      const result = await simulationSuitesService.getSimulationSuiteById(1, mockTenantId);
+
+      expect(result).toEqual(mockSuite);
+      expect(simulationSuitesRepository.getSimulationSuiteByIdFromDb).toHaveBeenCalledWith(1, mockTenantId);
+    });
+
+    it('should throw not found when suite is missing', async () => {
+      (simulationSuitesRepository.getSimulationSuiteByIdFromDb as jest.Mock).mockResolvedValue(null);
+
+      await expect(simulationSuitesService.getSimulationSuiteById(99, mockTenantId)).rejects.toThrow(
+        'Simulation suite with id 99 not found',
+      );
+    });
+
+    it('wraps non-HttpException repo error in 500', async () => {
+      (simulationSuitesRepository.getSimulationSuiteByIdFromDb as jest.Mock).mockRejectedValue(new Error('DB crash') as never);
+
+      await expect(simulationSuitesService.getSimulationSuiteById(1, mockTenantId)).rejects.toThrow(
+        'Failed to retrieve simulation suite: DB crash',
+      );
+    });
+  });
+
+  describe('createSimulationSuite', () => {
+    it('should create suite successfully', async () => {
+      const payload = {
+        name: 'Q3 Edge Cases',
+        description: 'Suite for regression tests',
+        rule_name: 'Rule 002',
+      };
+
+      (simulationSuitesRepository.createSimulationSuiteInDb as jest.Mock).mockResolvedValue(mockSuite);
+
+      const result = await simulationSuitesService.createSimulationSuite(payload as any, mockTenantId, mockUserId, mockUserEmail);
+
+      expect(result).toEqual({ ...mockSuite, generation_id: 7 });
+      expect(simulationSuitesRepository.createSimulationSuiteInDb).toHaveBeenCalledWith(
+        expect.objectContaining(payload),
+        mockTenantId,
+        mockUserId,
+        mockUserEmail,
+      );
+    });
+
+    it('should validate empty name', async () => {
+      await expect(
+        simulationSuitesService.createSimulationSuite({ name: '   ' } as any, mockTenantId, mockUserId, mockUserEmail),
+      ).rejects.toThrow('Simulation suite name is required');
+
+      expect(simulationSuitesRepository.createSimulationSuiteInDb).not.toHaveBeenCalled();
+    });
+
+    it('should validate name length', async () => {
+      await expect(
+        simulationSuitesService.createSimulationSuite({ name: 'A'.repeat(51) } as any, mockTenantId, mockUserId, mockUserEmail),
+      ).rejects.toThrow('Simulation suite name cannot exceed 50 characters');
+    });
+
+    it('should validate description length', async () => {
+      await expect(
+        simulationSuitesService.createSimulationSuite(
+          { name: 'Valid Name', description: 'D'.repeat(301) } as any,
+          mockTenantId,
+          mockUserId,
+          mockUserEmail,
+        ),
+      ).rejects.toThrow('Simulation suite description cannot exceed 300 characters');
+    });
+
+    it('wraps non-HttpException error from trigger config creation in 500', async () => {
+      (simulationSuitesRepository.createSimulationSuiteInDb as jest.Mock).mockResolvedValue(mockSuite);
+      jest.spyOn(triggerService, 'createTriggerTxtpConfig').mockRejectedValue(new Error('trigger DB fail'));
+
+      await expect(simulationSuitesService.createSimulationSuite({ name: 'Test' } as any, mockTenantId, mockUserId)).rejects.toThrow(
+        'Failed to create simulation suite: trigger DB fail',
+      );
+    });
+  });
+
+  describe('updateSimulationSuite', () => {
+    it('should update suite successfully', async () => {
+      const payload = {
+        description: 'Updated description',
+        wizard_progress: { currentStep: 2, completedSteps: [1] },
+      };
+
+      const updatedSuite = {
+        ...mockSuite,
+        description: 'Updated description',
+      };
+
+      (simulationSuitesRepository.updateSimulationSuiteInDb as jest.Mock).mockResolvedValue(updatedSuite);
+
+      const result = await simulationSuitesService.updateSimulationSuite(1, mockTenantId, payload as any);
+
+      expect(result).toEqual(updatedSuite);
+      expect(simulationSuitesRepository.updateSimulationSuiteInDb).toHaveBeenCalledWith(1, mockTenantId, payload);
+    });
+
+    it('should validate empty name during update', async () => {
+      await expect(simulationSuitesService.updateSimulationSuite(1, mockTenantId, { name: '   ' } as any)).rejects.toThrow(
+        'Simulation suite name cannot be empty',
+      );
+
+      expect(simulationSuitesRepository.updateSimulationSuiteInDb).not.toHaveBeenCalled();
+    });
+
+    it('should validate name length during update', async () => {
+      await expect(simulationSuitesService.updateSimulationSuite(1, mockTenantId, { name: 'A'.repeat(51) } as any)).rejects.toThrow(
+        'Simulation suite name cannot exceed 50 characters',
+      );
+    });
+
+    it('should throw not found when suite does not exist', async () => {
+      (simulationSuitesRepository.updateSimulationSuiteInDb as jest.Mock).mockResolvedValue(null);
+
+      await expect(simulationSuitesService.updateSimulationSuite(99, mockTenantId, { status: 'DRAFT' } as any)).rejects.toThrow(
+        'Simulation suite with id 99 not found',
+      );
+    });
+
+    it('should wrap repository errors during update', async () => {
+      (simulationSuitesRepository.updateSimulationSuiteInDb as jest.Mock).mockRejectedValue(new Error('DB update failed'));
+
+      await expect(simulationSuitesService.updateSimulationSuite(1, mockTenantId, { status: 'DRAFT' } as any)).rejects.toThrow(
+        'Failed to update simulation suite: DB update failed',
+      );
+    });
+  });
+});

--- a/__tests__/unit/trigger-txtp-config.logic.service.test.ts
+++ b/__tests__/unit/trigger-txtp-config.logic.service.test.ts
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/trigger-txtp-configs.repository', () => ({
+  createTriggerTxtpConfigInDb: jest.fn(),
+  updateTriggerTxtpConfigInDb: jest.fn(),
+  getTriggerTxtpConfigsByGenerationId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/trigger-field-strategies.repository', () => ({
+  upsertTriggerFieldOverrideInDb: jest.fn(),
+  getTriggerFieldOverridesByConfigId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
+  getSchemaByTransactionType: jest.fn(),
+}));
+
+jest.mock('@tazama-lf/tcs-lib', () => ({
+  ContentType: { XML: 'application/xml', JSON: 'application/json' },
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import { HttpException } from '../../src/utils/error';
+import * as triggerConfigRepo from '../../src/repositories/simulation-studio/trigger-txtp-configs.repository';
+import * as triggerOverrideRepo from '../../src/repositories/simulation-studio/trigger-field-strategies.repository';
+import * as tcsRepo from '../../src/repositories/configuration/tcs.config.repository';
+import {
+  createTriggerConfigWithDefaultStrategies,
+  createTriggerTxtpConfig,
+  addTriggerTxtpConfig,
+  getTriggerConfigsWithOverrides,
+  bulkUpdateTriggerConfigs,
+  getTriggerFieldOverridesForConfig,
+} from '../../src/services/trigger-txtp-config.logic.service';
+import type { SuiteTriggerTxtpConfig, TriggerFieldOverride } from '../../src/interface/suite-generation.interface';
+
+const mockTriggerConfig: SuiteTriggerTxtpConfig = {
+  id: 20,
+  generation_id: 1,
+  txtp: 'pacs.008',
+  txtp_version: '001.08',
+  display_order: 1,
+  message_count: 1,
+  link_to_context_pairs: false,
+  payload_template_json: { amount: 100, currency: 'USD' },
+  generator_profile: {},
+  created_at: new Date(),
+};
+
+const mockFieldOverride: TriggerFieldOverride = {
+  id: 1,
+  trigger_txtp_config_id: 20,
+  field_path: 'amount',
+  override_type: 'null',
+  generator_options: {},
+  created_at: new Date(),
+};
+
+const tcsRowJson = {
+  schema: { type: 'object', properties: { amount: {}, currency: {} } },
+  content_type: 'application/json',
+  payload_json: { amount: 100, currency: 'USD' },
+  payload_xml: null,
+};
+
+const tcsRowXml = {
+  schema: { type: 'object' },
+  content_type: 'application/xml',
+  payload_xml: { amount: '<xml>' },
+  payload_json: null,
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── createTriggerConfigWithDefaultStrategies ─────────────────────────────────
+
+describe('createTriggerConfigWithDefaultStrategies', () => {
+  it('fetches payload, inserts config, seeds null override for each payload field', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (triggerConfigRepo.createTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    const result = await createTriggerConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 1,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(tcsRepo.getSchemaByTransactionType).toHaveBeenCalledWith('pacs.008', '001.08', 'tenant-001');
+    expect(triggerConfigRepo.createTriggerTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation_id: 1,
+        txtp: 'pacs.008',
+        message_count: 1,
+        payload_template_json: tcsRowJson.payload_json,
+      }),
+    );
+    // payload has 2 leaf fields: amount, currency
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).toHaveBeenCalledTimes(2);
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).toHaveBeenCalledWith(20, expect.objectContaining({ override_type: 'null' }));
+    expect(result.trigger_txtp_config_id).toBe(20);
+    expect(result.field_overrides).toHaveLength(2);
+  });
+
+  it('uses payload_xml when content_type is XML', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowXml);
+    (triggerConfigRepo.createTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    await createTriggerConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 1,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(triggerConfigRepo.createTriggerTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ payload_template_json: tcsRowXml.payload_xml }),
+    );
+  });
+
+  it('seeds no overrides when payload is null', async () => {
+    const tcsNoPayload = { ...tcsRowJson, payload_json: null };
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsNoPayload);
+    (triggerConfigRepo.createTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue({ ...mockTriggerConfig, payload_template_json: {} });
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    const result = await createTriggerConfigWithDefaultStrategies({
+      generationId: 1,
+      txtp: 'pacs.008',
+      txtpVersion: '001.08',
+      messageCount: 1,
+      displayOrder: 1,
+      tenantId: 'tenant-001',
+    });
+
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).not.toHaveBeenCalled();
+    expect(result.field_overrides).toHaveLength(0);
+  });
+
+  it('throws when tcs_config row not found', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('Not found'));
+    await expect(
+      createTriggerConfigWithDefaultStrategies({
+        generationId: 1,
+        txtp: 'x',
+        txtpVersion: '1',
+        messageCount: 1,
+        displayOrder: 1,
+        tenantId: 'tenant',
+      }),
+    ).rejects.toThrow('Not found');
+  });
+});
+
+// ── createTriggerTxtpConfig ──────────────────────────────────────────────────
+
+describe('createTriggerTxtpConfig', () => {
+  it('calls factory with display_order=1 and message_count=1', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (triggerConfigRepo.createTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    await createTriggerTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001');
+
+    expect(triggerConfigRepo.createTriggerTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 1, message_count: 1 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(createTriggerTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('maps missing tcs_config to HttpException 404', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(new Error('Configuration not found'));
+    await expect(createTriggerTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('bad', 404);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue(err);
+    await expect(createTriggerTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockRejectedValue('string error');
+    await expect(createTriggerTxtpConfig(1, 'pacs.008', '001.08', 'tenant-001')).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── addTriggerTxtpConfig ─────────────────────────────────────────────────────
+
+describe('addTriggerTxtpConfig', () => {
+  it('sets display_order = existing count + 1', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockTriggerConfig]);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (triggerConfigRepo.createTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue({ ...mockTriggerConfig, id: 21, display_order: 2 });
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    const result = await addTriggerTxtpConfig(1, { txtp: 'pacs.002', txtp_version: '001.08', message_count: 2 }, 'tenant-001');
+
+    expect(triggerConfigRepo.createTriggerTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 2, message_count: 2 }),
+    );
+    expect(result.trigger_txtp_config_id).toBe(21);
+  });
+
+  it('defaults message_count to 1 when not provided', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([]);
+    (tcsRepo.getSchemaByTransactionType as jest.Mock).mockResolvedValue(tcsRowJson);
+    (triggerConfigRepo.createTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    await addTriggerTxtpConfig(1, { txtp: 'pacs.008', txtp_version: '001.08' }, 'tenant-001');
+
+    expect(triggerConfigRepo.createTriggerTxtpConfigInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ message_count: 1, display_order: 1 }),
+    );
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(addTriggerTxtpConfig(1, { txtp: 'x', txtp_version: '1' }, 'tenant')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('conflict', 409);
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(err);
+    await expect(addTriggerTxtpConfig(1, { txtp: 'x', txtp_version: '1' }, 'tenant')).rejects.toBe(err);
+  });
+});
+
+// ── getTriggerConfigsWithOverrides ───────────────────────────────────────────
+
+describe('getTriggerConfigsWithOverrides', () => {
+  it('returns all configs with their field overrides', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockTriggerConfig]);
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockResolvedValue([mockFieldOverride]);
+
+    const result = await getTriggerConfigsWithOverrides(1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].trigger_txtp_config_id).toBe(20);
+    expect(result[0].field_overrides).toEqual([mockFieldOverride]);
+    expect(triggerOverrideRepo.getTriggerFieldOverridesByConfigId).toHaveBeenCalledWith(20);
+  });
+
+  it('returns empty array when no configs', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([]);
+    expect(await getTriggerConfigsWithOverrides(1)).toEqual([]);
+  });
+
+  it('fetches overrides for each config independently', async () => {
+    const config2 = { ...mockTriggerConfig, id: 21, txtp: 'pacs.002' };
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockTriggerConfig, config2]);
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockResolvedValue([mockFieldOverride]);
+
+    const result = await getTriggerConfigsWithOverrides(1);
+
+    expect(result).toHaveLength(2);
+    expect(triggerOverrideRepo.getTriggerFieldOverridesByConfigId).toHaveBeenCalledTimes(2);
+    expect(triggerOverrideRepo.getTriggerFieldOverridesByConfigId).toHaveBeenCalledWith(20);
+    expect(triggerOverrideRepo.getTriggerFieldOverridesByConfigId).toHaveBeenCalledWith(21);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getTriggerConfigsWithOverrides(1)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockRejectedValue('string error');
+    await expect(getTriggerConfigsWithOverrides(1)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── bulkUpdateTriggerConfigs ─────────────────────────────────────────────────
+
+describe('bulkUpdateTriggerConfigs', () => {
+  beforeEach(() => {
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockTriggerConfig]);
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockResolvedValue([mockFieldOverride]);
+  });
+
+  it('updates message_count and upserts overrides, returns updated configs', async () => {
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    const result = await bulkUpdateTriggerConfigs(1, [
+      {
+        trigger_txtp_config_id: 20,
+        message_count: 3,
+        field_overrides: [{ field_path: 'amount', override_type: 'static', static_value: '999' }],
+      },
+    ]);
+
+    expect(triggerConfigRepo.updateTriggerTxtpConfigInDb).toHaveBeenCalledWith(20, { message_count: 3 });
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).toHaveBeenCalledWith(20, {
+      field_path: 'amount',
+      override_type: 'static',
+      static_value: '999',
+    });
+    expect(result[0].trigger_txtp_config_id).toBe(20);
+  });
+
+  it('skips update when no scalar fields provided', async () => {
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    await bulkUpdateTriggerConfigs(1, [{ trigger_txtp_config_id: 20, field_overrides: [{ field_path: 'amount', override_type: 'null' }] }]);
+
+    expect(triggerConfigRepo.updateTriggerTxtpConfigInDb).not.toHaveBeenCalled();
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips upsert when field_overrides is empty array', async () => {
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+
+    await bulkUpdateTriggerConfigs(1, [{ trigger_txtp_config_id: 20, message_count: 2, field_overrides: [] }]);
+
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).not.toHaveBeenCalled();
+  });
+
+  it('skips upsert when field_overrides absent', async () => {
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+
+    await bulkUpdateTriggerConfigs(1, [{ trigger_txtp_config_id: 20, message_count: 2 }]);
+
+    expect(triggerOverrideRepo.upsertTriggerFieldOverrideInDb).not.toHaveBeenCalled();
+  });
+
+  it('processes multiple items in parallel', async () => {
+    const config2 = { ...mockTriggerConfig, id: 21 };
+    (triggerConfigRepo.getTriggerTxtpConfigsByGenerationId as jest.Mock).mockResolvedValue([mockTriggerConfig, config2]);
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(mockTriggerConfig);
+    (triggerOverrideRepo.upsertTriggerFieldOverrideInDb as jest.Mock).mockResolvedValue(mockFieldOverride);
+
+    const result = await bulkUpdateTriggerConfigs(1, [
+      { trigger_txtp_config_id: 20, message_count: 2 },
+      {
+        trigger_txtp_config_id: 21,
+        message_count: 3,
+        field_overrides: [{ field_path: 'amount', override_type: 'range', range_min: 1, range_max: 100 }],
+      },
+    ]);
+
+    expect(triggerConfigRepo.updateTriggerTxtpConfigInDb).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(bulkUpdateTriggerConfigs(1, [{ trigger_txtp_config_id: 20, message_count: 2 }])).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue(err);
+    await expect(bulkUpdateTriggerConfigs(1, [{ trigger_txtp_config_id: 20, message_count: 2 }])).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (triggerConfigRepo.updateTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(bulkUpdateTriggerConfigs(1, [{ trigger_txtp_config_id: 20, message_count: 2 }])).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── getTriggerFieldOverridesForConfig ────────────────────────────────────────
+
+describe('getTriggerFieldOverridesForConfig', () => {
+  it('returns field overrides for a config', async () => {
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockResolvedValue([mockFieldOverride]);
+
+    const result = await getTriggerFieldOverridesForConfig(20);
+
+    expect(result).toEqual([mockFieldOverride]);
+    expect(triggerOverrideRepo.getTriggerFieldOverridesByConfigId).toHaveBeenCalledWith(20);
+  });
+
+  it('returns empty array when no overrides', async () => {
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockResolvedValue([]);
+    expect(await getTriggerFieldOverridesForConfig(20)).toEqual([]);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getTriggerFieldOverridesForConfig(20)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (triggerOverrideRepo.getTriggerFieldOverridesByConfigId as jest.Mock).mockRejectedValue('string error');
+    await expect(getTriggerFieldOverridesForConfig(20)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/__tests__/unit/trs-suite-generation-summary.test.ts
+++ b/__tests__/unit/trs-suite-generation-summary.test.ts
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/suite-generations.repository', () => ({
+  createSuiteGenerationInDb: jest.fn(),
+  getNextGenerationNumber: jest.fn(),
+  getGenerationsBySuiteId: jest.fn(),
+  getLatestGenerationBySuiteId: jest.fn(),
+  updateGenerationCountsInDb: jest.fn(),
+  getGenerationSummaryFromDb: jest.fn(),
+  updateWizardProgressInDb: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/trigger-txtp-configs.repository', () => ({
+  deleteTriggerTxtpConfigInDb: jest.fn(),
+}));
+
+jest.mock('../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/context-txtp-configs.repository', () => ({}));
+jest.mock('../../src/repositories/simulation-studio/context-field-strategies.repository', () => ({}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import { HttpException } from '../../src/utils/error';
+import * as generationsRepo from '../../src/repositories/simulation-studio/suite-generations.repository';
+import * as triggerRepo from '../../src/repositories/simulation-studio/trigger-txtp-configs.repository';
+import * as dbService from '../../src/services/database.logic.service';
+import {
+  recalculateGenerationCounts,
+  getGenerationSummary,
+  updateWizardProgress,
+  deleteTriggerTxtpConfig,
+} from '../../src/services/trs-suite-generation.logic.service';
+
+const mockSummary = {
+  generation_id: 7,
+  generation_number: 1,
+  status: 'DRAFT',
+  suite_name: 'Q3 Edge Cases',
+  associated_rule: 'Rule 001',
+  primary_txtp: 'pacs.008',
+  context_txtp_configs: [{ txtp: 'pacs.008', txtp_version: '001.08', message_count: 100 }],
+  enrichment_table_names: ['account_enrichment'],
+  context_count: 100,
+  trigger_count: 10,
+  enrichment_table_count: 1,
+  iteration_number: 0,
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── recalculateGenerationCounts ───────────────────────────────────────────────
+
+describe('recalculateGenerationCounts', () => {
+  it('sums message_count from all 3 tables and calls updateGenerationCountsInDb', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ total: '100' }] }) // context
+      .mockResolvedValueOnce({ rows: [{ total: '10' }] }) // trigger
+      .mockResolvedValueOnce({ rows: [{ total: '1' }] }); // enrichment
+    (generationsRepo.updateGenerationCountsInDb as jest.Mock).mockResolvedValue(undefined);
+
+    await recalculateGenerationCounts(7);
+
+    expect(dbService.handlePostExecuteSqlStatement).toHaveBeenCalledTimes(3);
+    expect(generationsRepo.updateGenerationCountsInDb).toHaveBeenCalledWith(7, {
+      context_count: 100,
+      trigger_count: 10,
+      enrichment_table_count: 1,
+    });
+  });
+
+  it('handles zero totals when tables are empty', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] });
+    (generationsRepo.updateGenerationCountsInDb as jest.Mock).mockResolvedValue(undefined);
+
+    await recalculateGenerationCounts(7);
+
+    expect(generationsRepo.updateGenerationCountsInDb).toHaveBeenCalledWith(7, {
+      context_count: 0,
+      trigger_count: 0,
+      enrichment_table_count: 0,
+    });
+  });
+
+  it('wraps DB error in HttpException 500', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(recalculateGenerationCounts(7)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('forbidden', 403);
+    (dbService.handlePostExecuteSqlStatement as jest.Mock).mockRejectedValue(err);
+    await expect(recalculateGenerationCounts(7)).rejects.toBe(err);
+  });
+
+  it('queries all 3 config tables with correct SQL patterns', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] });
+    (generationsRepo.updateGenerationCountsInDb as jest.Mock).mockResolvedValue(undefined);
+
+    await recalculateGenerationCounts(7);
+
+    const calls = (dbService.handlePostExecuteSqlStatement as jest.Mock).mock.calls;
+    expect((calls[0][0] as { text: string }).text).toContain('trs_suite_context_txtp_configs');
+    expect((calls[1][0] as { text: string }).text).toContain('trs_suite_trigger_txtp_configs');
+    expect((calls[2][0] as { text: string }).text).toContain('trs_suite_enrichment_tables');
+  });
+});
+
+// ── getGenerationSummary ──────────────────────────────────────────────────────
+
+describe('getGenerationSummary', () => {
+  it('returns summary from repo', async () => {
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockResolvedValue(mockSummary);
+
+    const result = await getGenerationSummary(7);
+
+    expect(result).toEqual(mockSummary);
+    expect(generationsRepo.getGenerationSummaryFromDb).toHaveBeenCalledWith(7);
+  });
+
+  it('returns null when generation not found', async () => {
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockResolvedValue(null);
+    expect(await getGenerationSummary(999)).toBeNull();
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getGenerationSummary(7)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockRejectedValue(err);
+    await expect(getGenerationSummary(7)).rejects.toBe(err);
+  });
+});
+
+// ── updateWizardProgress ──────────────────────────────────────────────────────
+
+describe('updateWizardProgress', () => {
+  it('calls updateWizardProgressInDb with generationId, currentStep and completedSteps', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockResolvedValue(undefined);
+
+    await updateWizardProgress(7, 3, [1, 2, 3]);
+
+    expect(generationsRepo.updateWizardProgressInDb).toHaveBeenCalledWith(7, 3, [1, 2, 3]);
+  });
+
+  it('handles step 1 with single completed step', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockResolvedValue(undefined);
+
+    await updateWizardProgress(7, 1, [1]);
+
+    expect(generationsRepo.updateWizardProgressInDb).toHaveBeenCalledWith(7, 1, [1]);
+  });
+
+  it('handles multiple completed steps', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockResolvedValue(undefined);
+
+    await updateWizardProgress(7, 5, [1, 2, 3, 4, 5]);
+
+    expect(generationsRepo.updateWizardProgressInDb).toHaveBeenCalledWith(7, 5, [1, 2, 3, 4, 5]);
+  });
+
+  it('wraps DB error in HttpException 500', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(updateWizardProgress(7, 2, [1, 2])).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockRejectedValue(err);
+    await expect(updateWizardProgress(7, 2, [1, 2])).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(updateWizardProgress(7, 2, [1, 2])).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── deleteTriggerTxtpConfig ───────────────────────────────────────────────────
+
+describe('deleteTriggerTxtpConfig', () => {
+  it('deletes trigger config successfully', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(true);
+    await expect(deleteTriggerTxtpConfig(20)).resolves.toBeUndefined();
+    expect(triggerRepo.deleteTriggerTxtpConfigInDb).toHaveBeenCalledWith(20);
+  });
+
+  it('throws 404 when config not found', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(false);
+    await expect(deleteTriggerTxtpConfig(999)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('wraps DB error in HttpException 500', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('DB fail'));
+    await expect(deleteTriggerTxtpConfig(20)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('forbidden', 403);
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue(err);
+    await expect(deleteTriggerTxtpConfig(20)).rejects.toBe(err);
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(deleteTriggerTxtpConfig(20)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/__tests__/unit/trs-suite-generation.logic.service.test.ts
+++ b/__tests__/unit/trs-suite-generation.logic.service.test.ts
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/repositories/simulation-studio/suite-generations.repository', () => ({
+  createSuiteGenerationInDb: jest.fn(),
+  getGenerationsBySuiteId: jest.fn(),
+  getLatestGenerationBySuiteId: jest.fn(),
+  resumeGenerationInDb: jest.fn(),
+  updateGenerationCountsInDb: jest.fn(),
+  getGenerationSummaryFromDb: jest.fn(),
+  updateWizardProgressInDb: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/trigger-txtp-configs.repository', () => ({
+  deleteTriggerTxtpConfigInDb: jest.fn(),
+}));
+
+jest.mock('../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: jest.fn(),
+  withConfigurationTransaction: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/context-txtp-configs.repository', () => ({
+  createContextTxtpConfigInDb: jest.fn(),
+  updateContextTxtpConfigInDb: jest.fn(),
+  getContextTxtpConfigsByGenerationId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/simulation-studio/context-field-strategies.repository', () => ({
+  upsertFieldStrategyInDb: jest.fn(),
+  getFieldStrategiesByContextConfigId: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
+  getSchemaByTransactionType: jest.fn(),
+}));
+
+jest.mock('@tazama-lf/tcs-lib', () => ({
+  ContentType: { XML: 'application/xml', JSON: 'application/json' },
+}));
+
+jest.mock('../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+  configuration: {},
+}));
+
+import { HttpException } from '../../src/utils/error';
+import * as generationsRepo from '../../src/repositories/simulation-studio/suite-generations.repository';
+import * as triggerRepo from '../../src/repositories/simulation-studio/trigger-txtp-configs.repository';
+import * as dbService from '../../src/services/database.logic.service';
+import {
+  createSuiteGeneration,
+  getGenerationsForSuite,
+  getLatestGenerationForSuite,
+  resumeGeneration,
+  updateWizardProgress,
+  deleteTriggerTxtpConfig,
+  recalculateGenerationCounts,
+  getGenerationSummary,
+} from '../../src/services/trs-suite-generation.logic.service';
+import type { SimulationSuite } from '../../src/interface/simulation-suites.interface';
+import type { SuiteGeneration } from '../../src/interface/suite-generation.interface';
+
+const mockSuite: SimulationSuite = {
+  id: 42,
+  tenant_id: 'tenant-001',
+  name: 'Test Suite',
+  simulation_type: 'SINGLE_RULE' as any,
+  status: 'DRAFT' as any,
+  rule_repo: 'repo-a',
+  rule_version: 'v1.0',
+  primary_txtp: 'pacs.008',
+  primary_txtp_version: '001.08',
+  iteration_count: 0,
+  run_count: 0,
+  wizard_progress: { completedSteps: [1] },
+  metadata: {},
+  created_by: 'user-1',
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+const mockGeneration: SuiteGeneration = {
+  id: 1,
+  suite_id: 42,
+  generation_number: 1,
+  status: 'DRAFT' as any,
+  simulation_type: 'SINGLE_RULE' as any,
+  wizard_snapshot: {},
+  generation_metadata: {},
+  created_by: 'user-1',
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── createSuiteGeneration ────────────────────────────────────────────────────
+
+describe('createSuiteGeneration', () => {
+  it('creates generation row using atomic repository insert', async () => {
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockResolvedValue(mockGeneration);
+
+    const result = await createSuiteGeneration(mockSuite, 'user-1', 'user@test.com');
+
+    expect(result).toEqual(mockGeneration);
+    expect(generationsRepo.createSuiteGenerationInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ suite_id: 42, simulation_type: 'SINGLE_RULE' }),
+      'user-1',
+      'user@test.com',
+    );
+  });
+
+  it('works without userEmail', async () => {
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockResolvedValue({ ...mockGeneration, generation_number: 2 });
+
+    const result = await createSuiteGeneration(mockSuite, 'user-1');
+
+    expect(result.generation_number).toBe(2);
+    expect(generationsRepo.createSuiteGenerationInDb).toHaveBeenCalledWith(expect.anything(), 'user-1', undefined);
+  });
+
+  it('passes wizard_progress as wizard_snapshot', async () => {
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockResolvedValue(mockGeneration);
+    const suiteWithProgress = { ...mockSuite, wizard_progress: { currentStep: 1, completedSteps: [1] } };
+
+    await createSuiteGeneration(suiteWithProgress, 'user-1');
+
+    expect(generationsRepo.createSuiteGenerationInDb).toHaveBeenCalledWith(
+      expect.objectContaining({ wizard_snapshot: { currentStep: 1, completedSteps: [1] } }),
+      expect.any(String),
+      undefined,
+    );
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const httpErr = new HttpException('conflict', 409);
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockRejectedValue(httpErr);
+    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toBe(httpErr);
+  });
+
+  it('wraps unknown Error in HttpException 500', async () => {
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockRejectedValue(new Error('DB down'));
+    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (generationsRepo.createSuiteGenerationInDb as jest.Mock).mockRejectedValue('string error');
+    await expect(createSuiteGeneration(mockSuite, 'user-1')).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── getGenerationsForSuite ───────────────────────────────────────────────────
+
+describe('getGenerationsForSuite', () => {
+  it('returns generations array', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockResolvedValue([mockGeneration]);
+    const result = await getGenerationsForSuite(42);
+    expect(result).toEqual([mockGeneration]);
+    expect(generationsRepo.getGenerationsBySuiteId).toHaveBeenCalledWith(42);
+  });
+
+  it('returns empty array when no generations', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockResolvedValue([]);
+    expect(await getGenerationsForSuite(42)).toEqual([]);
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getGenerationsForSuite(42)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (generationsRepo.getGenerationsBySuiteId as jest.Mock).mockRejectedValue('string error');
+    await expect(getGenerationsForSuite(42)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── getLatestGenerationForSuite ──────────────────────────────────────────────
+
+describe('getLatestGenerationForSuite', () => {
+  it('returns latest generation', async () => {
+    (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockResolvedValue(mockGeneration);
+    expect(await getLatestGenerationForSuite(42)).toEqual(mockGeneration);
+    expect(generationsRepo.getLatestGenerationBySuiteId).toHaveBeenCalledWith(42);
+  });
+
+  it('returns null when no generations exist', async () => {
+    (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockResolvedValue(null);
+    expect(await getLatestGenerationForSuite(42)).toBeNull();
+  });
+
+  it('wraps error in HttpException 500', async () => {
+    (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(getLatestGenerationForSuite(42)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value', async () => {
+    (generationsRepo.getLatestGenerationBySuiteId as jest.Mock).mockRejectedValue('string error');
+    await expect(getLatestGenerationForSuite(42)).rejects.toMatchObject({ status: 500 });
+  });
+  // ── resumeGeneration ────────────────────────────────────────────────────────
+
+  describe('resumeGeneration', () => {
+    it('delegates to resumeGenerationInDb', async () => {
+      const resumed = { id: 1, suite_id: 42 } as any;
+      (generationsRepo.resumeGenerationInDb as jest.Mock).mockResolvedValue(resumed);
+
+      await expect(resumeGeneration(42)).resolves.toBe(resumed);
+      expect(generationsRepo.resumeGenerationInDb).toHaveBeenCalledWith(42);
+    });
+
+    it('wraps repository errors in HttpException 500', async () => {
+      (generationsRepo.resumeGenerationInDb as jest.Mock).mockRejectedValue(new Error('db down'));
+
+      await expect(resumeGeneration(42)).rejects.toMatchObject({ status: 500 });
+    });
+  });
+});
+
+describe('updateWizardProgress', () => {
+  it('delegates to updateWizardProgressInDb', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockResolvedValue(undefined as never);
+    await expect(updateWizardProgress(1, 2, [1])).resolves.toBeUndefined();
+    expect(generationsRepo.updateWizardProgressInDb).toHaveBeenCalledWith(1, 2, [1]);
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('bad', 400);
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockRejectedValue(err as never);
+    await expect(updateWizardProgress(1, 2, [1])).rejects.toBe(err);
+  });
+
+  it('wraps unknown Error in HttpException 500', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockRejectedValue(new Error('db') as never);
+    await expect(updateWizardProgress(1, 2, [1])).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (generationsRepo.updateWizardProgressInDb as jest.Mock).mockRejectedValue('oops' as never);
+    await expect(updateWizardProgress(1, 2, [1])).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+describe('deleteTriggerTxtpConfig', () => {
+  it('calls deleteTriggerTxtpConfigInDb and resolves when deleted', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(true as never);
+    await expect(deleteTriggerTxtpConfig(5)).resolves.toBeUndefined();
+  });
+
+  it('throws 404 when config not found', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockResolvedValue(false as never);
+    await expect(deleteTriggerTxtpConfig(5)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('not found', 404);
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue(err as never);
+    await expect(deleteTriggerTxtpConfig(5)).rejects.toBe(err);
+  });
+
+  it('wraps unknown Error in HttpException 500', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue(new Error('db') as never);
+    await expect(deleteTriggerTxtpConfig(5)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (triggerRepo.deleteTriggerTxtpConfigInDb as jest.Mock).mockRejectedValue('oops' as never);
+    await expect(deleteTriggerTxtpConfig(5)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+describe('recalculateGenerationCounts', () => {
+  it('queries all three tables and calls updateGenerationCountsInDb', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ total: '5' }] } as never)
+      .mockResolvedValueOnce({ rows: [{ total: '3' }] } as never)
+      .mockResolvedValueOnce({ rows: [{ total: '2' }] } as never);
+    (generationsRepo.updateGenerationCountsInDb as jest.Mock).mockResolvedValue(undefined as never);
+
+    await expect(recalculateGenerationCounts(10)).resolves.toBeUndefined();
+    expect(generationsRepo.updateGenerationCountsInDb).toHaveBeenCalledWith(10, {
+      context_count: 5,
+      trigger_count: 3,
+      enrichment_table_count: 2,
+    });
+  });
+
+  it('parses totals as integers', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ total: '10' }] } as never)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as never)
+      .mockResolvedValueOnce({ rows: [{ total: '7' }] } as never);
+    (generationsRepo.updateGenerationCountsInDb as jest.Mock).mockResolvedValue(undefined as never);
+
+    await recalculateGenerationCounts(10);
+    expect(generationsRepo.updateGenerationCountsInDb).toHaveBeenCalledWith(10, {
+      context_count: 10,
+      trigger_count: 0,
+      enrichment_table_count: 7,
+    });
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('bad', 400);
+    (dbService.handlePostExecuteSqlStatement as jest.Mock).mockRejectedValue(err as never);
+    await expect(recalculateGenerationCounts(10)).rejects.toBe(err);
+  });
+
+  it('wraps unknown Error in HttpException 500', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock).mockRejectedValue(new Error('db') as never);
+    await expect(recalculateGenerationCounts(10)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (dbService.handlePostExecuteSqlStatement as jest.Mock).mockRejectedValue('oops' as never);
+    await expect(recalculateGenerationCounts(10)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+describe('getGenerationSummary', () => {
+  it('returns summary from repo', async () => {
+    const summary = { generation_id: 1 } as any;
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockResolvedValue(summary as never);
+    await expect(getGenerationSummary(1)).resolves.toBe(summary);
+  });
+
+  it('returns null when no summary exists', async () => {
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockResolvedValue(null as never);
+    await expect(getGenerationSummary(1)).resolves.toBeNull();
+  });
+
+  it('rethrows HttpException as-is', async () => {
+    const err = new HttpException('bad', 400);
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockRejectedValue(err as never);
+    await expect(getGenerationSummary(1)).rejects.toBe(err);
+  });
+
+  it('wraps unknown Error in HttpException 500', async () => {
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockRejectedValue(new Error('db') as never);
+    await expect(getGenerationSummary(1)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('wraps non-Error thrown value in HttpException 500', async () => {
+    (generationsRepo.getGenerationSummaryFromDb as jest.Mock).mockRejectedValue('oops' as never);
+    await expect(getGenerationSummary(1)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,7 +1,7 @@
 import type { AccountCondition, EntityCondition } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import * as util from 'node:util';
-import type { Config, AddMappingDto, AddFunctionDto } from '@tazama-lf/tcs-lib';
+import type { AddMappingDto, AddFunctionDto } from '@tazama-lf/tcs-lib';
 import { configuration, loggerService } from '.';
 import type { ConditionRequest } from './interface/query';
 import type { ITenantRequest } from './interface/ITenantRequest';
@@ -60,8 +60,51 @@ import {
 } from './services/rule.logic.service';
 import type { CloneRuleHandlerReqBody, CreateRuleHandlerReqBody } from './interface/rule.interface';
 import { getSimulationLogs, createSimulationLogs } from './services/simulation-logs.logic.service';
+import {
+  getSimulationSuites,
+  getSimulationSuiteById,
+  createSimulationSuite,
+  updateSimulationSuite,
+} from './services/simulation-suites.logic.service';
+import {
+  getGenerationsForSuite,
+  getLatestGenerationForSuite,
+  addContextTxtpConfig,
+  getContextConfigsWithStrategies,
+  bulkUpdateContextConfigs,
+  deleteContextTxtpConfig,
+  recalculateGenerationCounts,
+  getGenerationSummary,
+  updateWizardProgress,
+  deleteTriggerTxtpConfig,
+  resumeGeneration,
+} from './services/trs-suite-generation.logic.service';
+import {
+  addTriggerTxtpConfig,
+  getTriggerConfigsWithOverrides,
+  bulkUpdateTriggerConfigs,
+} from './services/trigger-txtp-config.logic.service';
+import {
+  createEnrichmentTable,
+  bulkUpdateEnrichmentTables,
+  deleteEnrichmentTable,
+  getEnrichmentTables,
+} from './services/enrichment-table.logic.service';
+import type {
+  AddContextTxtpConfigDto,
+  BulkConfigItemDto,
+  AddTriggerTxtpConfigDto,
+  BulkTriggerConfigItemDto,
+  BulkEnrichmentUpdateItemDto,
+} from './interface/suite-generation.interface';
 import { decodeInnerToken } from './utils/decode-token';
 import type { ISimulationBody } from './interface/simulattionLogs.interface';
+import type {
+  SimulationSuitesQueryDto,
+  CreateSimulationSuiteDto,
+  UpdateSimulationSuiteDto,
+  SimulationSuiteIdParamsDto,
+} from './interface/simulation-suites.interface';
 import {
   handleCreatePushJob,
   handleGetAllJobs,
@@ -76,6 +119,14 @@ import {
   handleValidateExisting,
   handleValidateActive,
 } from './services/job.logic.service';
+import { getFakerSemanticData } from './services/faker-semantic-data.logic.service';
+
+const scheduleRecalculateGenerationCounts = (generationId: number): void => {
+  // Prevent unhandled promise rejections while keeping count updates async/non-blocking.
+  void recalculateGenerationCounts(generationId).catch((error: unknown) => {
+    loggerService.error(`Failed to recalculate generation counts for generation ${generationId}. \n${util.inspect(error)}`);
+  });
+};
 
 export const reportRequestHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
   loggerService.log('Start - Handle report request');
@@ -274,7 +325,7 @@ export const writeConfigUpdateHandler = async (req: FastifyRequest, reply: Fasti
     const updateData = req.body as Record<string, unknown>;
     const { tenantId } = req as ITenantRequest;
 
-    const updatedConfig = await handleUpdateConfig(parseInt(id), tenantId, updateData as Partial<Config>);
+    const updatedConfig = await handleUpdateConfig(parseInt(id), tenantId, updateData);
     reply.code(200).send({ success: true, message: 'Config updated successfully', config: updatedConfig });
   } catch (error: unknown) {
     ErrorHandler.sendError(reply, error, 'Failed to update config');
@@ -1567,5 +1618,651 @@ export const putDataModelJsonHandler = async (req: FastifyRequest, reply: Fastif
     ErrorHandler.sendError(reply, error, 'Failed to save data model JSON');
   } finally {
     loggerService.log('End - Handle put data model JSON request');
+  }
+};
+
+// Simulation Studio
+
+/**
+ * WIZARD STEP 1: POST - Create Simulation Suite with Rule & Details
+ *
+ * Flow:
+ * 1. User fills "Rule & Details" form (Step 1 of 7)
+ * 2. POST to /v1/admin/simulation-studio/suites with:
+ *    - name: "Suite Name"
+ *    - description: "..." (optional)
+ *    - rule_name: "Selected Rule"
+ *    - rule_version: "v1.0"
+ *    - primary_txtp: "pacs.008"
+ *    - primary_txtp_version: "v1.0"
+ * 3. Suite created in DB with status="DRAFT", wizard_progress.currentStep=1
+ * 4. Response includes suite ID for use in subsequent PATCH requests
+ *
+ * Example Response:
+ * {
+ *   "success": true,
+ *   "data": {
+ *     "id": 123,
+ *     "name": "Test Suite",
+ *     "wizard_progress": { "currentStep": 1, "completedSteps": [1] },
+ *     ...
+ *   }
+ * }
+ */
+export const createSimulationHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Create simulation suite');
+    const authReq = req as AuthenticatedRequest;
+    const { tenantId } = req as ITenantRequest;
+    const userId = authReq.user?.clientId ?? authReq.user?.sub ?? authReq.user?.preferred_username ?? 'system';
+    const userEmail = authReq.user?.preferred_username ?? undefined;
+    const payload = req.body as CreateSimulationSuiteDto;
+
+    const simulation = await createSimulationSuite(payload, tenantId, userId, userEmail);
+
+    const body = {
+      success: true,
+      message: 'Simulation suite created successfully',
+      data: simulation,
+    };
+
+    reply.status(201).send(body);
+    loggerService.log('End - Create simulation suite');
+  } catch (err) {
+    const failMessage = `Failed to create simulation suite. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to create simulation suite');
+  }
+};
+
+export const getSimulationsHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get simulation suites');
+    const { tenantId } = req as ITenantRequest;
+    const query = req.query as SimulationSuitesQueryDto;
+
+    // Parse query parameters
+    const options = {
+      tenantId,
+      search: query.search,
+      status: query.status,
+      ruleName: query.rule_name,
+      txtp: query.txtp,
+      updatedFrom: query.updated_from ? new Date(query.updated_from) : undefined,
+      updatedTo: query.updated_to ? new Date(query.updated_to) : undefined,
+      limit: query.limit ?? 20,
+      offset: query.offset ?? 0,
+    };
+
+    const result = await getSimulationSuites(options);
+
+    const body = {
+      success: true,
+      message: 'Simulation suites retrieved successfully',
+      suites: result.data,
+      total: result.total,
+    };
+
+    reply.status(200).send(body);
+    loggerService.log('End - Get simulation suites');
+  } catch (err) {
+    const failMessage = `Failed to retrieve simulation suites. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve simulation suites');
+  }
+};
+
+export const getSimulationByIdHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get simulation suite by ID');
+    const { tenantId } = req as ITenantRequest;
+    const { id } = req.params as SimulationSuiteIdParamsDto;
+    const simulationId = parseInt(id, 10);
+
+    if (!id || isNaN(simulationId)) {
+      reply.status(400).send({
+        success: false,
+        message: 'Invalid simulation suite ID',
+      });
+      return;
+    }
+
+    const simulation = await getSimulationSuiteById(simulationId, tenantId);
+
+    const body = {
+      success: true,
+      message: 'Simulation suite retrieved successfully',
+      suite: simulation,
+    };
+
+    reply.status(200).send(body);
+    loggerService.log('End - Get simulation suite by ID');
+  } catch (err) {
+    const failMessage = `Failed to retrieve simulation suite. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve simulation suite');
+  }
+};
+
+/**
+ * WIZARD STEPS 2-7: PATCH - Update Simulation Suite with Additional Data
+ *
+ * Flow for each step transition:
+ * 1. User completes Step N (2, 3, 4, 5, 6, or 7) on UI
+ * 2. PATCH to /v1/admin/simulation-studio/suites/:id with:
+ *    - wizard_progress: { currentStep: N, completedSteps: [1, 2, ..., N-1], stepNData: {...} }
+ *    - Other fields to update (status, metadata, etc.)
+ * 3. Suite updated in DB with new wizard progress
+ * 4. Response includes updated suite for UI validation
+ *
+ * Step Descriptions:
+ * - Step 1: Rule & Details (done via POST)
+ * - Step 2: TXTP Selection
+ * - Step 3: Trigger Data
+ * - Step 4: Enrichment Data
+ * - Step 5: Preview & Save
+ * - Step 6: Simulation Results
+ * - Step 7: Final confirmation
+ *
+ * Example PATCH body for Step 2:
+ * {
+ *   "wizard_progress": {
+ *     "currentStep": 2,
+ *     "completedSteps": [1],
+ *     "step2Data": { "txtp": "pacs.008", ... }
+ *   }
+ * }
+ */
+export const updateSimulationHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Update simulation suite');
+    const { tenantId } = req as ITenantRequest;
+    const { id } = req.params as SimulationSuiteIdParamsDto;
+    const simulationId = parseInt(id, 10);
+    const payload = req.body as UpdateSimulationSuiteDto;
+
+    if (!id || isNaN(simulationId)) {
+      reply.status(400).send({
+        success: false,
+        message: 'Invalid simulation suite ID',
+      });
+      return;
+    }
+
+    const updatedSimulation = await updateSimulationSuite(simulationId, tenantId, payload);
+
+    const body = {
+      success: true,
+      message: 'Simulation suite updated successfully',
+      suite: updatedSimulation,
+    };
+
+    reply.status(200).send(body);
+    loggerService.log('End - Update simulation suite');
+  } catch (err) {
+    const failMessage = `Failed to update simulation suite. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to update simulation suite');
+  }
+};
+
+export const getSuiteGenerationsHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get suite generations');
+    const { id } = req.params as SimulationSuiteIdParamsDto;
+    const suiteId = parseInt(id, 10);
+
+    if (!id || isNaN(suiteId)) {
+      reply.status(400).send({ success: false, message: 'Invalid simulation suite ID' });
+      return;
+    }
+
+    const generations = await getGenerationsForSuite(suiteId);
+
+    reply.status(200).send({ success: true, data: generations });
+    loggerService.log('End - Get suite generations');
+  } catch (err) {
+    const failMessage = `Failed to retrieve suite generations. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve suite generations');
+  }
+};
+
+export const getLatestSuiteGenerationHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get latest suite generation');
+    const { id } = req.params as SimulationSuiteIdParamsDto;
+    const suiteId = parseInt(id, 10);
+
+    if (!id || isNaN(suiteId)) {
+      reply.status(400).send({ success: false, message: 'Invalid simulation suite ID' });
+      return;
+    }
+
+    const generation = await getLatestGenerationForSuite(suiteId);
+
+    if (!generation) {
+      reply.status(404).send({ success: false, message: 'No generation found for suite' });
+      return;
+    }
+
+    reply.status(200).send({ success: true, data: generation });
+    loggerService.log('End - Get latest suite generation');
+  } catch (err) {
+    const failMessage = `Failed to retrieve latest suite generation. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve latest suite generation');
+  }
+};
+
+export const getGenerationContextConfigsHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get generation context txtp configs');
+    const { generationId } = req.params as { generationId: string };
+    const genId = parseInt(generationId, 10);
+
+    if (!generationId || isNaN(genId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const configs = await getContextConfigsWithStrategies(genId);
+
+    reply.status(200).send({ success: true, data: configs });
+    loggerService.log('End - Get generation context txtp configs');
+  } catch (err) {
+    const failMessage = `Failed to retrieve context txtp configs. \n${util.inspect(err)}`;
+    loggerService.error(failMessage);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve context txtp configs');
+  }
+};
+
+// ── Step 2: POST new context txtp config (Add TXTP) ─────────────────────────
+
+export const addContextTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Add context txtp config');
+    const { tenantId } = req as ITenantRequest;
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const dto = req.body as AddContextTxtpConfigDto;
+    const created = await addContextTxtpConfig(generationId, dto, tenantId);
+    scheduleRecalculateGenerationCounts(generationId);
+
+    reply.status(201).send({ success: true, data: created });
+    loggerService.log('End - Add context txtp config');
+  } catch (err) {
+    loggerService.error(`Failed to add context txtp config. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to add context txtp config');
+  }
+};
+
+// ── Step 2: PATCH bulk update context configs (message_count + field strategies) ──
+
+export const updateContextTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Bulk update context txtp configs');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const items = req.body as BulkConfigItemDto[];
+    if (!Array.isArray(items) || items.length === 0) {
+      reply.status(400).send({ success: false, message: 'Request body must be a non-empty array' });
+      return;
+    }
+
+    const updated = await bulkUpdateContextConfigs(generationId, items);
+    // void recalculateGenerationCounts(generationId);
+
+    reply.status(200).send({ success: true, data: updated });
+    loggerService.log('End - Bulk update context txtp configs');
+  } catch (err) {
+    loggerService.error(`Failed to bulk update context txtp configs. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to bulk update context txtp configs');
+  }
+};
+
+// ── Step 3: GET all trigger configs + field strategies ───────────────────────
+
+export const getTriggerConfigsHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get trigger txtp configs');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const configs = await getTriggerConfigsWithOverrides(generationId);
+    reply.status(200).send({ success: true, data: configs });
+    loggerService.log('End - Get trigger txtp configs');
+  } catch (err) {
+    loggerService.error(`Failed to retrieve trigger txtp configs. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve trigger txtp configs');
+  }
+};
+
+// ── Step 3: POST new trigger txtp config (Add TXTP) ──────────────────────────
+
+export const addTriggerTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Add trigger txtp config');
+    const { tenantId } = req as ITenantRequest;
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const dto = req.body as AddTriggerTxtpConfigDto;
+    const created = await addTriggerTxtpConfig(generationId, dto, tenantId);
+    scheduleRecalculateGenerationCounts(generationId);
+
+    reply.status(201).send({ success: true, data: created });
+    loggerService.log('End - Add trigger txtp config');
+  } catch (err) {
+    loggerService.error(`Failed to add trigger txtp config. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to add trigger txtp config');
+  }
+};
+
+// ── Step 3: PATCH bulk update trigger configs ─────────────────────────────────
+
+export const bulkUpdateTriggerConfigsHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Bulk update trigger txtp configs');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const items = req.body as BulkTriggerConfigItemDto[];
+    if (!Array.isArray(items) || items.length === 0) {
+      reply.status(400).send({ success: false, message: 'Request body must be a non-empty array' });
+      return;
+    }
+
+    const updated = await bulkUpdateTriggerConfigs(generationId, items);
+
+    reply.status(200).send({ success: true, data: updated });
+    loggerService.log('End - Bulk update trigger txtp configs');
+  } catch (err) {
+    loggerService.error(`Failed to bulk update trigger txtp configs. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to bulk update trigger txtp configs');
+  }
+};
+
+// ── Step 4: POST create enrichment table ─────────────────────────────────────
+
+export const createEnrichmentTableHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Create enrichment table');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const {
+      table_name: tableName,
+      row_count: rowCount,
+      payload_template_json: payloadTemplateJson,
+      schema_template_json: schemaTemplateJson,
+    } = req.body as {
+      table_name: string;
+      row_count?: number;
+      payload_template_json?: Record<string, unknown>;
+      schema_template_json?: Record<string, unknown>;
+    };
+
+    if (!tableName || typeof tableName !== 'string') {
+      reply.status(400).send({ success: false, message: 'table_name is required' });
+      return;
+    }
+
+    const created = await createEnrichmentTable(generationId, tableName, rowCount ?? 1, payloadTemplateJson, schemaTemplateJson);
+    scheduleRecalculateGenerationCounts(generationId);
+    reply.status(201).send({ success: true, data: created });
+    loggerService.log('End - Create enrichment table');
+  } catch (err) {
+    loggerService.error(`Failed to create enrichment table. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to create enrichment table');
+  }
+};
+
+// ── Step 4: GET all enrichment tables with field strategies ───────────────────
+
+export const getEnrichmentTablesHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get enrichment tables');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const tables = await getEnrichmentTables(generationId);
+    reply.status(200).send({ success: true, data: tables });
+    loggerService.log('End - Get enrichment tables');
+  } catch (err) {
+    loggerService.error(`Failed to retrieve enrichment tables. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve enrichment tables');
+  }
+};
+
+// ── Step 4: PATCH bulk update enrichment tables ───────────────────────────────
+
+export const bulkUpdateEnrichmentTablesHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Bulk update enrichment tables');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const items = req.body as BulkEnrichmentUpdateItemDto[];
+    if (!Array.isArray(items) || items.length === 0) {
+      reply.status(400).send({ success: false, message: 'Request body must be a non-empty array' });
+      return;
+    }
+
+    const updated = await bulkUpdateEnrichmentTables(generationId, items);
+
+    reply.status(200).send({ success: true, data: updated });
+    loggerService.log('End - Bulk update enrichment tables');
+  } catch (err) {
+    loggerService.error(`Failed to bulk update enrichment tables. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to bulk update enrichment tables');
+  }
+};
+
+// ── Step 4: DELETE enrichment table ──────────────────────────────────────────
+
+export const deleteEnrichmentTableHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Delete enrichment table');
+    const { tableId: tableIdStr, generationId: generationIdStr } = req.params as { tableId: string; generationId: string };
+    const tableId = parseInt(tableIdStr, 10);
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(tableId)) {
+      reply.status(400).send({ success: false, message: 'Invalid table ID' });
+      return;
+    }
+
+    await deleteEnrichmentTable(tableId);
+    scheduleRecalculateGenerationCounts(generationId);
+    reply.status(200).send({ success: true, message: 'Enrichment table deleted' });
+    loggerService.log('End - Delete enrichment table');
+  } catch (err) {
+    loggerService.error(`Failed to delete enrichment table. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to delete enrichment table');
+  }
+};
+
+// ── Step 5: GET generation summary ───────────────────────────────────────────
+
+export const getGenerationSummaryHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get generation summary');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+
+    const summary = await getGenerationSummary(generationId);
+    if (!summary) {
+      reply.status(404).send({ success: false, message: 'Generation not found' });
+      return;
+    }
+
+    reply.status(200).send({ success: true, data: summary });
+    loggerService.log('End - Get generation summary');
+  } catch (err) {
+    loggerService.error(`Failed to retrieve generation summary. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to retrieve generation summary');
+  }
+};
+
+// ── PATCH wizard progress ─────────────────────────────────────────────────────
+
+export const updateWizardProgressHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Update wizard progress');
+    const { generationId: generationIdStr } = req.params as { generationId: string };
+    const generationId = parseInt(generationIdStr, 10);
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+    const { current_step_num: currentStepNum, completed_step_num: completedStepNum } = req.body as {
+      current_step_num: number;
+      completed_step_num: number;
+    };
+    if (!currentStepNum || typeof currentStepNum !== 'number') {
+      reply.status(400).send({ success: false, message: 'current_step_num is required' });
+      return;
+    }
+    if (!completedStepNum || typeof completedStepNum !== 'number') {
+      reply.status(400).send({ success: false, message: 'completed_step_num is required' });
+      return;
+    }
+    const completedSteps = Array.from({ length: completedStepNum }, (_, i) => i + 1);
+    await updateWizardProgress(generationId, currentStepNum, completedSteps);
+    reply.status(200).send({ success: true, message: `Step ${currentStepNum} saved, steps 1-${completedStepNum} complete` });
+    loggerService.log('End - Update wizard progress');
+  } catch (err) {
+    loggerService.error(`Failed to update wizard progress. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to update wizard progress');
+  }
+};
+
+// ── DELETE context txtp config ────────────────────────────────────────────────
+
+export const deleteContextTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Delete context txtp config');
+    const { configId: configIdStr, generationId: generationIdStr } = req.params as { configId: string; generationId: string };
+    const configId = parseInt(configIdStr, 10);
+    const generationId = parseInt(generationIdStr, 10);
+    if (isNaN(configId)) {
+      reply.status(400).send({ success: false, message: 'Invalid config ID' });
+      return;
+    }
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+    await deleteContextTxtpConfig(configId);
+    scheduleRecalculateGenerationCounts(generationId);
+    reply.status(200).send({ success: true, message: 'Context txtp config deleted' });
+    loggerService.log('End - Delete context txtp config');
+  } catch (err) {
+    loggerService.error(`Failed to delete context txtp config. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to delete context txtp config');
+  }
+};
+
+// ── DELETE trigger txtp config ────────────────────────────────────────────────
+
+export const deleteTriggerTxtpConfigHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Delete trigger txtp config');
+    const { configId: configIdStr, generationId: generationIdStr } = req.params as { configId: string; generationId: string };
+    const configId = parseInt(configIdStr, 10);
+    const generationId = parseInt(generationIdStr, 10);
+    if (isNaN(configId)) {
+      reply.status(400).send({ success: false, message: 'Invalid config ID' });
+      return;
+    }
+    if (isNaN(generationId)) {
+      reply.status(400).send({ success: false, message: 'Invalid generation ID' });
+      return;
+    }
+    await deleteTriggerTxtpConfig(configId);
+    scheduleRecalculateGenerationCounts(generationId);
+    reply.status(200).send({ success: true, message: 'Trigger txtp config deleted' });
+    loggerService.log('End - Delete trigger txtp config');
+  } catch (err) {
+    loggerService.error(`Failed to delete trigger txtp config. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to delete trigger txtp config');
+  }
+};
+
+export const resumeGenerationHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Resume generation');
+    const { suiteId: suiteIdStr } = req.params as { suiteId: string };
+    const suiteId = parseInt(suiteIdStr, 10);
+    if (isNaN(suiteId)) {
+      reply.status(400).send({ success: false, message: 'Invalid suite ID' });
+      return;
+    }
+    const resumeGenerationResult = await resumeGeneration(suiteId);
+    reply.status(200).send({ success: true, message: 'Generation resumed', data: resumeGenerationResult });
+    loggerService.log('End - Resume generation');
+  } catch (err) {
+    loggerService.error(`Failed to resume generation. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to resume generation');
+  }
+};
+
+export const getFakerSemanticDataHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  try {
+    loggerService.log('Start - Get faker semantic data');
+    const data = await getFakerSemanticData();
+    reply.status(200).send({ success: true, data });
+    loggerService.log('End - Get faker semantic data');
+  } catch (err) {
+    loggerService.error(`Failed to get faker semantic data. \n${util.inspect(err)}`);
+    ErrorHandler.sendError(reply, err, 'Failed to get faker semantic data');
   }
 };

--- a/src/interface/simulation-suites.interface.ts
+++ b/src/interface/simulation-suites.interface.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export enum SimulationSuiteStatus {
+  DRAFT = 'DRAFT',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export enum SimulationType {
+  SINGLE_RULE = 'SINGLE_RULE',
+  INTEGRATION_TESTING = 'INTEGRATION_TESTING',
+}
+
+export const SIMULATION_SUITE_NAME_MAX_LENGTH = 50;
+export const SIMULATION_SUITE_DESCRIPTION_MAX_LENGTH = 300;
+
+/**
+ * Wizard step tracking for multi-step simulation suite creation
+ * Steps: 1=Rule & Details, 2=TXTP Selection, 3=Trigger Data, 4=Enrichment Data, 5=Preview & Save, 6=Simulation Results
+ */
+export interface WizardProgress {
+  currentStep?: number;
+  completedSteps?: number[];
+  [key: string]: unknown;
+}
+
+export interface SimulationSuite {
+  id: number;
+  tenant_id: string;
+  name: string;
+  description?: string;
+  simulation_type: SimulationType;
+  status: SimulationSuiteStatus;
+  rule_repo?: string;
+  rule_name?: string;
+  rule_version?: string;
+  rule_config: Record<string, unknown>;
+  primary_txtp?: string;
+  primary_txtp_version?: string;
+  clone_source_suite_id?: number;
+  iteration_count: number;
+  run_count: number;
+  last_run_at?: Date;
+  wizard_progress: WizardProgress;
+  metadata: Record<string, unknown>;
+  created_by: string;
+  created_by_email?: string;
+  created_at: Date;
+  updated_at: Date;
+  generation_id?: number;
+}
+
+/**
+ * POST /v1/admin/simulation-studio/suites
+ * Creates a new simulation suite with Step 1 (Rule & Details) data
+ * Subsequent steps use PATCH API to update wizard_progress
+ */
+export interface CreateSimulationSuiteDto {
+  name: string;
+  description?: string;
+  simulation_type?: SimulationType;
+  rule_repo: string;
+  rule_name: string;
+  rule_version: string;
+  rule_config: Record<string, unknown>;
+  primary_txtp: string;
+  primary_txtp_version: string;
+  clone_source_suite_id?: number;
+  wizard_progress?: WizardProgress;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * PATCH /v1/admin/simulation-studio/suites/:id
+ * Updates simulation suite with data from next wizard steps
+ * Use wizard_progress to track completion of steps 2-7
+ */
+export interface UpdateSimulationSuiteDto {
+  name?: string;
+  description?: string;
+  simulation_type?: SimulationType;
+  status?: SimulationSuiteStatus;
+  rule_repo?: string;
+  rule_name?: string;
+  rule_version?: string;
+  rule_config?: Record<string, unknown>;
+  primary_txtp?: string;
+  primary_txtp_version?: string;
+  iteration_count?: number;
+  run_count?: number;
+  last_run_at?: Date;
+  wizard_progress?: WizardProgress;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SimulationSuitesQueryDto {
+  search?: string; // Search by suite name (case-insensitive contains)
+  status?: SimulationSuiteStatus; // Filter by status
+  rule_name?: string; // Filter by associated rule name
+  txtp?: string; // Filter by transaction type (TXTP)
+  updated_from?: string; // Filter by updated date from (inclusive) - ISO format
+  updated_to?: string; // Filter by updated date to (inclusive) - ISO format
+  offset?: number; // Offset (0-based)
+  limit?: number; // Limit
+}
+
+export interface SimulationSuiteIdParamsDto {
+  id: string;
+}
+
+export interface SimulationSuitesQueryOptions {
+  tenantId: string;
+  search?: string;
+  status?: SimulationSuiteStatus;
+  ruleName?: string;
+  txtp?: string;
+  updatedFrom?: Date;
+  updatedTo?: Date;
+  offset?: number;
+  limit?: number;
+}
+
+export interface SimulationSuitesListResponse {
+  data: SimulationSuite[];
+  total: number;
+  limit?: number;
+  offset?: number;
+}

--- a/src/interface/suite-generation.interface.ts
+++ b/src/interface/suite-generation.interface.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export enum SuiteGenerationStatus {
+  DRAFT = 'DRAFT',
+  READY = 'READY',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+export enum SimulationType {
+  SINGLE_RULE = 'SINGLE_RULE',
+  INTEGRATION_TESTING = 'INTEGRATION_TESTING',
+}
+
+export type ContextFieldStrategyCode = 'keep_sample' | 'static' | 'range' | 'generated' | 'null' | 'skip';
+
+export interface SuiteGeneration {
+  id: number;
+  suite_id: number;
+  generation_number: number;
+  status: SuiteGenerationStatus;
+  simulation_type: SimulationType;
+  rule_repo?: string;
+  rule_version?: string;
+  context_count: number;
+  trigger_count: number;
+  enrichment_table_count: number;
+  generated_context_count: number;
+  generated_trigger_count: number;
+  generated_enrichment_row_count: number;
+  context_field_config_count: number;
+  trigger_field_config_count: number;
+  enrichment_field_config_count: number;
+  wizard_snapshot: Record<string, unknown>;
+  generation_metadata: Record<string, unknown>;
+  created_by: string;
+  created_by_email?: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreateSuiteGenerationDto {
+  suite_id: number;
+  simulation_type?: SimulationType;
+  rule_repo?: string;
+  rule_version?: string;
+  wizard_snapshot?: Record<string, unknown>;
+  generation_metadata?: Record<string, unknown>;
+}
+
+// ── Context TXTP Config ──────────────────────────────────────────────────────
+
+export interface SuiteContextTxtpConfig {
+  id: number;
+  generation_id: number;
+  txtp: string;
+  txtp_version: string;
+  display_order: number;
+  message_count: number;
+  schema_snapshot: Record<string, unknown>;
+  sample_payload_snapshot?: Record<string, unknown>;
+  faker_seed?: number;
+  generator_profile: Record<string, unknown>;
+  created_at: Date;
+}
+
+export interface CreateContextTxtpConfigDto {
+  generation_id: number;
+  txtp: string;
+  txtp_version: string;
+  display_order: number;
+  message_count: number;
+  schema_snapshot: Record<string, unknown>;
+  sample_payload_snapshot?: Record<string, unknown>;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+}
+
+export interface UpdateContextTxtpConfigDto {
+  message_count?: number;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+}
+
+export interface AddContextTxtpConfigDto {
+  txtp: string;
+  txtp_version: string;
+  message_count?: number;
+}
+
+// ── Context Field Strategies ─────────────────────────────────────────────────
+
+export interface ContextFieldStrategy {
+  id: number;
+  context_txtp_config_id: number;
+  field_path: string;
+  strategy_code: ContextFieldStrategyCode;
+  static_value?: unknown;
+  range_min?: number;
+  range_max?: number;
+  faker_semantic_type?: string;
+  generator_options: Record<string, unknown>;
+  is_required_override?: boolean;
+  created_at: Date;
+}
+
+export interface UpsertFieldStrategyDto {
+  field_path: string;
+  strategy_code: ContextFieldStrategyCode;
+  static_value?: unknown;
+  range_min?: number;
+  range_max?: number;
+  faker_semantic_type?: string;
+  generator_options?: Record<string, unknown>;
+  is_required_override?: boolean;
+}
+
+export interface ContextTxtpConfigWithStrategies {
+  context_txtp_config_id: number;
+  txtp: string;
+  txtp_version: string;
+  message_count: number;
+  display_order: number;
+  schema_snapshot: Record<string, unknown>;
+  sample_payload_snapshot?: Record<string, unknown>;
+  field_strategies: ContextFieldStrategy[];
+}
+
+export interface BulkConfigItemDto {
+  context_txtp_config_id: number;
+  message_count?: number;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+  field_strategies?: UpsertFieldStrategyDto[];
+}
+
+// ── Trigger TXTP Config ──────────────────────────────────────────────────────
+
+export type TriggerOverrideType = 'static' | 'range' | 'generated' | 'remove' | 'null';
+export type TriggerExpectedBand = 'good' | 'neutral' | 'bad' | 'error';
+
+export interface SuiteTriggerTxtpConfig {
+  id: number;
+  generation_id: number;
+  txtp: string;
+  txtp_version: string;
+  display_order: number;
+  message_count: number;
+  link_to_context_pairs: boolean;
+  payload_template_json: Record<string, unknown>;
+  expected_independent_variable?: number;
+  expected_result_band?: TriggerExpectedBand;
+  notes?: string;
+  faker_seed?: number;
+  generator_profile: Record<string, unknown>;
+  created_at: Date;
+}
+
+export interface CreateTriggerTxtpConfigDto {
+  generation_id: number;
+  txtp: string;
+  txtp_version: string;
+  display_order: number;
+  message_count: number;
+  payload_template_json: Record<string, unknown>;
+  link_to_context_pairs?: boolean;
+  expected_independent_variable?: number;
+  expected_result_band?: TriggerExpectedBand;
+  notes?: string;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+}
+
+export interface UpdateTriggerTxtpConfigDto {
+  message_count?: number;
+  link_to_context_pairs?: boolean;
+  payload_template_json?: Record<string, unknown>;
+  expected_independent_variable?: number;
+  expected_result_band?: TriggerExpectedBand;
+  notes?: string;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+}
+
+export interface AddTriggerTxtpConfigDto {
+  txtp: string;
+  txtp_version: string;
+  message_count?: number;
+}
+
+export interface TriggerFieldOverride {
+  id: number;
+  trigger_txtp_config_id: number;
+  field_path: string;
+  override_type: TriggerOverrideType;
+  static_value?: unknown;
+  range_min?: number;
+  range_max?: number;
+  faker_semantic_type?: string;
+  generator_options: Record<string, unknown>;
+  created_at: Date;
+}
+
+export interface UpsertTriggerFieldOverrideDto {
+  field_path: string;
+  override_type: TriggerOverrideType;
+  static_value?: unknown;
+  range_min?: number;
+  range_max?: number;
+  faker_semantic_type?: string;
+  generator_options?: Record<string, unknown>;
+}
+
+export interface TriggerTxtpConfigWithOverrides {
+  trigger_txtp_config_id: number;
+  txtp: string;
+  txtp_version: string;
+  message_count: number;
+  display_order: number;
+  payload_template_json: Record<string, unknown>;
+  link_to_context_pairs: boolean;
+  expected_result_band?: TriggerExpectedBand;
+  notes?: string;
+  field_overrides: TriggerFieldOverride[];
+}
+
+export interface BulkTriggerConfigItemDto {
+  trigger_txtp_config_id: number;
+  message_count?: number;
+  link_to_context_pairs?: boolean;
+  payload_template_json?: Record<string, unknown>;
+  expected_result_band?: TriggerExpectedBand;
+  notes?: string;
+  faker_seed?: number;
+  generator_profile?: Record<string, unknown>;
+  field_overrides?: UpsertTriggerFieldOverrideDto[];
+}
+
+// ── Enrichment Tables ────────────────────────────────────────────────────────
+
+export type EnrichmentFieldStrategyCode = 'static' | 'range' | 'generated' | 'null' | 'copy';
+
+export interface SuiteEnrichmentTable {
+  id: number;
+  generation_id: number;
+  table_name: string;
+  table_order: number;
+  row_count: number;
+  payload_template_json?: Record<string, unknown>;
+  schema_template_json?: Record<string, unknown>;
+  faker_profile: Record<string, unknown>;
+  created_at: Date;
+}
+
+export interface CreateEnrichmentTableDto {
+  generation_id: number;
+  table_name: string;
+  table_order?: number;
+  row_count: number;
+  payload_template_json?: Record<string, unknown>;
+  schema_template_json?: Record<string, unknown>;
+  faker_profile?: Record<string, unknown>;
+}
+
+export interface UpdateEnrichmentTableDto {
+  row_count?: number;
+  payload_template_json?: Record<string, unknown>;
+  schema_template_json?: Record<string, unknown>;
+  faker_profile?: Record<string, unknown>;
+}
+
+export interface BulkEnrichmentUpdateItemDto {
+  id: number;
+  row_count?: number;
+  payload_template_json?: Record<string, unknown>;
+  schema_template_json?: Record<string, unknown>;
+  faker_profile?: Record<string, unknown>;
+}

--- a/src/repositories/configuration/node.repository.ts
+++ b/src/repositories/configuration/node.repository.ts
@@ -5,7 +5,6 @@ import type { Node } from '../../interface/node.interface';
 export const getNodeByName = async (nodeName: string, tenantId: string): Promise<Node[] | null> => {
   const queryRes = await handlePostExecuteSqlStatement<Node>(
     {
-      // eslint-disable-next-line @stylistic/quotes -- SQL string contains single quotes
       text: "SELECT id FROM trs_nodes WHERE (node_json->>'name') = $1 AND tenant_id = $2 LIMIT 1",
       values: [nodeName, tenantId],
     } satisfies PgQueryConfig,

--- a/src/repositories/configuration/simulation-logs.repository.ts
+++ b/src/repositories/configuration/simulation-logs.repository.ts
@@ -59,16 +59,27 @@ export const getSimulationLogsFromDb = async (options: SimulationLogQueryOptions
   }));
 };
 
-export const createSimulationLogsInDb = async (
-  userId: string,
-  tenantId: string,
-  ruleId: string,
-  oldData: Record<string, unknown>,
-  newData: Record<string, unknown>,
-  description: string,
-  category: string,
-  createdByEmail?: string,
-): Promise<void> => {
+export interface CreateSimulationLogDbPayload {
+  userId: string;
+  tenantId: string;
+  ruleId: string;
+  oldData: Record<string, unknown>;
+  newData: Record<string, unknown>;
+  description: string;
+  category: string;
+  createdByEmail?: string;
+}
+
+export const createSimulationLogsInDb = async ({
+  userId,
+  tenantId,
+  ruleId,
+  oldData,
+  newData,
+  description,
+  category,
+  createdByEmail,
+}: CreateSimulationLogDbPayload): Promise<void> => {
   const columns = [
     'created_by',
     'tenant_id',

--- a/src/repositories/simulation-studio/context-field-strategies.repository.ts
+++ b/src/repositories/simulation-studio/context-field-strategies.repository.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type { ContextFieldStrategy, UpsertFieldStrategyDto } from '../../interface/suite-generation.interface';
+
+const mapRow = (row: Record<string, unknown>): ContextFieldStrategy => ({
+  id: row.id as number,
+  context_txtp_config_id: row.context_txtp_config_id as number,
+  field_path: row.field_path as string,
+  strategy_code: row.strategy_code as ContextFieldStrategy['strategy_code'],
+  static_value: row.static_value ?? undefined,
+  range_min: row.range_min as number | undefined,
+  range_max: row.range_max as number | undefined,
+  faker_semantic_type: row.faker_semantic_type as string | undefined,
+  generator_options:
+    typeof row.generator_options === 'string'
+      ? (JSON.parse(row.generator_options) as Record<string, unknown>)
+      : (row.generator_options as Record<string, unknown>),
+  is_required_override: row.is_required_override as boolean | undefined,
+  created_at: new Date(row.created_at as string),
+});
+
+/**
+ * Upsert a single field strategy row.
+ * ON CONFLICT (context_txtp_config_id, field_path) → update all strategy columns.
+ */
+export const upsertFieldStrategyInDb = async (contextTxtpConfigId: number, dto: UpsertFieldStrategyDto): Promise<ContextFieldStrategy> => {
+  const query = `
+    INSERT INTO trs_suite_context_field_strategies (
+      context_txtp_config_id, field_path, strategy_code,
+      static_value, range_min, range_max,
+      faker_semantic_type, generator_options, is_required_override,
+      created_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+    ON CONFLICT (context_txtp_config_id, field_path)
+    DO UPDATE SET
+      strategy_code        = EXCLUDED.strategy_code,
+      static_value         = EXCLUDED.static_value,
+      range_min            = EXCLUDED.range_min,
+      range_max            = EXCLUDED.range_max,
+      faker_semantic_type       = EXCLUDED.faker_semantic_type,
+      generator_options    = EXCLUDED.generator_options,
+      is_required_override = EXCLUDED.is_required_override
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: query,
+      values: [
+        contextTxtpConfigId,
+        dto.field_path,
+        dto.strategy_code,
+        dto.static_value !== undefined ? JSON.stringify(dto.static_value) : null,
+        dto.range_min ?? null,
+        dto.range_max ?? null,
+        dto.faker_semantic_type ?? null,
+        JSON.stringify(dto.generator_options ?? {}),
+        dto.is_required_override ?? null,
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return mapRow(result.rows[0]);
+};
+
+export const getFieldStrategiesByContextConfigId = async (contextTxtpConfigId: number): Promise<ContextFieldStrategy[]> => {
+  const query = `
+    SELECT * FROM trs_suite_context_field_strategies
+    WHERE context_txtp_config_id = $1
+    ORDER BY field_path ASC
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [contextTxtpConfigId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.map(mapRow);
+};

--- a/src/repositories/simulation-studio/context-txtp-configs.repository.ts
+++ b/src/repositories/simulation-studio/context-txtp-configs.repository.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type {
+  SuiteContextTxtpConfig,
+  CreateContextTxtpConfigDto,
+  UpdateContextTxtpConfigDto,
+} from '../../interface/suite-generation.interface';
+
+const mapRowToContextConfig = (row: Record<string, unknown>): SuiteContextTxtpConfig => ({
+  id: row.id as number,
+  generation_id: row.generation_id as number,
+  txtp: row.txtp as string,
+  txtp_version: row.txtp_version as string,
+  display_order: row.display_order as number,
+  message_count: row.message_count as number,
+  schema_snapshot:
+    typeof row.schema_snapshot === 'string'
+      ? (JSON.parse(row.schema_snapshot) as Record<string, unknown>)
+      : (row.schema_snapshot as Record<string, unknown>),
+  sample_payload_snapshot: row.sample_payload_snapshot
+    ? typeof row.sample_payload_snapshot === 'string'
+      ? (JSON.parse(row.sample_payload_snapshot) as Record<string, unknown>)
+      : (row.sample_payload_snapshot as Record<string, unknown>)
+    : undefined,
+  faker_seed: row.faker_seed as number | undefined,
+  generator_profile:
+    typeof row.generator_profile === 'string'
+      ? (JSON.parse(row.generator_profile) as Record<string, unknown>)
+      : (row.generator_profile as Record<string, unknown>),
+  created_at: new Date(row.created_at as string),
+});
+
+export const createContextTxtpConfigInDb = async (dto: CreateContextTxtpConfigDto): Promise<SuiteContextTxtpConfig> => {
+  const query = `
+    INSERT INTO trs_suite_context_txtp_configs (
+      generation_id, txtp, txtp_version, display_order, message_count,
+      schema_snapshot, sample_payload_snapshot, faker_seed, generator_profile,
+      created_at
+    ) VALUES (
+      $1, $2, $3, $4, $5,
+      $6, $7, $8, $9,
+      NOW()
+    )
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: query,
+      values: [
+        dto.generation_id,
+        dto.txtp,
+        dto.txtp_version,
+        dto.display_order,
+        dto.message_count,
+        JSON.stringify(dto.schema_snapshot),
+        dto.sample_payload_snapshot ? JSON.stringify(dto.sample_payload_snapshot) : null,
+        dto.faker_seed ?? null,
+        JSON.stringify(dto.generator_profile ?? {}),
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return mapRowToContextConfig(result.rows[0]);
+};
+
+export const updateContextTxtpConfigInDb = async (id: number, dto: UpdateContextTxtpConfigDto): Promise<SuiteContextTxtpConfig | null> => {
+  const updates: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  if (dto.message_count !== undefined) {
+    updates.push(`message_count = $${idx++}`);
+    values.push(dto.message_count);
+  }
+  if (dto.faker_seed !== undefined) {
+    updates.push(`faker_seed = $${idx++}`);
+    values.push(dto.faker_seed);
+  }
+  if (dto.generator_profile !== undefined) {
+    updates.push(`generator_profile = $${idx++}`);
+    values.push(JSON.stringify(dto.generator_profile));
+  }
+
+  if (updates.length === 0) {
+    const existing = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+      { text: 'SELECT * FROM trs_suite_context_txtp_configs WHERE id = $1', values: [id] } satisfies PgQueryConfig,
+      'simulation',
+    );
+    return existing.rows.length ? mapRowToContextConfig(existing.rows[0]) : null;
+  }
+
+  values.push(id);
+  const query = `
+    UPDATE trs_suite_context_txtp_configs
+    SET ${updates.join(', ')}
+    WHERE id = $${idx}
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.length ? mapRowToContextConfig(result.rows[0]) : null;
+};
+
+export const deleteContextTxtpConfigInDb = async (id: number): Promise<boolean> => {
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: 'DELETE FROM trs_suite_context_txtp_configs WHERE id = $1 RETURNING id', values: [id] } satisfies PgQueryConfig,
+    'simulation',
+  );
+  return result.rows.length > 0;
+};
+
+export const getContextTxtpConfigsByGenerationId = async (generationId: number): Promise<SuiteContextTxtpConfig[]> => {
+  const query = `
+    SELECT *
+    FROM trs_suite_context_txtp_configs
+    WHERE generation_id = $1
+    ORDER BY display_order ASC
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [generationId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.map(mapRowToContextConfig);
+};

--- a/src/repositories/simulation-studio/enrichment-tables.repository.ts
+++ b/src/repositories/simulation-studio/enrichment-tables.repository.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type { SuiteEnrichmentTable, CreateEnrichmentTableDto, UpdateEnrichmentTableDto } from '../../interface/suite-generation.interface';
+
+const parseJsonCol = (val: unknown): Record<string, unknown> | undefined =>
+  val ? (typeof val === 'string' ? (JSON.parse(val) as Record<string, unknown>) : (val as Record<string, unknown>)) : undefined;
+
+const mapRow = (row: Record<string, unknown>): SuiteEnrichmentTable => ({
+  id: row.id as number,
+  generation_id: row.generation_id as number,
+  table_name: row.table_name as string,
+  table_order: row.table_order as number,
+  row_count: row.row_count as number,
+  payload_template_json: parseJsonCol(row.payload_template_json),
+  schema_template_json: parseJsonCol(row.schema_template_json),
+  faker_profile:
+    typeof row.faker_profile === 'string'
+      ? (JSON.parse(row.faker_profile) as Record<string, unknown>)
+      : row.faker_profile
+        ? (row.faker_profile as Record<string, unknown>)
+        : {},
+  created_at: new Date(row.created_at as string),
+});
+
+export const createEnrichmentTableInDb = async (dto: CreateEnrichmentTableDto): Promise<SuiteEnrichmentTable> => {
+  const query = `
+    INSERT INTO trs_suite_enrichment_tables (
+      generation_id, table_name, table_order, row_count,
+      payload_template_json, schema_template_json, faker_profile, created_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: query,
+      values: [
+        dto.generation_id,
+        dto.table_name,
+        dto.table_order ?? 1,
+        dto.row_count,
+        dto.payload_template_json ? JSON.stringify(dto.payload_template_json) : null,
+        dto.schema_template_json ? JSON.stringify(dto.schema_template_json) : null,
+        JSON.stringify(dto.faker_profile ?? {}),
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return mapRow(result.rows[0]);
+};
+
+export const getNextEnrichmentTableOrderInDb = async (generationId: number): Promise<number> => {
+  const result = await handlePostExecuteSqlStatement<{ next_order: string | number }>(
+    {
+      text: `
+        SELECT COALESCE(MAX(table_order), 0) + 1 AS next_order
+        FROM trs_suite_enrichment_tables
+        WHERE generation_id = $1
+      `,
+      values: [generationId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return parseInt(String(result.rows[0]?.next_order ?? '1'), 10);
+};
+
+export const updateEnrichmentTableInDb = async (
+  id: number,
+  generationId: number,
+  dto: UpdateEnrichmentTableDto,
+): Promise<SuiteEnrichmentTable | null> => {
+  const updates: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  if (dto.row_count !== undefined) {
+    updates.push(`row_count = $${idx++}`);
+    values.push(dto.row_count);
+  }
+  if (dto.payload_template_json !== undefined) {
+    updates.push(`payload_template_json = $${idx++}`);
+    values.push(JSON.stringify(dto.payload_template_json));
+  }
+  if (dto.schema_template_json !== undefined) {
+    updates.push(`schema_template_json = $${idx++}`);
+    values.push(JSON.stringify(dto.schema_template_json));
+  }
+  if (dto.faker_profile !== undefined) {
+    updates.push(`faker_profile = $${idx++}`);
+    values.push(JSON.stringify(dto.faker_profile));
+  }
+
+  if (updates.length === 0) {
+    const existing = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+      {
+        text: 'SELECT * FROM trs_suite_enrichment_tables WHERE id = $1 AND generation_id = $2',
+        values: [id, generationId],
+      } satisfies PgQueryConfig,
+      'simulation',
+    );
+    return existing.rows.length ? mapRow(existing.rows[0]) : null;
+  }
+
+  values.push(id, generationId);
+  const query = `UPDATE trs_suite_enrichment_tables SET ${updates.join(', ')} WHERE id = $${idx} AND generation_id = $${idx + 1} RETURNING *`;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.length ? mapRow(result.rows[0]) : null;
+};
+
+export const getEnrichmentTablesByGenerationId = async (generationId: number): Promise<SuiteEnrichmentTable[]> => {
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: 'SELECT * FROM trs_suite_enrichment_tables WHERE generation_id = $1 ORDER BY table_order ASC',
+      values: [generationId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+  return result.rows.map(mapRow);
+};
+
+export const deleteEnrichmentTableInDb = async (id: number): Promise<boolean> => {
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: 'DELETE FROM trs_suite_enrichment_tables WHERE id = $1 RETURNING id', values: [id] } satisfies PgQueryConfig,
+    'simulation',
+  );
+  return result.rows.length > 0;
+};

--- a/src/repositories/simulation-studio/faker-semantic-data.repository.ts
+++ b/src/repositories/simulation-studio/faker-semantic-data.repository.ts
@@ -1,0 +1,27 @@
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+
+export interface FakerSemanticDataType {
+  id: number;
+  name: string;
+}
+
+const mapRow = (row: Record<string, unknown>): FakerSemanticDataType => ({
+  id: row.id as number,
+  name: row.name as string,
+});
+
+export const getFakerSemanticDataFromDb = async (): Promise<FakerSemanticDataType[]> => {
+  const query = `
+        SELECT id, name
+        FROM trs_faker_semantic_data_types
+        ORDER BY id ASC
+    `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.map(mapRow);
+};

--- a/src/repositories/simulation-studio/suite-generations.repository.ts
+++ b/src/repositories/simulation-studio/suite-generations.repository.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type { SuiteGeneration, CreateSuiteGenerationDto } from '../../interface/suite-generation.interface';
+
+const mapRowToGeneration = (row: Record<string, unknown>): SuiteGeneration => ({
+  id: row.id as number,
+  suite_id: row.suite_id as number,
+  generation_number: row.generation_number as number,
+  status: row.status as SuiteGeneration['status'],
+  simulation_type: row.simulation_type as SuiteGeneration['simulation_type'],
+  rule_repo: row.rule_repo as string | undefined,
+  rule_version: row.rule_version as string | undefined,
+  context_count: row.context_count as number,
+  trigger_count: row.trigger_count as number,
+  enrichment_table_count: row.enrichment_table_count as number,
+  generated_context_count: row.generated_context_count as number,
+  generated_trigger_count: row.generated_trigger_count as number,
+  generated_enrichment_row_count: row.generated_enrichment_row_count as number,
+  context_field_config_count: row.context_field_config_count as number,
+  trigger_field_config_count: row.trigger_field_config_count as number,
+  enrichment_field_config_count: row.enrichment_field_config_count as number,
+  wizard_snapshot:
+    typeof row.wizard_snapshot === 'string'
+      ? (JSON.parse(row.wizard_snapshot) as Record<string, unknown>)
+      : (row.wizard_snapshot as Record<string, unknown>),
+  generation_metadata:
+    typeof row.generation_metadata === 'string'
+      ? (JSON.parse(row.generation_metadata) as Record<string, unknown>)
+      : (row.generation_metadata as Record<string, unknown>),
+  created_by: row.created_by as string,
+  created_by_email: row.created_by_email as string | undefined,
+  created_at: new Date(row.created_at as string),
+  updated_at: new Date(row.updated_at as string),
+});
+
+export const createSuiteGenerationInDb = async (
+  dto: CreateSuiteGenerationDto,
+  userId: string,
+  userEmail?: string,
+): Promise<SuiteGeneration> => {
+  const query = `
+    WITH lock_row AS (
+      SELECT pg_advisory_xact_lock($1::bigint)
+    ),
+    next_num AS (
+      SELECT COALESCE(MAX(generation_number), 0) + 1 AS generation_number
+      FROM trs_suite_generations
+      WHERE suite_id = $1
+    )
+    INSERT INTO trs_suite_generations (
+      suite_id, generation_number, status, simulation_type,
+      rule_repo, rule_version,
+      context_count, trigger_count, enrichment_table_count,
+      generated_context_count, generated_trigger_count, generated_enrichment_row_count,
+      context_field_config_count, trigger_field_config_count, enrichment_field_config_count,
+      wizard_snapshot, generation_metadata,
+      created_by, created_by_email, created_at, updated_at
+    )
+    SELECT
+      $1, next_num.generation_number, 'DRAFT', $2,
+      $3, $4,
+      0, 0, 0,
+      0, 0, 0,
+      0, 0, 0,
+      $5, $6,
+      $7, $8, NOW(), NOW()
+    FROM next_num, lock_row
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: query,
+      values: [
+        dto.suite_id,
+        dto.simulation_type ?? 'SINGLE_RULE',
+        dto.rule_repo ?? null,
+        dto.rule_version ?? null,
+        JSON.stringify(dto.wizard_snapshot ?? {}),
+        JSON.stringify(dto.generation_metadata ?? {}),
+        userId,
+        userEmail ?? null,
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return mapRowToGeneration(result.rows[0]);
+};
+
+export const getNextGenerationNumber = async (suiteId: number): Promise<number> => {
+  const query = `
+    SELECT COALESCE(MAX(generation_number), 0) + 1 AS next_num
+    FROM trs_suite_generations
+    WHERE suite_id = $1
+  `;
+
+  const result = await handlePostExecuteSqlStatement<{ next_num: number }>(
+    { text: query, values: [suiteId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows[0].next_num;
+};
+
+export const getGenerationsBySuiteId = async (suiteId: number): Promise<SuiteGeneration[]> => {
+  const query = `
+    SELECT *
+    FROM trs_suite_generations
+    WHERE suite_id = $1
+    ORDER BY generation_number ASC
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [suiteId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.map(mapRowToGeneration);
+};
+
+export const updateWizardProgressInDb = async (generationId: number, currentStep: number, completedSteps: number[]): Promise<void> => {
+  await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: `
+        UPDATE trs_suite_generations
+        SET wizard_snapshot = jsonb_set(
+              jsonb_set(
+                wizard_snapshot,
+                '{currentStep}',
+                to_jsonb($1::int)
+              ),
+              '{completedSteps}',
+              $2::jsonb
+            ),
+            updated_at = NOW()
+        WHERE id = $3
+      `,
+      values: [currentStep, JSON.stringify(completedSteps), generationId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+};
+
+export const updateGenerationCountsInDb = async (
+  generationId: number,
+  counts: { context_count?: number; trigger_count?: number; enrichment_table_count?: number },
+): Promise<void> => {
+  const updates: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  if (counts.context_count !== undefined) {
+    updates.push(`context_count = $${idx++}`);
+    values.push(counts.context_count);
+  }
+  if (counts.trigger_count !== undefined) {
+    updates.push(`trigger_count = $${idx++}`);
+    values.push(counts.trigger_count);
+  }
+  if (counts.enrichment_table_count !== undefined) {
+    updates.push(`enrichment_table_count = $${idx++}`);
+    values.push(counts.enrichment_table_count);
+  }
+
+  if (updates.length === 0) return;
+
+  values.push(generationId);
+  await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: `UPDATE trs_suite_generations SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $${idx}`,
+      values,
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+};
+
+export interface GenerationSummary {
+  generation_id: number;
+  generation_number: number;
+  status: string;
+  suite_name: string;
+  associated_rule: string | null;
+  primary_txtp: string | null;
+  context_txtp_configs: Array<{ txtp: string; txtp_version: string; message_count: number }>;
+  enrichment_table_names: string[];
+  context_count: number;
+  trigger_count: number;
+  enrichment_table_count: number;
+  iteration_number: number;
+}
+
+export const getGenerationSummaryFromDb = async (generationId: number): Promise<GenerationSummary | null> => {
+  const genResult = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: `
+        SELECT
+          g.id AS generation_id,
+          g.generation_number,
+          g.status,
+          g.context_count,
+          g.trigger_count,
+          g.enrichment_table_count,
+          s.name AS suite_name,
+          s.rule_name AS associated_rule,
+          s.primary_txtp,
+          s.iteration_count AS iteration_number
+        FROM trs_suite_generations g
+        JOIN trs_simulation_suites s ON s.id = g.suite_id
+        WHERE g.id = $1
+      `,
+      values: [generationId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  if (genResult.rows.length === 0) return null;
+  const [gen] = genResult.rows;
+
+  const ctxResult = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: 'SELECT txtp, txtp_version, message_count FROM trs_suite_context_txtp_configs WHERE generation_id = $1 ORDER BY display_order ASC',
+      values: [generationId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  const enrichResult = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: 'SELECT table_name FROM trs_suite_enrichment_tables WHERE generation_id = $1 ORDER BY table_order ASC',
+      values: [generationId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return {
+    generation_id: gen.generation_id as number,
+    generation_number: gen.generation_number as number,
+    status: gen.status as string,
+    suite_name: gen.suite_name as string,
+    associated_rule: gen.associated_rule as string | null,
+    primary_txtp: gen.primary_txtp as string | null,
+    context_txtp_configs: ctxResult.rows.map((r) => ({
+      txtp: r.txtp as string,
+      txtp_version: r.txtp_version as string,
+      message_count: r.message_count as number,
+    })),
+    enrichment_table_names: enrichResult.rows.map((r) => r.table_name as string),
+    context_count: gen.context_count as number,
+    trigger_count: gen.trigger_count as number,
+    enrichment_table_count: gen.enrichment_table_count as number,
+    iteration_number: gen.iteration_number as number,
+  };
+};
+
+export const getLatestGenerationBySuiteId = async (suiteId: number): Promise<SuiteGeneration | null> => {
+  const query = `
+    SELECT *
+    FROM trs_suite_generations
+    WHERE suite_id = $1
+    ORDER BY generation_number DESC
+    LIMIT 1
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [suiteId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  if (result.rows.length === 0) return null;
+  return mapRowToGeneration(result.rows[0]);
+};
+
+export const resumeGenerationInDb = async (suiteId: number): Promise<SuiteGeneration | null> => {
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: "Select * FROM trs_suite_generations WHERE suite_id = $1 AND status IN ('DRAFT') ORDER BY generation_number DESC LIMIT 1",
+      values: [suiteId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  if (result.rows.length === 0) return null;
+  return mapRowToGeneration(result.rows[0]);
+};

--- a/src/repositories/simulation-studio/suites.repository.ts
+++ b/src/repositories/simulation-studio/suites.repository.ts
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type {
+  SimulationSuite,
+  SimulationSuitesQueryOptions,
+  SimulationSuitesListResponse,
+  CreateSimulationSuiteDto,
+  UpdateSimulationSuiteDto,
+} from '../../interface/simulation-suites.interface';
+
+export const getSimulationSuitesFromDb = async (options: SimulationSuitesQueryOptions): Promise<SimulationSuitesListResponse> => {
+  const { tenantId, search, status, ruleName, txtp, updatedFrom, updatedTo, limit = 20, offset = 0 } = options;
+
+  const params: unknown[] = [];
+  let paramIndex = 1;
+
+  let whereClause = `WHERE tenant_id = $${paramIndex++}`;
+  params.push(tenantId);
+
+  if (search) {
+    whereClause += ` AND name ILIKE $${paramIndex++}`;
+    params.push(`%${search}%`);
+  }
+
+  if (status) {
+    whereClause += ` AND status = $${paramIndex++}`;
+    params.push(status);
+  }
+
+  if (ruleName) {
+    whereClause += ` AND rule_name ILIKE $${paramIndex++}`;
+    params.push(`%${ruleName}%`);
+  }
+
+  if (txtp) {
+    whereClause += ` AND primary_txtp ILIKE $${paramIndex++}`;
+    params.push(`%${txtp}%`);
+  }
+
+  if (updatedFrom) {
+    whereClause += ` AND updated_at >= $${paramIndex++}`;
+    params.push(updatedFrom);
+  }
+
+  if (updatedTo) {
+    whereClause += ` AND updated_at <= $${paramIndex++}`;
+    params.push(updatedTo);
+  }
+
+  // Get total count
+  const countQuery = `SELECT COUNT(*) as total FROM trs_simulation_suites ${whereClause}`;
+  const countResult = await handlePostExecuteSqlStatement<{ total: string }>(
+    {
+      text: countQuery,
+      values: params,
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  const total = parseInt(countResult.rows[0]?.total ?? '0', 10);
+
+  // Get paginated results
+  let query = `
+    SELECT 
+      id, tenant_id, name, description, simulation_type, status, rule_repo, rule_name, rule_version, rule_config,
+      primary_txtp, primary_txtp_version, clone_source_suite_id, iteration_count, run_count,
+      last_run_at, wizard_progress, metadata, created_by, created_by_email, created_at, updated_at
+    FROM trs_simulation_suites
+    ${whereClause}
+    ORDER BY updated_at DESC
+  `;
+
+  const queryParams = [...params];
+  queryParams.push(limit);
+  queryParams.push(offset);
+
+  query += ` LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
+
+  const result = await handlePostExecuteSqlStatement<SimulationSuite>(
+    {
+      text: query,
+      values: queryParams,
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return {
+    data: result.rows.map((row) => ({
+      ...row,
+      rule_config: row.rule_config
+        ? typeof row.rule_config === 'string'
+          ? (JSON.parse(row.rule_config) as Record<string, unknown>)
+          : row.rule_config
+        : {},
+      wizard_progress: normalizeWizardProgress(row.wizard_progress),
+      metadata: typeof row.metadata === 'string' ? (JSON.parse(row.metadata) as Record<string, unknown>) : row.metadata,
+      created_at: new Date(row.created_at),
+      updated_at: new Date(row.updated_at),
+      last_run_at: row.last_run_at ? new Date(row.last_run_at) : undefined,
+    })),
+    total,
+    limit,
+    offset,
+  };
+};
+
+const normalizeWizardProgress = (raw: unknown): Record<string, unknown> => {
+  const wp = (typeof raw === 'string' ? (JSON.parse(raw) as Record<string, unknown>) : raw) as Record<string, unknown>;
+  // Migrate legacy format { step, completed } → { currentStep, completedSteps }
+  if (!Array.isArray(wp.completedSteps)) {
+    const step = typeof wp.currentStep === 'number' ? wp.currentStep : typeof wp.step === 'number' ? wp.step : 1;
+    return { ...wp, currentStep: step, completedSteps: Array.from({ length: step }, (_, i) => i + 1) };
+  }
+  return wp;
+};
+
+export const getSimulationSuiteByIdFromDb = async (id: number, tenantId: string): Promise<SimulationSuite | null> => {
+  const query = `
+    SELECT 
+      id, tenant_id, name, description, simulation_type, status, rule_repo, rule_name, rule_version, rule_config,
+      primary_txtp, primary_txtp_version, clone_source_suite_id, iteration_count, run_count,
+      last_run_at, wizard_progress, metadata, created_by, created_by_email, created_at, updated_at
+    FROM trs_simulation_suites
+    WHERE id = $1 AND tenant_id = $2
+  `;
+
+  const result = await handlePostExecuteSqlStatement<SimulationSuite>(
+    {
+      text: query,
+      values: [id, tenantId],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const [row] = result.rows;
+  return {
+    ...row,
+    rule_config: row.rule_config
+      ? typeof row.rule_config === 'string'
+        ? (JSON.parse(row.rule_config) as Record<string, unknown>)
+        : row.rule_config
+      : {},
+    wizard_progress: normalizeWizardProgress(row.wizard_progress),
+    metadata: typeof row.metadata === 'string' ? (JSON.parse(row.metadata) as Record<string, unknown>) : row.metadata,
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
+    last_run_at: row.last_run_at ? new Date(row.last_run_at) : undefined,
+  };
+};
+
+export const createSimulationSuiteInDb = async (
+  payload: CreateSimulationSuiteDto,
+  tenantId: string,
+  userId: string,
+  userEmail?: string,
+): Promise<SimulationSuite> => {
+  const query = `
+    INSERT INTO trs_simulation_suites (
+      tenant_id, name, description, simulation_type, status, rule_repo, rule_name, rule_version, rule_config,
+      primary_txtp, primary_txtp_version, clone_source_suite_id, iteration_count, run_count,
+      wizard_progress, metadata, created_by, created_by_email, created_at, updated_at
+    ) VALUES (
+      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, NOW(), NOW()
+    )
+    RETURNING 
+      id, tenant_id, name, description, simulation_type, status, rule_repo, rule_name, rule_version, rule_config,
+      primary_txtp, primary_txtp_version, clone_source_suite_id, iteration_count, run_count,
+      last_run_at, wizard_progress, metadata, created_by, created_by_email, created_at, updated_at
+  `;
+
+  // Initialize wizard_progress with step 1 completed
+  const wizardProgress = payload.wizard_progress ?? {
+    currentStep: 1,
+    completedSteps: [1],
+  };
+
+  const result = await handlePostExecuteSqlStatement<SimulationSuite>(
+    {
+      text: query,
+      values: [
+        tenantId,
+        payload.name,
+        payload.description ?? null,
+        payload.simulation_type ?? 'SINGLE_RULE',
+        'DRAFT',
+        payload.rule_repo ?? null,
+        payload.rule_name ?? null,
+        payload.rule_version ?? null,
+        payload.rule_config ? JSON.stringify(payload.rule_config) : null,
+        payload.primary_txtp ?? null,
+        payload.primary_txtp_version ?? null,
+        payload.clone_source_suite_id ?? null,
+        0,
+        0,
+        JSON.stringify(wizardProgress),
+        JSON.stringify(payload.metadata ?? {}),
+        userId,
+        userEmail ?? null,
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  const [row] = result.rows;
+  return {
+    ...row,
+    rule_config: row.rule_config
+      ? typeof row.rule_config === 'string'
+        ? (JSON.parse(row.rule_config) as Record<string, unknown>)
+        : row.rule_config
+      : {},
+    wizard_progress:
+      typeof row.wizard_progress === 'string' ? (JSON.parse(row.wizard_progress) as Record<string, unknown>) : row.wizard_progress,
+    metadata: typeof row.metadata === 'string' ? (JSON.parse(row.metadata) as Record<string, unknown>) : row.metadata,
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
+  };
+};
+
+export const updateSimulationSuiteInDb = async (
+  id: number,
+  tenantId: string,
+  payload: UpdateSimulationSuiteDto,
+): Promise<SimulationSuite | null> => {
+  const updates: string[] = [];
+  const values: unknown[] = [];
+  let paramIndex = 1;
+
+  interface FieldConfig {
+    key: keyof UpdateSimulationSuiteDto;
+    column: string;
+    transform?: (value: unknown) => unknown;
+  }
+
+  const nullableValue = (value: unknown): unknown => value ?? null;
+
+  const fieldConfigs: FieldConfig[] = [
+    { key: 'name', column: 'name' },
+    { key: 'description', column: 'description', transform: nullableValue },
+    { key: 'simulation_type', column: 'simulation_type' },
+    { key: 'status', column: 'status' },
+    { key: 'rule_repo', column: 'rule_repo', transform: nullableValue },
+    { key: 'rule_name', column: 'rule_name', transform: nullableValue },
+    { key: 'rule_version', column: 'rule_version', transform: nullableValue },
+    { key: 'rule_config', column: 'rule_config', transform: (value: unknown) => (value ? JSON.stringify(value) : null) },
+    { key: 'primary_txtp', column: 'primary_txtp', transform: nullableValue },
+    { key: 'primary_txtp_version', column: 'primary_txtp_version', transform: nullableValue },
+    { key: 'iteration_count', column: 'iteration_count' },
+    { key: 'run_count', column: 'run_count' },
+    { key: 'last_run_at', column: 'last_run_at', transform: nullableValue },
+    { key: 'wizard_progress', column: 'wizard_progress', transform: (value: unknown) => JSON.stringify(value) },
+    { key: 'metadata', column: 'metadata', transform: (value: unknown) => JSON.stringify(value) },
+  ];
+
+  for (const { key, column, transform } of fieldConfigs) {
+    const rawValue = payload[key];
+
+    if (rawValue !== undefined) {
+      updates.push(`${column} = $${paramIndex++}`);
+      values.push(transform ? transform(rawValue) : rawValue);
+    }
+  }
+
+  if (updates.length === 0) {
+    return await getSimulationSuiteByIdFromDb(id, tenantId);
+  }
+
+  updates.push('updated_at = NOW()');
+
+  const query = `
+    UPDATE trs_simulation_suites
+    SET ${updates.join(', ')}
+    WHERE id = $${paramIndex++} AND tenant_id = $${paramIndex++}
+    RETURNING 
+      id, tenant_id, name, description, simulation_type, status, rule_repo, rule_name, rule_version, rule_config,
+      primary_txtp, primary_txtp_version, clone_source_suite_id, iteration_count, run_count,
+      last_run_at, wizard_progress, metadata, created_by, created_by_email, created_at, updated_at
+  `;
+
+  values.push(id, tenantId);
+
+  const result = await handlePostExecuteSqlStatement<SimulationSuite>(
+    {
+      text: query,
+      values,
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const [row] = result.rows;
+  return {
+    ...row,
+    rule_config: row.rule_config
+      ? typeof row.rule_config === 'string'
+        ? (JSON.parse(row.rule_config) as Record<string, unknown>)
+        : row.rule_config
+      : {},
+    wizard_progress:
+      typeof row.wizard_progress === 'string' ? (JSON.parse(row.wizard_progress) as Record<string, unknown>) : row.wizard_progress,
+    metadata: typeof row.metadata === 'string' ? (JSON.parse(row.metadata) as Record<string, unknown>) : row.metadata,
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
+    last_run_at: row.last_run_at ? new Date(row.last_run_at) : undefined,
+  };
+};

--- a/src/repositories/simulation-studio/trigger-field-strategies.repository.ts
+++ b/src/repositories/simulation-studio/trigger-field-strategies.repository.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type { TriggerFieldOverride, UpsertTriggerFieldOverrideDto } from '../../interface/suite-generation.interface';
+
+const mapRow = (row: Record<string, unknown>): TriggerFieldOverride => ({
+  id: row.id as number,
+  trigger_txtp_config_id: row.trigger_txtp_config_id as number,
+  field_path: row.field_path as string,
+  override_type: row.override_type as TriggerFieldOverride['override_type'],
+  static_value: row.static_value ?? undefined,
+  range_min: row.range_min as number | undefined,
+  range_max: row.range_max as number | undefined,
+  faker_semantic_type: row.faker_semantic_type as string | undefined,
+  generator_options:
+    typeof row.generator_options === 'string'
+      ? (JSON.parse(row.generator_options) as Record<string, unknown>)
+      : (row.generator_options as Record<string, unknown>),
+  created_at: new Date(row.created_at as string),
+});
+
+export const upsertTriggerFieldOverrideInDb = async (
+  triggerTxtpConfigId: number,
+  dto: UpsertTriggerFieldOverrideDto,
+): Promise<TriggerFieldOverride> => {
+  const query = `
+    INSERT INTO trs_suite_trigger_field_overrides (
+      trigger_txtp_config_id, field_path, override_type,
+      static_value, range_min, range_max,
+      faker_semantic_type, generator_options,
+      created_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+    ON CONFLICT (trigger_txtp_config_id, field_path)
+    DO UPDATE SET
+      override_type     = EXCLUDED.override_type,
+      static_value      = EXCLUDED.static_value,
+      range_min         = EXCLUDED.range_min,
+      range_max         = EXCLUDED.range_max,
+      faker_semantic_type    = EXCLUDED.faker_semantic_type,
+      generator_options = EXCLUDED.generator_options
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: query,
+      values: [
+        triggerTxtpConfigId,
+        dto.field_path,
+        dto.override_type,
+        dto.static_value !== undefined ? JSON.stringify(dto.static_value) : null,
+        dto.range_min ?? null,
+        dto.range_max ?? null,
+        dto.faker_semantic_type ?? null,
+        JSON.stringify(dto.generator_options ?? {}),
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return mapRow(result.rows[0]);
+};
+
+export const getTriggerFieldOverridesByConfigId = async (triggerTxtpConfigId: number): Promise<TriggerFieldOverride[]> => {
+  const query = `
+    SELECT * FROM trs_suite_trigger_field_overrides
+    WHERE trigger_txtp_config_id = $1
+    ORDER BY field_path ASC
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [triggerTxtpConfigId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.map(mapRow);
+};

--- a/src/repositories/simulation-studio/trigger-txtp-configs.repository.ts
+++ b/src/repositories/simulation-studio/trigger-txtp-configs.repository.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type {
+  SuiteTriggerTxtpConfig,
+  CreateTriggerTxtpConfigDto,
+  UpdateTriggerTxtpConfigDto,
+} from '../../interface/suite-generation.interface';
+
+const mapRow = (row: Record<string, unknown>): SuiteTriggerTxtpConfig => ({
+  id: row.id as number,
+  generation_id: row.generation_id as number,
+  txtp: row.txtp as string,
+  txtp_version: row.txtp_version as string,
+  display_order: row.display_order as number,
+  message_count: row.message_count as number,
+  link_to_context_pairs: row.link_to_context_pairs as boolean,
+  payload_template_json:
+    typeof row.payload_template_json === 'string'
+      ? (JSON.parse(row.payload_template_json) as Record<string, unknown>)
+      : (row.payload_template_json as Record<string, unknown>),
+  expected_independent_variable: row.expected_independent_variable as number | undefined,
+  expected_result_band: row.expected_result_band as SuiteTriggerTxtpConfig['expected_result_band'],
+  notes: row.notes as string | undefined,
+  faker_seed: row.faker_seed as number | undefined,
+  generator_profile:
+    typeof row.generator_profile === 'string'
+      ? (JSON.parse(row.generator_profile) as Record<string, unknown>)
+      : (row.generator_profile as Record<string, unknown>),
+  created_at: new Date(row.created_at as string),
+});
+
+export const createTriggerTxtpConfigInDb = async (dto: CreateTriggerTxtpConfigDto): Promise<SuiteTriggerTxtpConfig> => {
+  const query = `
+    INSERT INTO trs_suite_trigger_txtp_configs (
+      generation_id, txtp, txtp_version, display_order, message_count,
+      payload_template_json, link_to_context_pairs,
+      expected_independent_variable, expected_result_band, notes,
+      faker_seed, generator_profile, created_at
+    ) VALUES (
+      $1, $2, $3, $4, $5,
+      $6, $7,
+      $8, $9, $10,
+      $11, $12, NOW()
+    )
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    {
+      text: query,
+      values: [
+        dto.generation_id,
+        dto.txtp,
+        dto.txtp_version,
+        dto.display_order,
+        dto.message_count,
+        JSON.stringify(dto.payload_template_json),
+        dto.link_to_context_pairs ?? false,
+        dto.expected_independent_variable ?? null,
+        dto.expected_result_band ?? null,
+        dto.notes ?? null,
+        dto.faker_seed ?? null,
+        JSON.stringify(dto.generator_profile ?? {}),
+      ],
+    } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return mapRow(result.rows[0]);
+};
+
+export const updateTriggerTxtpConfigInDb = async (id: number, dto: UpdateTriggerTxtpConfigDto): Promise<SuiteTriggerTxtpConfig | null> => {
+  const updates: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  if (dto.message_count !== undefined) {
+    updates.push(`message_count = $${idx++}`);
+    values.push(dto.message_count);
+  }
+  if (dto.link_to_context_pairs !== undefined) {
+    updates.push(`link_to_context_pairs = $${idx++}`);
+    values.push(dto.link_to_context_pairs);
+  }
+  if (dto.payload_template_json !== undefined) {
+    updates.push(`payload_template_json = $${idx++}`);
+    values.push(JSON.stringify(dto.payload_template_json));
+  }
+  if (dto.expected_independent_variable !== undefined) {
+    updates.push(`expected_independent_variable = $${idx++}`);
+    values.push(dto.expected_independent_variable);
+  }
+  if (dto.expected_result_band !== undefined) {
+    updates.push(`expected_result_band = $${idx++}`);
+    values.push(dto.expected_result_band);
+  }
+  if (dto.notes !== undefined) {
+    updates.push(`notes = $${idx++}`);
+    values.push(dto.notes);
+  }
+  if (dto.faker_seed !== undefined) {
+    updates.push(`faker_seed = $${idx++}`);
+    values.push(dto.faker_seed);
+  }
+  if (dto.generator_profile !== undefined) {
+    updates.push(`generator_profile = $${idx++}`);
+    values.push(JSON.stringify(dto.generator_profile));
+  }
+
+  if (updates.length === 0) {
+    const existing = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+      { text: 'SELECT * FROM trs_suite_trigger_txtp_configs WHERE id = $1', values: [id] } satisfies PgQueryConfig,
+      'simulation',
+    );
+    return existing.rows.length ? mapRow(existing.rows[0]) : null;
+  }
+
+  values.push(id);
+  const query = `
+    UPDATE trs_suite_trigger_txtp_configs
+    SET ${updates.join(', ')}
+    WHERE id = $${idx}
+    RETURNING *
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.length ? mapRow(result.rows[0]) : null;
+};
+
+export const deleteTriggerTxtpConfigInDb = async (id: number): Promise<boolean> => {
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: 'DELETE FROM trs_suite_trigger_txtp_configs WHERE id = $1 RETURNING id', values: [id] } satisfies PgQueryConfig,
+    'simulation',
+  );
+  return result.rows.length > 0;
+};
+
+export const getTriggerTxtpConfigsByGenerationId = async (generationId: number): Promise<SuiteTriggerTxtpConfig[]> => {
+  const query = `
+    SELECT *
+    FROM trs_suite_trigger_txtp_configs
+    WHERE generation_id = $1
+    ORDER BY display_order ASC
+  `;
+
+  const result = await handlePostExecuteSqlStatement<Record<string, unknown>>(
+    { text: query, values: [generationId] } satisfies PgQueryConfig,
+    'simulation',
+  );
+
+  return result.rows.map(mapRow);
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -64,6 +64,28 @@ import {
   getRuleConfigurationHandler,
   getRuleFlowHandler,
   updateRuleHandler,
+  updateSimulationHandler,
+  createSimulationHandler,
+  getSimulationByIdHandler,
+  getSimulationsHandler,
+  getSuiteGenerationsHandler,
+  getLatestSuiteGenerationHandler,
+  getGenerationContextConfigsHandler,
+  addContextTxtpConfigHandler,
+  updateContextTxtpConfigHandler,
+  getTriggerConfigsHandler,
+  addTriggerTxtpConfigHandler,
+  bulkUpdateTriggerConfigsHandler,
+  createEnrichmentTableHandler,
+  getEnrichmentTablesHandler,
+  bulkUpdateEnrichmentTablesHandler,
+  deleteEnrichmentTableHandler,
+  getGenerationSummaryHandler,
+  updateWizardProgressHandler,
+  deleteContextTxtpConfigHandler,
+  deleteTriggerTxtpConfigHandler,
+  resumeGenerationHandler,
+  getFakerSemanticDataHandler,
 } from './app.controller';
 import { NetworkMapRepo, RuleConfigRepo, TypologyConfigRepo } from './repositories';
 import {
@@ -140,6 +162,35 @@ const routePrivilege = {
   getSimulationLogs: ['editor', 'approver'],
   getDataModelJson: ['editor', 'approver', 'exporter', 'publisher'],
   putDataModelJson: ['editor', 'approver', 'exporter', 'publisher'],
+  createMask: 'trs_data_engineer_editor',
+  updateMask: 'trs_data_engineer_editor',
+  reviewMask: 'trs_data_engineer_approver',
+  createSimulationSuites: ['editor', 'approver'],
+  getSimulationSuites: ['editor', 'approver'],
+  getSimulationSuiteById: ['editor', 'approver'],
+  updateSimulationSuite: ['editor', 'approver'],
+  getSuiteGenerations: ['editor', 'approver'],
+  getGenerationContextConfigs: ['editor', 'approver'],
+  addContextTxtpConfig: ['editor', 'approver'],
+  updateContextTxtpConfig: ['editor', 'approver'],
+  getTriggerConfigs: ['editor', 'approver'],
+  addTriggerTxtpConfig: ['editor', 'approver'],
+  bulkUpdateTriggerConfigs: ['editor', 'approver'],
+  getEnrichmentTables: ['editor', 'approver'],
+  createEnrichmentTable: ['editor', 'approver'],
+  bulkUpdateEnrichmentTables: ['editor', 'approver'],
+  deleteEnrichmentTable: ['editor', 'approver'],
+  getGenerationSummary: ['editor', 'approver'],
+  updateWizardProgress: ['editor', 'approver'],
+  deleteContextTxtpConfig: ['editor', 'approver'],
+  deleteTriggerTxtpConfig: ['editor', 'approver'],
+  getSimulations: ['editor', 'approver'],
+  createSimulation: ['editor', 'approver'],
+  getSimulationStats: ['editor', 'approver'],
+  getSimulationResults: ['editor', 'approver'],
+  saveRecordInTrsSimulation: ['editor', 'approver', 'exporter', 'publisher'],
+  resumeGeneration: ['editor', 'approver'],
+  getFakerSemanticData: ['editor', 'approver'],
 };
 
 function Routes(fastify: FastifyInstance): void {
@@ -422,6 +473,98 @@ function Routes(fastify: FastifyInstance): void {
   fastify.get('/v1/admin/simulation-logs/:ruleId', {
     ...SetOptionsBodyAndParams(getSimulationLogsHandler, routePrivilege.getSimulationLogs),
   });
+
+  //---------------------------------------- Simulation Studio ---------------------------------------------
+
+  fastify.post('/v1/admin/trs/simulation-studio/suites', {
+    ...SetOptionsBodyAndParams(createSimulationHandler, routePrivilege.createSimulationSuites),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/suites', {
+    ...SetOptionsBodyAndParams(getSimulationsHandler, routePrivilege.getSimulationSuites),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/suites/:id', {
+    ...SetOptionsBodyAndParams(getSimulationByIdHandler, routePrivilege.getSimulationSuiteById),
+  });
+
+  fastify.patch('/v1/admin/trs/simulation-studio/suites/:id', {
+    ...SetOptionsBodyAndParams(updateSimulationHandler, routePrivilege.updateSimulationSuite),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/suites/:id/generations', {
+    ...SetOptionsBodyAndParams(getSuiteGenerationsHandler, routePrivilege.getSuiteGenerations),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/suites/:id/generations/latest', {
+    ...SetOptionsBodyAndParams(getLatestSuiteGenerationHandler, routePrivilege.getSuiteGenerations),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs', {
+    ...SetOptionsBodyAndParams(getGenerationContextConfigsHandler, routePrivilege.getGenerationContextConfigs),
+  });
+
+  fastify.post('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs', {
+    ...SetOptionsBodyAndParams(addContextTxtpConfigHandler, routePrivilege.addContextTxtpConfig),
+  });
+
+  fastify.patch('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs', {
+    ...SetOptionsBodyAndParams(updateContextTxtpConfigHandler, routePrivilege.updateContextTxtpConfig),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/generations/:generationId/trigger-configs', {
+    ...SetOptionsBodyAndParams(getTriggerConfigsHandler, routePrivilege.getTriggerConfigs),
+  });
+
+  fastify.post('/v1/admin/trs/simulation-studio/generations/:generationId/trigger-configs', {
+    ...SetOptionsBodyAndParams(addTriggerTxtpConfigHandler, routePrivilege.addTriggerTxtpConfig),
+  });
+
+  fastify.patch('/v1/admin/trs/simulation-studio/generations/:generationId/trigger-configs', {
+    ...SetOptionsBodyAndParams(bulkUpdateTriggerConfigsHandler, routePrivilege.bulkUpdateTriggerConfigs),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/generations/:generationId/enrichment-tables', {
+    ...SetOptionsBodyAndParams(getEnrichmentTablesHandler, routePrivilege.getEnrichmentTables),
+  });
+
+  fastify.post('/v1/admin/trs/simulation-studio/generations/:generationId/enrichment-tables', {
+    ...SetOptionsBodyAndParams(createEnrichmentTableHandler, routePrivilege.createEnrichmentTable),
+  });
+
+  fastify.patch('/v1/admin/trs/simulation-studio/generations/:generationId/enrichment-tables', {
+    ...SetOptionsBodyAndParams(bulkUpdateEnrichmentTablesHandler, routePrivilege.bulkUpdateEnrichmentTables),
+  });
+
+  fastify.delete('/v1/admin/trs/simulation-studio/generations/:generationId/enrichment-tables/:tableId', {
+    ...SetOptionsBodyAndParams(deleteEnrichmentTableHandler, routePrivilege.deleteEnrichmentTable),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/generations/:generationId/summary', {
+    ...SetOptionsBodyAndParams(getGenerationSummaryHandler, routePrivilege.getGenerationSummary),
+  });
+
+  fastify.patch('/v1/admin/trs/simulation-studio/generations/:generationId/wizard-progress', {
+    ...SetOptionsBodyAndParams(updateWizardProgressHandler, routePrivilege.updateWizardProgress),
+  });
+
+  fastify.delete('/v1/admin/trs/simulation-studio/generations/:generationId/context-configs/:configId', {
+    ...SetOptionsBodyAndParams(deleteContextTxtpConfigHandler, routePrivilege.deleteContextTxtpConfig),
+  });
+
+  fastify.delete('/v1/admin/trs/simulation-studio/generations/:generationId/trigger-configs/:configId', {
+    ...SetOptionsBodyAndParams(deleteTriggerTxtpConfigHandler, routePrivilege.deleteTriggerTxtpConfig),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/suites/:suiteId/generation/resume', {
+    ...SetOptionsBodyAndParams(resumeGenerationHandler, routePrivilege.resumeGeneration),
+  });
+
+  fastify.get('/v1/admin/trs/simulation-studio/faker-semantic-data', {
+    ...SetOptionsBodyAndParams(getFakerSemanticDataHandler, routePrivilege.getFakerSemanticData),
+  });
+
+  //--------------------------------- END SIMULATION STUDIO -----------------------------------------------------
 }
 
 export default Routes;

--- a/src/services/context-txtp-config.logic.service.ts
+++ b/src/services/context-txtp-config.logic.service.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+import type {
+  ContextFieldStrategy,
+  AddContextTxtpConfigDto,
+  BulkConfigItemDto,
+  ContextTxtpConfigWithStrategies,
+} from '../interface/suite-generation.interface';
+import {
+  createContextTxtpConfigInDb,
+  updateContextTxtpConfigInDb,
+  getContextTxtpConfigsByGenerationId,
+  deleteContextTxtpConfigInDb,
+} from '../repositories/simulation-studio/context-txtp-configs.repository';
+import {
+  upsertFieldStrategyInDb,
+  getFieldStrategiesByContextConfigId,
+} from '../repositories/simulation-studio/context-field-strategies.repository';
+import { getSchemaByTransactionType } from '../repositories/configuration/tcs.config.repository';
+import { ContentType } from '@tazama-lf/tcs-lib';
+import { HttpException, HttpStatus } from '../utils/error';
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+const flattenSchemaPaths = (obj: unknown, prefix = ''): string[] => {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return prefix ? [prefix] : [];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, val]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'object' && val !== null && !Array.isArray(val) && Object.keys(val).length > 0) {
+      return flattenSchemaPaths(val, path);
+    }
+    return [path];
+  });
+};
+
+// ── Shared factory ───────────────────────────────────────────────────────────
+
+/**
+ * Creates a context txtp config row and seeds all field paths with strategy_code = 'keep_sample'.
+ * Used by Step 1 (suite creation) and Step 2 (Add TXTP button).
+ * Throws HttpException if tcs_config row not found.
+ */
+interface CreateConfigOptions {
+  generationId: number;
+  txtp: string;
+  txtpVersion: string;
+  messageCount: number;
+  displayOrder: number;
+  tenantId: string;
+}
+
+const isMissingTcsConfigError = (error: unknown): boolean =>
+  error instanceof Error && error.message.toLowerCase().includes('configuration not found');
+
+export const createConfigWithDefaultStrategies = async (opts: CreateConfigOptions): Promise<ContextTxtpConfigWithStrategies> => {
+  const { generationId, txtp, txtpVersion, messageCount, displayOrder, tenantId } = opts;
+  const tcsRow = await getSchemaByTransactionType(txtp, txtpVersion, tenantId);
+
+  const schema = tcsRow.schema as Record<string, unknown>;
+  const samplePayload = (tcsRow.content_type === (ContentType.XML as string) ? tcsRow.payload_xml : tcsRow.payload_json) as
+    | Record<string, unknown>
+    | undefined;
+
+  const config = await createContextTxtpConfigInDb({
+    generation_id: generationId,
+    txtp,
+    txtp_version: txtpVersion,
+    display_order: displayOrder,
+    message_count: messageCount,
+    schema_snapshot: schema,
+    sample_payload_snapshot: samplePayload,
+  });
+
+  const schemaFallback = (schema.properties as Record<string, unknown> | undefined) ?? schema;
+  const fieldPaths = flattenSchemaPaths(samplePayload ?? schemaFallback);
+  const fieldStrategies = await Promise.all(
+    fieldPaths.map(async (path) => await upsertFieldStrategyInDb(config.id, { field_path: path, strategy_code: 'keep_sample' })),
+  );
+
+  return {
+    context_txtp_config_id: config.id,
+    txtp: config.txtp,
+    txtp_version: config.txtp_version,
+    message_count: config.message_count,
+    display_order: config.display_order,
+    schema_snapshot: config.schema_snapshot,
+    sample_payload_snapshot: config.sample_payload_snapshot,
+    field_strategies: fieldStrategies,
+  };
+};
+
+// ── Step 1 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Called during suite creation. Creates the primary context txtp config with default strategies.
+ */
+export const createContextTxtpConfig = async (
+  generationId: number,
+  txtp: string,
+  txtpVersion: string,
+  tenantId: string,
+): Promise<ContextTxtpConfigWithStrategies> => {
+  try {
+    return await createConfigWithDefaultStrategies({ generationId, txtp, txtpVersion, messageCount: 100, displayOrder: 1, tenantId });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    if (isMissingTcsConfigError(error)) {
+      throw new HttpException(`Configuration not found for ${txtp} ${txtpVersion}`, HttpStatus.NOT_FOUND);
+    }
+    throw new HttpException(
+      `Failed to create context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 2: Add TXTP ─────────────────────────────────────────────────────────
+
+/**
+ * Called when user clicks "Add TXTP". display_order = existing count + 1.
+ */
+export const addContextTxtpConfig = async (
+  generationId: number,
+  dto: AddContextTxtpConfigDto,
+  tenantId: string,
+): Promise<ContextTxtpConfigWithStrategies> => {
+  try {
+    const existing = await getContextTxtpConfigsByGenerationId(generationId);
+    const displayOrder = existing.length + 1;
+    return await createConfigWithDefaultStrategies({
+      generationId,
+      txtp: dto.txtp,
+      txtpVersion: dto.txtp_version,
+      messageCount: dto.message_count ?? 100,
+      displayOrder,
+      tenantId,
+    });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    if (isMissingTcsConfigError(error)) {
+      throw new HttpException(`Configuration not found for ${dto.txtp} ${dto.txtp_version}`, HttpStatus.NOT_FOUND);
+    }
+    throw new HttpException(
+      `Failed to add context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 2: GET all ──────────────────────────────────────────────────────────
+
+/**
+ * Returns all context configs with field strategies for a generation.
+ */
+export const getContextConfigsWithStrategies = async (generationId: number): Promise<ContextTxtpConfigWithStrategies[]> => {
+  try {
+    const configs = await getContextTxtpConfigsByGenerationId(generationId);
+    return await Promise.all(
+      configs.map(async (config) => {
+        const fieldStrategies = await getFieldStrategiesByContextConfigId(config.id);
+        return {
+          context_txtp_config_id: config.id,
+          txtp: config.txtp,
+          txtp_version: config.txtp_version,
+          message_count: config.message_count,
+          display_order: config.display_order,
+          schema_snapshot: config.schema_snapshot,
+          sample_payload_snapshot: config.sample_payload_snapshot,
+          field_strategies: fieldStrategies,
+        };
+      }),
+    );
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to retrieve context configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 2: Bulk update ──────────────────────────────────────────────────────
+
+/**
+ * Bulk update message_count + field strategies for all provided configs.
+ * Silently skips missing context_txtp_config_id entries.
+ * Returns full updated state for the generation.
+ */
+export const bulkUpdateContextConfigs = async (
+  generationId: number,
+  items: BulkConfigItemDto[],
+): Promise<ContextTxtpConfigWithStrategies[]> => {
+  try {
+    await Promise.all(
+      items.map(async (item) => {
+        const { context_txtp_config_id: contextTxtpConfigId, field_strategies: fieldStrategies, ...updateFields } = item;
+        // Skip malformed entries instead of issuing DB writes with an undefined id.
+        if (!Number.isInteger(contextTxtpConfigId) || contextTxtpConfigId <= 0) return;
+        if (Object.keys(updateFields).length > 0) {
+          await updateContextTxtpConfigInDb(contextTxtpConfigId, updateFields);
+        }
+        if (Array.isArray(fieldStrategies) && fieldStrategies.length > 0) {
+          await Promise.all(fieldStrategies.map(async (s) => await upsertFieldStrategyInDb(contextTxtpConfigId, s)));
+        }
+      }),
+    );
+    return await getContextConfigsWithStrategies(generationId);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to bulk update context configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Delete context txtp config ───────────────────────────────────────────────
+
+export const deleteContextTxtpConfig = async (configId: number): Promise<void> => {
+  try {
+    const deleted = await deleteContextTxtpConfigInDb(configId);
+    if (!deleted) throw new HttpException(`Context txtp config ${configId} not found`, HttpStatus.NOT_FOUND);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to delete context txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Read helper ──────────────────────────────────────────────────────────────
+
+export const getFieldStrategiesForContextConfig = async (contextTxtpConfigId: number): Promise<ContextFieldStrategy[]> => {
+  try {
+    return await getFieldStrategiesByContextConfigId(contextTxtpConfigId);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to retrieve field strategies: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/services/enrichment-table.logic.service.ts
+++ b/src/services/enrichment-table.logic.service.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { SuiteEnrichmentTable, BulkEnrichmentUpdateItemDto } from '../interface/suite-generation.interface';
+import {
+  createEnrichmentTableInDb,
+  getNextEnrichmentTableOrderInDb,
+  updateEnrichmentTableInDb,
+  getEnrichmentTablesByGenerationId,
+  deleteEnrichmentTableInDb,
+} from '../repositories/simulation-studio/enrichment-tables.repository';
+import { HttpException, HttpStatus } from '../utils/error';
+
+// ── Step 4: Create enrichment table ──────────────────────────────────────────
+
+/**
+ * POST — creates enrichment table row + seeds all payload column names with strategy_code = 'null'.
+ */
+export const createEnrichmentTable = async (
+  generationId: number,
+  tableName: string,
+  rowCount: number,
+  payloadTemplateJson?: Record<string, unknown>,
+  schemaTemplateJson?: Record<string, unknown>,
+): Promise<SuiteEnrichmentTable> => {
+  try {
+    // Keep ordering stable by assigning the next server-side order for the generation.
+    const tableOrder = await getNextEnrichmentTableOrderInDb(generationId);
+    const table = await createEnrichmentTableInDb({
+      generation_id: generationId,
+      table_name: tableName,
+      table_order: tableOrder,
+      row_count: rowCount,
+      payload_template_json: payloadTemplateJson,
+      schema_template_json: schemaTemplateJson,
+    });
+
+    return table;
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to create enrichment table: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 4: GET all ───────────────────────────────────────────────────────────
+
+export const getEnrichmentTables = async (generationId: number): Promise<SuiteEnrichmentTable[]> => {
+  try {
+    const tables = await getEnrichmentTablesByGenerationId(generationId);
+    return tables;
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to retrieve enrichment tables: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 4: Bulk update ───────────────────────────────────────────────────────
+
+export const bulkUpdateEnrichmentTables = async (
+  generationId: number,
+  items: BulkEnrichmentUpdateItemDto[],
+): Promise<SuiteEnrichmentTable[]> => {
+  try {
+    await Promise.all(
+      items.map(async (item) => {
+        const { id: tableId, ...updateFields } = item;
+        if (!Number.isInteger(tableId) || tableId <= 0) return;
+        if (Object.keys(updateFields).length > 0) {
+          const updated = await updateEnrichmentTableInDb(tableId, generationId, updateFields);
+          if (!updated) {
+            throw new HttpException(`Enrichment table ${tableId} not found for generation ${generationId}`, HttpStatus.NOT_FOUND);
+          }
+        }
+      }),
+    );
+    return await getEnrichmentTables(generationId);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to bulk update enrichment tables: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 4: Delete ────────────────────────────────────────────────────────────
+
+export const deleteEnrichmentTable = async (tableId: number): Promise<void> => {
+  try {
+    const deleted = await deleteEnrichmentTableInDb(tableId);
+    if (!deleted) throw new HttpException(`Enrichment table ${tableId} not found`, HttpStatus.NOT_FOUND);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to delete enrichment table: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/services/faker-semantic-data.logic.service.ts
+++ b/src/services/faker-semantic-data.logic.service.ts
@@ -1,0 +1,14 @@
+import { getFakerSemanticDataFromDb, type FakerSemanticDataType } from '../repositories/simulation-studio/faker-semantic-data.repository';
+
+import { HttpException, HttpStatus } from '../utils/error';
+
+export const getFakerSemanticData = async (): Promise<FakerSemanticDataType[]> => {
+  try {
+    return await getFakerSemanticDataFromDb();
+  } catch (error) {
+    throw new HttpException(
+      `Failed to get faker semantic data: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/services/simulation-logs.logic.service.ts
+++ b/src/services/simulation-logs.logic.service.ts
@@ -11,7 +11,16 @@ export const createSimulationLogs = async ({
   category,
   createdByEmail,
 }: SimulationLogRequest): Promise<void> => {
-  await createSimulationLogsInDb(userId, tenantId, ruleId, oldData, newData, description, category, createdByEmail);
+  await createSimulationLogsInDb({
+    userId,
+    tenantId,
+    ruleId,
+    oldData,
+    newData,
+    description,
+    category,
+    createdByEmail,
+  });
 };
 
 export const getSimulationLogs = async (

--- a/src/services/simulation-suites.logic.service.ts
+++ b/src/services/simulation-suites.logic.service.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+import type {
+  SimulationSuite,
+  CreateSimulationSuiteDto,
+  UpdateSimulationSuiteDto,
+  SimulationSuitesQueryOptions,
+  SimulationSuitesListResponse,
+} from '../interface/simulation-suites.interface';
+import {
+  getSimulationSuitesFromDb,
+  getSimulationSuiteByIdFromDb,
+  createSimulationSuiteInDb,
+  updateSimulationSuiteInDb,
+} from '../repositories/simulation-studio/suites.repository';
+import { createSuiteGeneration, createContextTxtpConfig } from './trs-suite-generation.logic.service';
+import { createTriggerTxtpConfig } from './trigger-txtp-config.logic.service';
+import { HttpException, HttpStatus } from '../utils/error';
+import { validateSimulationSuiteLengthConstraints } from '../utils/simulation-suite-validation';
+
+export const getSimulationSuites = async (options: SimulationSuitesQueryOptions): Promise<SimulationSuitesListResponse> => {
+  try {
+    return await getSimulationSuitesFromDb(options);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to retrieve simulation suites: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+export const getSimulationSuiteById = async (id: number, tenantId: string): Promise<SimulationSuite | null> => {
+  try {
+    const suite = await getSimulationSuiteByIdFromDb(id, tenantId);
+    if (!suite) throw new HttpException(`Simulation suite with id ${id} not found`, HttpStatus.NOT_FOUND);
+    return suite;
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to retrieve simulation suite: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+/**
+ * POST /suites — Step 1 (Rule & Details).
+ *
+ * Flow per plan:
+ *   1. INSERT trs_simulation_suites (status=DRAFT)
+ *   2. INSERT trs_suite_generations (generation_number=1)
+ *   3. Fetch schema + sample_payload from tcs_config by primary_txtp + version
+ *   4. INSERT trs_suite_context_txtp_configs with schema_snapshot + sample_payload_snapshot
+ */
+export const createSimulationSuite = async (
+  payload: CreateSimulationSuiteDto,
+  tenantId: string,
+  userId: string,
+  userEmail?: string,
+): Promise<SimulationSuite> => {
+  try {
+    if (!payload.name || payload.name.trim().length === 0) {
+      throw new HttpException('Simulation suite name is required', HttpStatus.BAD_REQUEST);
+    }
+
+    validateSimulationSuiteLengthConstraints(payload);
+
+    const suite = await createSimulationSuiteInDb(payload, tenantId, userId, userEmail);
+
+    const generation = await createSuiteGeneration(suite, userId, userEmail);
+
+    if (suite.primary_txtp && suite.primary_txtp_version) {
+      await Promise.all([
+        createContextTxtpConfig(generation.id, suite.primary_txtp, suite.primary_txtp_version, tenantId),
+        createTriggerTxtpConfig(generation.id, suite.primary_txtp, suite.primary_txtp_version, tenantId),
+      ]);
+    }
+
+    return { ...suite, generation_id: generation.id };
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to create simulation suite: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+export const updateSimulationSuite = async (id: number, tenantId: string, payload: UpdateSimulationSuiteDto): Promise<SimulationSuite> => {
+  try {
+    if (payload.name?.trim().length === 0) {
+      throw new HttpException('Simulation suite name cannot be empty', HttpStatus.BAD_REQUEST);
+    }
+
+    validateSimulationSuiteLengthConstraints(payload);
+
+    const updatedSuite = await updateSimulationSuiteInDb(id, tenantId, payload);
+
+    if (updatedSuite == null) throw new HttpException(`Simulation suite with id ${id} not found`, HttpStatus.NOT_FOUND);
+
+    return updatedSuite;
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to update simulation suite: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/services/trigger-txtp-config.logic.service.ts
+++ b/src/services/trigger-txtp-config.logic.service.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+import type {
+  TriggerFieldOverride,
+  AddTriggerTxtpConfigDto,
+  BulkTriggerConfigItemDto,
+  TriggerTxtpConfigWithOverrides,
+} from '../interface/suite-generation.interface';
+import {
+  createTriggerTxtpConfigInDb,
+  updateTriggerTxtpConfigInDb,
+  getTriggerTxtpConfigsByGenerationId,
+} from '../repositories/simulation-studio/trigger-txtp-configs.repository';
+import {
+  upsertTriggerFieldOverrideInDb,
+  getTriggerFieldOverridesByConfigId,
+} from '../repositories/simulation-studio/trigger-field-strategies.repository';
+import { getSchemaByTransactionType } from '../repositories/configuration/tcs.config.repository';
+import { ContentType } from '@tazama-lf/tcs-lib';
+import { HttpException, HttpStatus } from '../utils/error';
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+const flattenPayloadPaths = (obj: unknown, prefix = ''): string[] => {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return prefix ? [prefix] : [];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, val]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'object' && val !== null && !Array.isArray(val) && Object.keys(val).length > 0) {
+      return flattenPayloadPaths(val, path);
+    }
+    return [path];
+  });
+};
+
+// ── Shared factory ───────────────────────────────────────────────────────────
+
+interface CreateTriggerConfigOptions {
+  generationId: number;
+  txtp: string;
+  txtpVersion: string;
+  messageCount: number;
+  displayOrder: number;
+  tenantId: string;
+}
+
+const isMissingTcsConfigError = (error: unknown): boolean =>
+  error instanceof Error && error.message.toLowerCase().includes('configuration not found');
+
+/**
+ * Creates a trigger txtp config row using sample payload from tcs_config as payload_template_json.
+ * Seeds all payload field paths with override_type = 'null' (use payload as-is, no transformation).
+ * Throws if tcs_config row not found.
+ */
+export const createTriggerConfigWithDefaultStrategies = async (
+  opts: CreateTriggerConfigOptions,
+): Promise<TriggerTxtpConfigWithOverrides> => {
+  const { generationId, txtp, txtpVersion, messageCount, displayOrder, tenantId } = opts;
+  const tcsRow = await getSchemaByTransactionType(txtp, txtpVersion, tenantId);
+
+  // const schema = tcsRow.schema as Record<string, unknown>;
+  const payloadTemplate = (tcsRow.content_type === (ContentType.XML as string) ? tcsRow.payload_xml : tcsRow.payload_json) as
+    | Record<string, unknown>
+    | undefined;
+
+  const config = await createTriggerTxtpConfigInDb({
+    generation_id: generationId,
+    txtp,
+    txtp_version: txtpVersion,
+    display_order: displayOrder,
+    message_count: messageCount,
+    payload_template_json: payloadTemplate ?? {},
+  });
+
+  // Use payload for field paths;
+  const fieldPaths = flattenPayloadPaths(payloadTemplate);
+  const fieldOverrides = await Promise.all(
+    fieldPaths.map(async (path) => await upsertTriggerFieldOverrideInDb(config.id, { field_path: path, override_type: 'null' })),
+  );
+
+  return {
+    trigger_txtp_config_id: config.id,
+    txtp: config.txtp,
+    txtp_version: config.txtp_version,
+    message_count: config.message_count,
+    display_order: config.display_order,
+    payload_template_json: config.payload_template_json,
+    link_to_context_pairs: config.link_to_context_pairs,
+    expected_result_band: config.expected_result_band,
+    notes: config.notes,
+    field_overrides: fieldOverrides,
+  };
+};
+
+// ── Step 1 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Called during suite creation. Creates the primary trigger config. message_count = 1.
+ */
+export const createTriggerTxtpConfig = async (
+  generationId: number,
+  txtp: string,
+  txtpVersion: string,
+  tenantId: string,
+): Promise<TriggerTxtpConfigWithOverrides> => {
+  try {
+    return await createTriggerConfigWithDefaultStrategies({ generationId, txtp, txtpVersion, messageCount: 1, displayOrder: 1, tenantId });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    if (isMissingTcsConfigError(error)) {
+      throw new HttpException(`Configuration not found for ${txtp} ${txtpVersion}`, HttpStatus.NOT_FOUND);
+    }
+    throw new HttpException(
+      `Failed to create trigger txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 3: Add TXTP ─────────────────────────────────────────────────────────
+
+/**
+ * Called when user clicks "Add TXTP" in Step 3. display_order = existing count + 1.
+ */
+export const addTriggerTxtpConfig = async (
+  generationId: number,
+  dto: AddTriggerTxtpConfigDto,
+  tenantId: string,
+): Promise<TriggerTxtpConfigWithOverrides> => {
+  try {
+    const existing = await getTriggerTxtpConfigsByGenerationId(generationId);
+    const displayOrder = existing.length + 1;
+    return await createTriggerConfigWithDefaultStrategies({
+      generationId,
+      txtp: dto.txtp,
+      txtpVersion: dto.txtp_version,
+      messageCount: dto.message_count ?? 1,
+      displayOrder,
+      tenantId,
+    });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    if (isMissingTcsConfigError(error)) {
+      throw new HttpException(`Configuration not found for ${dto.txtp} ${dto.txtp_version}`, HttpStatus.NOT_FOUND);
+    }
+    throw new HttpException(
+      `Failed to add trigger txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 3: GET all ──────────────────────────────────────────────────────────
+
+export const getTriggerConfigsWithOverrides = async (generationId: number): Promise<TriggerTxtpConfigWithOverrides[]> => {
+  try {
+    const configs = await getTriggerTxtpConfigsByGenerationId(generationId);
+    return await Promise.all(
+      configs.map(async (config) => {
+        const fieldOverrides = await getTriggerFieldOverridesByConfigId(config.id);
+        return {
+          trigger_txtp_config_id: config.id,
+          txtp: config.txtp,
+          txtp_version: config.txtp_version,
+          message_count: config.message_count,
+          display_order: config.display_order,
+          payload_template_json: config.payload_template_json,
+          link_to_context_pairs: config.link_to_context_pairs,
+          expected_result_band: config.expected_result_band,
+          notes: config.notes,
+          field_overrides: fieldOverrides,
+        };
+      }),
+    );
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to retrieve trigger configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Step 3: Bulk update ──────────────────────────────────────────────────────
+
+export const bulkUpdateTriggerConfigs = async (
+  generationId: number,
+  items: BulkTriggerConfigItemDto[],
+): Promise<TriggerTxtpConfigWithOverrides[]> => {
+  try {
+    await Promise.all(
+      items.map(async (item) => {
+        const { trigger_txtp_config_id: configId, field_overrides: fieldOverrides, ...updateFields } = item;
+        // Skip malformed entries instead of issuing DB writes with an undefined id.
+        if (!Number.isInteger(configId) || configId <= 0) return;
+        if (Object.keys(updateFields).length > 0) {
+          await updateTriggerTxtpConfigInDb(configId, updateFields);
+        }
+        if (Array.isArray(fieldOverrides) && fieldOverrides.length > 0) {
+          await Promise.all(fieldOverrides.map(async (o) => await upsertTriggerFieldOverrideInDb(configId, o)));
+        }
+      }),
+    );
+    return await getTriggerConfigsWithOverrides(generationId);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to bulk update trigger configs: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Read helper ──────────────────────────────────────────────────────────────
+
+export const getTriggerFieldOverridesForConfig = async (triggerTxtpConfigId: number): Promise<TriggerFieldOverride[]> => {
+  try {
+    return await getTriggerFieldOverridesByConfigId(triggerTxtpConfigId);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to retrieve trigger field overrides: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/services/trs-suite-generation.logic.service.ts
+++ b/src/services/trs-suite-generation.logic.service.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { SuiteGeneration } from '../interface/suite-generation.interface';
+import type { SimulationSuite } from '../interface/simulation-suites.interface';
+import {
+  createSuiteGenerationInDb,
+  getGenerationsBySuiteId,
+  getLatestGenerationBySuiteId,
+  updateGenerationCountsInDb,
+  getGenerationSummaryFromDb,
+  updateWizardProgressInDb,
+  type GenerationSummary,
+  resumeGenerationInDb,
+} from '../repositories/simulation-studio/suite-generations.repository';
+import { deleteTriggerTxtpConfigInDb } from '../repositories/simulation-studio/trigger-txtp-configs.repository';
+import { handlePostExecuteSqlStatement } from './database.logic.service';
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { HttpException, HttpStatus } from '../utils/error';
+// Re-export context config service for app.controller consumers
+export {
+  createConfigWithDefaultStrategies,
+  createContextTxtpConfig,
+  addContextTxtpConfig,
+  getContextConfigsWithStrategies,
+  bulkUpdateContextConfigs,
+  getFieldStrategiesForContextConfig,
+  deleteContextTxtpConfig,
+} from './context-txtp-config.logic.service';
+
+export type { GenerationSummary };
+
+// ── Wizard progress ───────────────────────────────────────────────────────────
+
+export const updateWizardProgress = async (generationId: number, currentStep: number, completedSteps: number[]): Promise<void> => {
+  try {
+    await updateWizardProgressInDb(generationId, currentStep, completedSteps);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to update wizard progress: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Delete trigger txtp config ────────────────────────────────────────────────
+
+export const deleteTriggerTxtpConfig = async (configId: number): Promise<void> => {
+  try {
+    const deleted = await deleteTriggerTxtpConfigInDb(configId);
+    if (!deleted) throw new HttpException(`Trigger txtp config ${configId} not found`, HttpStatus.NOT_FOUND);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to delete trigger txtp config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Count recalculation ──────────────────────────────────────────────────────
+
+/**
+ * Recalculates context_count, trigger_count, enrichment_table_count for a generation
+ * by summing message_count from each config table, then saves to trs_suite_generations.
+ * Called after each bulk PATCH on context / trigger / enrichment steps.
+ */
+export const recalculateGenerationCounts = async (generationId: number): Promise<void> => {
+  try {
+    const [ctxRes, trigRes, enrRes] = await Promise.all([
+      handlePostExecuteSqlStatement<{ total: string }>(
+        {
+          text: 'SELECT COALESCE(SUM(message_count), 0) AS total FROM trs_suite_context_txtp_configs WHERE generation_id = $1',
+          values: [generationId],
+        } satisfies PgQueryConfig,
+        'simulation',
+      ),
+      handlePostExecuteSqlStatement<{ total: string }>(
+        {
+          text: 'SELECT COALESCE(SUM(message_count), 0) AS total FROM trs_suite_trigger_txtp_configs WHERE generation_id = $1',
+          values: [generationId],
+        } satisfies PgQueryConfig,
+        'simulation',
+      ),
+      handlePostExecuteSqlStatement<{ total: string }>(
+        {
+          text: 'SELECT COALESCE(SUM(row_count), 0) AS total FROM trs_suite_enrichment_tables WHERE generation_id = $1',
+          values: [generationId],
+        } satisfies PgQueryConfig,
+        'simulation',
+      ),
+    ]);
+
+    await updateGenerationCountsInDb(generationId, {
+      context_count: parseInt(ctxRes.rows[0].total, 10),
+      trigger_count: parseInt(trigRes.rows[0].total, 10),
+      enrichment_table_count: parseInt(enrRes.rows[0].total, 10),
+    });
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to recalculate generation counts: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+
+export const getGenerationSummary = async (generationId: number): Promise<GenerationSummary | null> => {
+  try {
+    return await getGenerationSummaryFromDb(generationId);
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to retrieve generation summary: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+// ── Suite Generation ─────────────────────────────────────────────────────────
+
+export const createSuiteGeneration = async (suite: SimulationSuite, userId: string, userEmail?: string): Promise<SuiteGeneration> => {
+  try {
+    return await createSuiteGenerationInDb(
+      {
+        suite_id: suite.id,
+        simulation_type: suite.simulation_type,
+        rule_repo: suite.rule_repo,
+        rule_version: suite.rule_version,
+        wizard_snapshot: suite.wizard_progress,
+        generation_metadata: {},
+      },
+      userId,
+      userEmail,
+    );
+  } catch (error) {
+    if (error instanceof HttpException) throw error;
+    throw new HttpException(
+      `Failed to create suite generation: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+export const getGenerationsForSuite = async (suiteId: number): Promise<SuiteGeneration[]> => {
+  try {
+    return await getGenerationsBySuiteId(suiteId);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to retrieve generations: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+export const getLatestGenerationForSuite = async (suiteId: number): Promise<SuiteGeneration | null> => {
+  try {
+    return await getLatestGenerationBySuiteId(suiteId);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to retrieve latest generation: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};
+
+export const resumeGeneration = async (suiteId: number): Promise<SuiteGeneration | null> => {
+  try {
+    return await resumeGenerationInDb(suiteId);
+  } catch (error) {
+    throw new HttpException(
+      `Failed to resume generation: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -19,8 +19,9 @@ export class HttpException extends Error {
 export const HttpStatus = {
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
   NOT_FOUND: 404,
   CONFLICT: 409,
+  PRECONDITION_REQUIRED: 428,
   INTERNAL_SERVER_ERROR: 500,
-  FORBIDDEN: 403,
 };

--- a/src/utils/schema-utils.ts
+++ b/src/utils/schema-utils.ts
@@ -13,15 +13,17 @@ export const SetOptionsBodyAndParams = (
   handler: RouteHandlerMethod,
   claim: Claim,
   bodySchemaName?: TSchema,
-  paramSchemaName?: TSchema,
+  querySchemaName?: TSchema,
+  paramsSchemaName?: TSchema,
 ): { preHandler?: preHandler[]; handler: RouteHandlerMethod; schema: FastifySchema } => {
   loggerService.debug(`Authentication is ${configuration.AUTHENTICATED ? 'ENABLED' : 'DISABLED'} for ${handler.name}`);
   const preHandlers: preHandler[] = configuration.AUTHENTICATED
     ? [validateTenantMiddleware, tokenHandler(claim)]
     : [validateTenantMiddleware];
-  const querystring = paramSchemaName ? { querystring: paramSchemaName } : undefined;
+  const querystring = querySchemaName ? { querystring: querySchemaName } : undefined;
+  const params = paramsSchemaName ? { params: paramsSchemaName } : undefined;
   const body = bodySchemaName ? { body: bodySchemaName } : undefined;
-  const schema: FastifySchema = { ...querystring, ...body };
+  const schema: FastifySchema = { ...querystring, ...params, ...body };
   return {
     preHandler: preHandlers,
     handler,

--- a/src/utils/simulation-suite-validation.ts
+++ b/src/utils/simulation-suite-validation.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { SIMULATION_SUITE_DESCRIPTION_MAX_LENGTH, SIMULATION_SUITE_NAME_MAX_LENGTH } from '../interface/simulation-suites.interface';
+import { HttpException, HttpStatus } from './error';
+
+export const validateSimulationSuiteLengthConstraints = (payload: { name?: string; description?: string }): void => {
+  if (payload.name && payload.name.length > SIMULATION_SUITE_NAME_MAX_LENGTH) {
+    throw new HttpException(`Simulation suite name cannot exceed ${SIMULATION_SUITE_NAME_MAX_LENGTH} characters`, HttpStatus.BAD_REQUEST);
+  }
+
+  if (payload.description && payload.description.length > SIMULATION_SUITE_DESCRIPTION_MAX_LENGTH) {
+    throw new HttpException(
+      `Simulation suite description cannot exceed ${SIMULATION_SUITE_DESCRIPTION_MAX_LENGTH} characters`,
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+};


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulation Studio: create, list, view, update suites; manage generations, context/trigger configs, enrichment tables, wizard progress, and resume generation
  * Faker semantic data endpoint
  * Bulk update support for configs and enrichment tables
  * Input validation for suite name/description length

* **Tests**
  * Large expansion of unit tests covering suites, generations, configs, repositories, services, handlers, and enrichment/faker flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->