### PR TITLE
fix: align rule and typology schemas with frms-coe-lib (#411, #412)

### DIFF
--- a/__tests__/unit/network.map.crud-plugin.test.ts
+++ b/__tests__/unit/network.map.crud-plugin.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+
+// Regression test for the response-schema serialisation path used by
+// /v1/admin/configuration/network_map. The NetworkMapRepo is wired into the
+// same buildCrudPlugin helper that surfaced the cases-shape mismatch in
+// issue #411, so we apply the same end-to-end approach: register the plugin
+// against a mock repo and assert a real library-shaped NetworkMap round trips
+// through GET /v1/admin/configuration/network_map without triggering
+// fast-json-stringify's "does not match schema definition" error.
+
+const mockList = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/network.map.repository', () => ({
+  NetworkMapRepo: {
+    list: (...args: unknown[]) => mockList(...args),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { NetworkMapRepo } from '../../src/repositories/configuration/network.map.repository';
+import { NetworkMapSchema } from '../../src/schemas/networkMapSchema';
+
+describe('GET /v1/admin/configuration/network_map response schema', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+    const ajv = new Ajv({
+      removeAdditional: 'all',
+      useDefaults: true,
+      coerceTypes: 'array',
+      strictTuples: false,
+    });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/network_map',
+        repo: NetworkMapRepo,
+        schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema },
+        idParam: { kind: 'cfg' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('serialises a network map matching the NetworkMap library shape', async () => {
+    const networkMap: NetworkMap = {
+      active: true,
+      cfg: '1.0.0',
+      tenantId: 'DEFAULT',
+      creDtTm: '2026-01-01T00:00:00.000Z',
+      updDtTm: '2026-01-02T00:00:00.000Z',
+      messages: [
+        {
+          id: 'msg-001',
+          cfg: '1.0.0',
+          txTp: 'pacs.008.001.10',
+          typologies: [
+            {
+              id: 'typology-001',
+              cfg: '1.0.0',
+              rules: [
+                { id: 'rule-001', cfg: '1.0.0' },
+                { id: 'rule-002', cfg: '1.0.0' },
+              ],
+            },
+            {
+              id: 'typology-002',
+              cfg: '1.0.0',
+              rules: [{ id: 'rule-003', cfg: '1.0.0' }],
+            },
+          ],
+        },
+        {
+          id: 'msg-002',
+          cfg: '1.0.0',
+          txTp: 'pain.001.001.11',
+          typologies: [
+            {
+              id: 'typology-003',
+              cfg: '1.0.0',
+              rules: [{ id: 'rule-004', cfg: '1.0.0' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    mockList.mockResolvedValue({ data: [networkMap], total: 1 });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/admin/configuration/network_map' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: NetworkMap[]; meta: { total: number; limit: number; offset: number } };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].active).toBe(true);
+    expect(body.data[0].cfg).toBe('1.0.0');
+    expect(body.data[0].messages).toEqual(networkMap.messages);
+    expect(body.meta).toEqual({ total: 1, limit: 20, offset: 0 });
+  });
+
+  it('serialises a network map with an empty messages array', async () => {
+    const emptyNetworkMap: NetworkMap = {
+      active: false,
+      cfg: '0.0.1',
+      tenantId: 'DEFAULT',
+      messages: [],
+    };
+
+    mockList.mockResolvedValue({ data: [emptyNetworkMap], total: 1 });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/admin/configuration/network_map' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: NetworkMap[] };
+    expect(body.data[0].messages).toEqual([]);
+    expect(body.data[0].active).toBe(false);
+  });
+});

--- a/__tests__/unit/rule.crud-plugin.test.ts
+++ b/__tests__/unit/rule.crud-plugin.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+
+// Regression test for
+// https://github.com/tazama-lf/admin-service/issues/411
+//
+// Before the fix, src/schemas/ruleSchema.ts declared
+//   cases: Type.Optional(Type.Array(Case))   // Case = { subRuleRef, reason, value }
+// but @tazama-lf/frms-coe-lib's RuleConfig.config.cases is a single object
+//   { expressions: Expression[]; alternative: OutcomeResult }
+// so fast-json-stringify (used by Fastify as the default response serializer)
+// would throw
+//   "The value of '#/properties/data/items/properties/config/properties/cases'
+//    does not match schema definition."
+// whenever a rule with a populated cases field was returned by the LIST endpoint.
+// These tests assert that GET /v1/admin/configuration/rule serialises such a rule
+// successfully.
+
+const mockList = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/rule.config.repository', () => ({
+  RuleConfigRepo: {
+    list: (...args: unknown[]) => mockList(...args),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { RuleConfigRepo } from '../../src/repositories/configuration/rule.config.repository';
+import { RuleSchema } from '../../src/schemas/ruleSchema';
+
+describe('GET /v1/admin/configuration/rule response schema', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+
+    // Mirror the Ajv setup used by src/clients/fastify.ts so request-side
+    // validation behaves the same way as in production.
+    const ajv = new Ajv({
+      removeAdditional: 'all',
+      useDefaults: true,
+      coerceTypes: 'array',
+      strictTuples: false,
+    });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/rule',
+        repo: RuleConfigRepo,
+        schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
+        idParam: { kind: 'single', name: 'id' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('serialises a rule whose config.cases matches the RuleConfig library shape', async () => {
+    const ruleWithCases: RuleConfig = {
+      id: 'rule-001',
+      cfg: '1.0.0',
+      tenantId: 'DEFAULT',
+      desc: 'rule using the real library cases shape',
+      config: {
+        parameters: { threshold: 100 },
+        exitConditions: [{ subRuleRef: 'exit-001', reason: 'threshold exceeded' }],
+        bands: [{ subRuleRef: 'band-001', reason: 'low risk', lowerLimit: 0, upperLimit: 50 }],
+        cases: {
+          expressions: [
+            { subRuleRef: 'expr-001', reason: 'matched value A', value: 'A' },
+            { subRuleRef: 'expr-002', reason: 'matched value B', value: 'B' },
+          ],
+          alternative: { subRuleRef: 'alt-001', reason: 'no expression matched' },
+        },
+      },
+    };
+
+    mockList.mockResolvedValue({ data: [ruleWithCases], total: 1 });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: RuleConfig[]; meta: { total: number; limit: number; offset: number } };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('rule-001');
+    expect(body.data[0].config?.cases).toEqual(ruleWithCases.config?.cases);
+    expect(body.meta).toEqual({ total: 1, limit: 20, offset: 0 });
+  });
+
+  it('serialises a rule whose config has no cases field (cases remains optional)', async () => {
+    const ruleNoCases: RuleConfig = {
+      id: 'rule-002',
+      cfg: '1.0.0',
+      tenantId: 'DEFAULT',
+      config: {
+        parameters: { threshold: 100 },
+        exitConditions: [{ subRuleRef: 'exit-001', reason: 'threshold exceeded' }],
+      },
+    };
+
+    mockList.mockResolvedValue({ data: [ruleNoCases], total: 1 });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: RuleConfig[] };
+    expect(body.data[0].config?.cases).toBeUndefined();
+  });
+});

--- a/__tests__/unit/typology.config.crud-plugin.test.ts
+++ b/__tests__/unit/typology.config.crud-plugin.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { TypologyConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
+
+// Regression test for the response-schema serialisation path used by
+// /v1/admin/configuration/typology. The TypologyConfigRepo is wired into the
+// same buildCrudPlugin helper that surfaced the cases-shape mismatch in
+// issue #411, so we apply the same end-to-end approach: register the plugin
+// against a mock repo and assert a real library-shaped TypologyConfig round
+// trips through GET /v1/admin/configuration/typology without triggering
+// fast-json-stringify's "does not match schema definition" error.
+
+const mockList = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/typology.config.repository', () => ({
+  TypologyConfigRepo: {
+    list: (...args: unknown[]) => mockList(...args),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { TypologyConfigRepo } from '../../src/repositories/configuration/typology.config.repository';
+import { TypologySchema } from '../../src/schemas/typologySchema';
+
+describe('GET /v1/admin/configuration/typology response schema', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+    const ajv = new Ajv({
+      removeAdditional: 'all',
+      useDefaults: true,
+      coerceTypes: 'array',
+      strictTuples: false,
+    });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/typology',
+        repo: TypologyConfigRepo,
+        schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema },
+        idParam: { kind: 'single', name: 'id' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('serialises a typology whose expression matches the ExpressionMathJSON library shape', async () => {
+    const typology: TypologyConfig = {
+      id: 'typology-001',
+      cfg: '1.0.0',
+      tenantId: 'DEFAULT',
+      desc: 'typology using the real library expression shape',
+      rules: [
+        {
+          id: 'rule-001',
+          cfg: '1.0.0',
+          termId: 'term-A',
+          wghts: [{ ref: 'weight-ref-1', wght: 1.5 }],
+        },
+        {
+          id: 'rule-002',
+          cfg: '1.0.0',
+          termId: 'term-B',
+          wghts: [{ ref: 'weight-ref-2', wght: 2.25 }],
+        },
+      ],
+      // ExpressionMathJSON = Array<string | number | ExpressionMathJSON>
+      // e.g. ["+", 1, ["*", 2, 3]]
+      expression: ['+', 1, ['*', 2, 3]],
+      workflow: {
+        alertThreshold: 200,
+        interdictionThreshold: 500,
+        flowProcessor: 'default-processor',
+      },
+    };
+
+    mockList.mockResolvedValue({ data: [typology], total: 1 });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/admin/configuration/typology' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: TypologyConfig[]; meta: { total: number; limit: number; offset: number } };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('typology-001');
+    expect(body.data[0].expression).toEqual(typology.expression);
+    expect(body.data[0].rules).toEqual(typology.rules);
+    expect(body.data[0].workflow).toEqual(typology.workflow);
+    expect(body.meta).toEqual({ total: 1, limit: 20, offset: 0 });
+  });
+
+  it('serialises a typology whose expression is a flat string-only array', async () => {
+    const typology: TypologyConfig = {
+      id: 'typology-002',
+      cfg: '1.0.0',
+      tenantId: 'DEFAULT',
+      rules: [
+        {
+          id: 'rule-001',
+          cfg: '1.0.0',
+          termId: 'term-A',
+          wghts: [],
+        },
+      ],
+      expression: ['x', 'y', 'z'],
+      workflow: { alertThreshold: 100 },
+    };
+
+    mockList.mockResolvedValue({ data: [typology], total: 1 });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/admin/configuration/typology' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: TypologyConfig[] };
+    expect(body.data[0].expression).toEqual(typology.expression);
+  });
+});

--- a/src/schemas/ruleSchema.ts
+++ b/src/schemas/ruleSchema.ts
@@ -17,20 +17,20 @@ export const Band = Type.Composite([
   }),
 ]);
 
-export type Case = Static<typeof Case>;
-export const Case = Type.Composite([
-  OutcomeResult,
-  Type.Object({
-    value: Type.String(),
-  }),
-]);
+export type Expression = Static<typeof Expression>;
+export const Expression = Type.Composite([OutcomeResult, Type.Object({ value: Type.String() })]);
 
-export type Config = Static<typeof Config>;
+export type Case = Static<typeof Case>;
+export const Case = Type.Object({
+  expressions: Type.Array(Expression),
+  alternative: OutcomeResult,
+});
+
 export const Config = Type.Object({
   parameters: Type.Optional(Type.Record(Type.Optional(Type.Union([Type.String(), Type.Number()])), Type.Optional(Type.Unknown()))),
   exitConditions: Type.Optional(Type.Array(OutcomeResult)),
   bands: Type.Optional(Type.Array(Band)),
-  cases: Type.Optional(Type.Array(Case)),
+  cases: Type.Optional(Case),
 });
 
 export type Rule = Static<typeof RuleSchema>;

--- a/src/schemas/typologySchema.ts
+++ b/src/schemas/typologySchema.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Type, type Static } from '@sinclair/typebox';
 
-const ExpressionMathJSON = Type.String();
+// Mirrors @tazama-lf/frms-coe-lib's TypologyConfig.expression:
+//   type ExpressionMathJSON = Array<string | number | ExpressionMathJSON>
+const ExpressionMathJSON = Type.Recursive((Self) => Type.Array(Type.Union([Type.String(), Type.Number(), Self])));
 
 const Weight = Type.Object({
   ref: Type.String(),
@@ -28,7 +30,7 @@ export const TypologySchema = Type.Object(
     cfg: Type.String(),
     desc: Type.Optional(Type.String()),
     rules: Type.Array(RuleValue),
-    expression: Type.Array(ExpressionMathJSON),
+    expression: ExpressionMathJSON,
     workflow: WorkFlow,
     creDtTm: Type.Optional(Type.String({ format: 'date-time' })),
     updDtTm: Type.Optional(Type.String({ format: 'date-time' })),


### PR DESCRIPTION
## Summary

Aligns two configuration response schemas with the corresponding interfaces in `@tazama-lf/frms-coe-lib`, and adds end-to-end regression coverage for the three configuration CRUD endpoints served by `buildCrudPlugin`.

Closes #411
Closes #412

## Background

Two latent typebox/library mismatches in the admin-service caused `fast-json-stringify` (Fastify's default response serialiser) to misbehave on configuration GET endpoints:

| | Endpoint | Field | Symptom |
|---|---|---|---|
| #411 | `GET /v1/admin/configuration/rule` | `config.cases` | HTTP 500, "does not match schema definition" |
| #412 | `GET /v1/admin/configuration/typology` | `expression` | HTTP 200 with silent numeric/array coercion to strings |

Both schemas were introduced in commit `0016650` ("refactor: Postgres", #208, 2025-10-30) without a contract test against the corresponding `RuleConfig` and `TypologyConfig` shapes from the library, so the mismatches went undetected.

## Changes

### `fix: align rule and typology schemas with frms-coe-lib interfaces`

#### `src/schemas/ruleSchema.ts` (#411)

`Config.cases` was declared as `Type.Optional(Type.Array(Case))` where `Case` was `{ subRuleRef, reason, value }`. The library defines `cases` as a single `Case` object `{ expressions: Expression[]; alternative: OutcomeResult }` with `Expression extends OutcomeResult { value: string }`. Updated to match: introduces an explicit `Expression` typebox schema, redefines `Case` as `{ expressions, alternative }`, and uses `Type.Optional(Case)` on `Config`.

#### `src/schemas/typologySchema.ts` (#412)

`expression` was declared as `Type.Array(Type.String())`. The library defines `expression` as `ExpressionMathJSON = Array<string | number | ExpressionMathJSON>` (recursive nested array of strings and numbers). Replaced the string-only placeholder with a proper `Type.Recursive` union of string, number, and `Self`, and used it directly on `TypologySchema.expression` (no extra `Type.Array` wrapper).

### `test: cover configuration CRUD response-schema serialisation`

Three new fastify.inject-based regression tests register `buildCrudPlugin` against mocked repos and exercise the response-serialisation path with library-shaped fixtures:

- [__tests__/unit/rule.crud-plugin.test.ts](../blob/fix/rule-schema-mismatch/__tests__/unit/rule.crud-plugin.test.ts) - reproduces #411. Verified to return HTTP 500 against the old schema; HTTP 200 with the round-trip preserved against the fix.
- [__tests__/unit/typology.config.crud-plugin.test.ts](../blob/fix/rule-schema-mismatch/__tests__/unit/typology.config.crud-plugin.test.ts) - reproduces #412. Asserts that an `expression` like `['+', 1, ['*', 2, 3]]` round-trips identically rather than being coerced to `['+', '1', '*,2,3']`.
- [__tests__/unit/network.map.crud-plugin.test.ts](../blob/fix/rule-schema-mismatch/__tests__/unit/network.map.crud-plugin.test.ts) - confirms `NetworkMapSchema` is already aligned with the library's `NetworkMap` interface; included for completeness so the same coverage exists across all three CRUD endpoints.

## Verification

```
Test Suites: 28 passed, 28 total
Tests:       644 passed, 644 total
```

Negative validation: temporarily reverting [src/schemas/ruleSchema.ts](../blob/fix/rule-schema-mismatch/src/schemas/ruleSchema.ts) reproduces the user-reported HTTP 500 in the rule regression test; restoring the fix turns it green.

## Out of scope

- `timeframes` on `Config` is deprecated in `frms-coe-lib` and intentionally not modelled here.
- The pre-existing version and `@tazama-lf/auth-lib` bump in `package.json` / `package-lock.json` is unrelated to these fixes and is not included in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema validation and serialization for rule configurations with complex expression structures.
  * Corrected typology expression handling to support recursive math expression formats.

* **Tests**
  * Added regression tests for rule, network map, and typology configuration CRUD endpoints to prevent schema mismatch issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->