### PR TITLE
fix: (#414) expire condition for debtor-only perspectives and route debtor edge args correctly

### DIFF
--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -13,6 +13,8 @@ import {
 import {
   accountResponse,
   entityResponse,
+  fixedDate,
+  incptnDtTm,
   rawResponseAccount,
   rawResponseEntity,
   sampleAccountCondition,
@@ -793,6 +795,124 @@ describe('handleUpdateExpiryDateForConditionsOfAccount', () => {
 
     expect(result).toEqual({ code: 200, message: '' });
   });
+
+  // Regression tests for tazama-lf/admin-service#414.
+  // The handler had a copy-paste typo: `debtorByEdgeE = creditorByEdge` (should be `debtorByEdge`).
+  // For debtor-only conditions the bug produced a spurious 404 "Account does not exist".
+  // For "both"-perspective conditions the debtor edge updater was called with the creditor edge's
+  // source/destination - the existing happy-path tests do not catch this because their fixtures
+  // populate creditor and debtor edges with identical source/destination values.
+  it('should expire a debtor-only account condition (regression for #414)', async () => {
+    const debtorOnlyFixture = {
+      governed_as_creditor_account_by: [],
+      governed_as_debtor_account_by: [
+        {
+          id: 'edge-debtor-only',
+          source: 'account/debtor-src',
+          destination: 'condition/dst',
+          edge: { source: 'account/debtor-src', destination: 'condition/dst' },
+          result: {},
+          condition: {
+            condId: 'cond123',
+            condTp: 'overridable-block',
+            incptnDtTm,
+            condRsn: 'R001',
+            evtTp: ['pacs.008.001.10'],
+            usr: 'bob',
+            creDtTm: fixedDate,
+            updDtTm: fixedDate,
+            tenantId: 'DEFAULT',
+            acct: {
+              id: '1010101010',
+              schmeNm: { prtry: 'Mxx' },
+              agt: { finInstnId: { clrSysMmbId: { mmbId: 'dfsp001' } } },
+            },
+          },
+        },
+      ],
+      governed_as_creditor_by: [],
+      governed_as_debtor_by: [],
+    };
+    (databaseManager.getAccountConditionsByGraph as jest.Mock).mockResolvedValue([debtorOnlyFixture]);
+    (databaseManager.updateExpiryDateOfCreditorAccountEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateExpiryDateOfDebtorAccountEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateCondition as jest.Mock).mockResolvedValue('test');
+
+    const result = await handleUpdateExpiryDateForConditionsOfAccount(params, 'DEFAULT', xprtnDtTm);
+
+    expect(result).toEqual({ code: 200, message: '' });
+    expect(databaseManager.updateExpiryDateOfDebtorAccountEdges).toHaveBeenCalledWith(
+      'account/debtor-src',
+      'condition/dst',
+      xprtnDtTm,
+      'DEFAULT',
+    );
+    expect(databaseManager.updateExpiryDateOfCreditorAccountEdges).not.toHaveBeenCalled();
+    expect(databaseManager.updateCondition).toHaveBeenCalledWith('cond123', xprtnDtTm, 'DEFAULT');
+  });
+
+  it('should call debtor edge updater with debtor edge args (not creditor args) for "both" perspective (regression for #414)', async () => {
+    const conditionBase = {
+      condId: 'cond123',
+      condTp: 'overridable-block',
+      incptnDtTm,
+      condRsn: 'R001',
+      evtTp: ['pacs.008.001.10'],
+      usr: 'bob',
+      creDtTm: fixedDate,
+      updDtTm: fixedDate,
+      tenantId: 'DEFAULT',
+      acct: {
+        id: '1010101010',
+        schmeNm: { prtry: 'Mxx' },
+        agt: { finInstnId: { clrSysMmbId: { mmbId: 'dfsp001' } } },
+      },
+    };
+    const bothFixture = {
+      governed_as_creditor_account_by: [
+        {
+          id: 'edge-cred',
+          source: 'account/cred-src',
+          destination: 'condition/dst',
+          edge: { source: 'account/cred-src', destination: 'condition/dst' },
+          result: {},
+          condition: conditionBase,
+        },
+      ],
+      governed_as_debtor_account_by: [
+        {
+          id: 'edge-debtor',
+          source: 'account/debtor-src',
+          destination: 'condition/dst',
+          edge: { source: 'account/debtor-src', destination: 'condition/dst' },
+          result: {},
+          condition: conditionBase,
+        },
+      ],
+      governed_as_creditor_by: [],
+      governed_as_debtor_by: [],
+    };
+    (databaseManager.getAccountConditionsByGraph as jest.Mock).mockResolvedValue([bothFixture]);
+    (databaseManager.updateExpiryDateOfCreditorAccountEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateExpiryDateOfDebtorAccountEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateCondition as jest.Mock).mockResolvedValue('test');
+
+    const result = await handleUpdateExpiryDateForConditionsOfAccount(params, 'DEFAULT', xprtnDtTm);
+
+    expect(result).toEqual({ code: 200, message: '' });
+    expect(databaseManager.updateExpiryDateOfCreditorAccountEdges).toHaveBeenCalledWith(
+      'account/cred-src',
+      'condition/dst',
+      xprtnDtTm,
+      'DEFAULT',
+    );
+    expect(databaseManager.updateExpiryDateOfDebtorAccountEdges).toHaveBeenCalledWith(
+      'account/debtor-src',
+      'condition/dst',
+      xprtnDtTm,
+      'DEFAULT',
+    );
+  });
 });
 
 describe('handleUpdateExpiryDateForConditionsOfEntity', () => {
@@ -918,6 +1038,111 @@ describe('handleUpdateExpiryDateForConditionsOfEntity', () => {
     expect(databaseManager.updateCondition).toHaveBeenCalledWith('cond123', xprtnDtTm, 'DEFAULT');
 
     expect(result).toEqual({ code: 200, message: '' });
+  });
+
+  // Regression tests for tazama-lf/admin-service#414 - entity mirror of the account-handler bug.
+  it('should expire a debtor-only entity condition (regression for #414)', async () => {
+    const debtorOnlyFixture = {
+      governed_as_creditor_by: [],
+      governed_as_debtor_by: [
+        {
+          id: 'edge-debtor-only',
+          source: 'entity/debtor-src',
+          destination: 'condition/dst',
+          edge: { source: 'entity/debtor-src', destination: 'condition/dst' },
+          result: {},
+          condition: {
+            condId: 'cond123',
+            condTp: 'overridable-block',
+            incptnDtTm,
+            condRsn: 'R001',
+            evtTp: ['pacs.008.001.10'],
+            usr: 'bob',
+            creDtTm: fixedDate,
+            updDtTm: fixedDate,
+            tenantId: 'DEFAULT',
+            ntty: { id: '+27733161225', schmeNm: { prtry: 'MSISDN' } },
+          },
+        },
+      ],
+      governed_as_creditor_account_by: [],
+      governed_as_debtor_account_by: [],
+    };
+    (databaseManager.getEntityConditionsByGraph as jest.Mock).mockResolvedValue([debtorOnlyFixture]);
+    (databaseManager.updateExpiryDateOfCreditorEntityEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateExpiryDateOfDebtorEntityEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateCondition as jest.Mock).mockResolvedValue('test');
+
+    const result = await handleUpdateExpiryDateForConditionsOfEntity(params, 'DEFAULT', xprtnDtTm);
+
+    expect(result).toEqual({ code: 200, message: '' });
+    expect(databaseManager.updateExpiryDateOfDebtorEntityEdges).toHaveBeenCalledWith(
+      'entity/debtor-src',
+      'condition/dst',
+      xprtnDtTm,
+      'DEFAULT',
+    );
+    expect(databaseManager.updateExpiryDateOfCreditorEntityEdges).not.toHaveBeenCalled();
+    expect(databaseManager.updateCondition).toHaveBeenCalledWith('cond123', xprtnDtTm, 'DEFAULT');
+  });
+
+  it('should call debtor edge updater with debtor edge args (not creditor args) for "both" perspective (regression for #414)', async () => {
+    const conditionBase = {
+      condId: 'cond123',
+      condTp: 'overridable-block',
+      incptnDtTm,
+      condRsn: 'R001',
+      evtTp: ['pacs.008.001.10'],
+      usr: 'bob',
+      creDtTm: fixedDate,
+      updDtTm: fixedDate,
+      tenantId: 'DEFAULT',
+      ntty: { id: '+27733161225', schmeNm: { prtry: 'MSISDN' } },
+    };
+    const bothFixture = {
+      governed_as_creditor_by: [
+        {
+          id: 'edge-cred',
+          source: 'entity/cred-src',
+          destination: 'condition/dst',
+          edge: { source: 'entity/cred-src', destination: 'condition/dst' },
+          result: {},
+          condition: conditionBase,
+        },
+      ],
+      governed_as_debtor_by: [
+        {
+          id: 'edge-debtor',
+          source: 'entity/debtor-src',
+          destination: 'condition/dst',
+          edge: { source: 'entity/debtor-src', destination: 'condition/dst' },
+          result: {},
+          condition: conditionBase,
+        },
+      ],
+      governed_as_creditor_account_by: [],
+      governed_as_debtor_account_by: [],
+    };
+    (databaseManager.getEntityConditionsByGraph as jest.Mock).mockResolvedValue([bothFixture]);
+    (databaseManager.updateExpiryDateOfCreditorEntityEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateExpiryDateOfDebtorEntityEdges as jest.Mock).mockResolvedValue('test');
+    (databaseManager.updateCondition as jest.Mock).mockResolvedValue('test');
+
+    const result = await handleUpdateExpiryDateForConditionsOfEntity(params, 'DEFAULT', xprtnDtTm);
+
+    expect(result).toEqual({ code: 200, message: '' });
+    expect(databaseManager.updateExpiryDateOfCreditorEntityEdges).toHaveBeenCalledWith(
+      'entity/cred-src',
+      'condition/dst',
+      xprtnDtTm,
+      'DEFAULT',
+    );
+    expect(databaseManager.updateExpiryDateOfDebtorEntityEdges).toHaveBeenCalledWith(
+      'entity/debtor-src',
+      'condition/dst',
+      xprtnDtTm,
+      'DEFAULT',
+    );
   });
 });
 

--- a/src/services/event-flow.logic.service.ts
+++ b/src/services/event-flow.logic.service.ts
@@ -221,7 +221,7 @@ export const handleUpdateExpiryDateForConditionsOfEntity = async (
     };
   }
   const creditorByEdgeE = creditorByEdge as unknown as Edge[];
-  const debtorByEdgeE = creditorByEdge as unknown as Edge[];
+  const debtorByEdgeE = debtorByEdge as unknown as Edge[];
 
   if (!creditorByEdgeE.some((eachDocument) => eachDocument.id) && !debtorByEdgeE.some((eachDocument) => eachDocument.id)) {
     return { code: 404, message: 'Entity does not exist in the database.' };
@@ -298,7 +298,7 @@ export const handlePostConditionAccount = async (
       await databaseManager.saveCondition({ ...condition, creDtTm: nowDateTime, tenantId, updDtTm: nowDateTime });
     }
 
-    await saveConditionEdges(condition.prsptv, condId, accountIdentifier, condition as ConditionEdge, 'account', tenantId);
+    await saveConditionEdges(condition.prsptv, condId, accountIdentifier, condition, 'account', tenantId);
 
     const report = await databaseManager.getAccountConditionsByGraph(condAccountId, condSchemeProprietary, tenantId, condMemberid);
 
@@ -470,7 +470,7 @@ export const handleUpdateExpiryDateForConditionsOfAccount = async (
     };
   }
   const creditorByEdgeE = creditorByEdge as unknown as Edge[];
-  const debtorByEdgeE = creditorByEdge as unknown as Edge[];
+  const debtorByEdgeE = debtorByEdge as unknown as Edge[];
 
   if (!creditorByEdgeE.some((eachDocument) => eachDocument.id) && !debtorByEdgeE.some((eachDocument) => eachDocument.id)) {
     return { code: 404, message: 'Account does not exist in the database.' };


### PR DESCRIPTION
## Summary

Fixes a copy-paste typo in `src/services/event-flow.logic.service.ts` that caused two production-impacting bugs in the event-flow expiry handlers.

In both `handleUpdateExpiryDateForConditionsOfAccount` and `handleUpdateExpiryDateForConditionsOfEntity`:

```diff
   const creditorByEdgeE = creditorByEdge as unknown as Edge[];
-  const debtorByEdgeE = creditorByEdge as unknown as Edge[];
+  const debtorByEdgeE = debtorByEdge as unknown as Edge[];
```

## Bugs fixed

1. **Debtor-only conditions could not be expired.** `PUT /event-flow-control/account/expire/...` and the entity equivalent returned `404 "Account does not exist in the database."` / `404 "Entity does not exist in the database."` whenever the condition had no creditor edges, because the existence check inspected the creditor array twice instead of once each.
2. **"both" perspective conditions silently corrupted the debtor edge.** When a condition had both creditor and debtor edges, the debtor edge updater (`updateExpiryDateOfDebtorAccountEdges` / `updateExpiryDateOfDebtorEntityEdges`) was invoked with the creditor edge's `source` and `destination`, so the expiry date was written to the wrong vertex pair on the debtor side. The fix restores correct routing of `source`/`destination` per perspective.

## Tests

Four new unit tests in `__tests__/unit/app.eventFlow.test.ts` (commit 1) reproduce the failure modes against `dev` and now pass with the fix (commit 2):

- `handleUpdateExpiryDateForConditionsOfAccount`
  - `should expire a debtor-only account condition (regression for #414)` - empty creditor array + single debtor edge, asserts `{ code: 200 }` and that `updateExpiryDateOfDebtorAccountEdges` is called with the debtor source/destination while `updateExpiryDateOfCreditorAccountEdges` is not called.
  - `should call debtor edge updater with debtor edge args (not creditor args) for "both" perspective (regression for #414)` - distinct creditor and debtor source values; asserts each updater receives its own source.
- `handleUpdateExpiryDateForConditionsOfEntity`
  - Mirrors of the two account tests above, using `entity/*` ids and `governed_as_{creditor,debtor}_by` edge collections.

Full suite (648 tests) and `npm run build` pass locally.

## Drive-by lint fix

The pre-commit `lint-staged` hook auto-removed one unrelated `as ConditionEdge` assertion in `handlePostConditionAccount` (line 301) flagged by `@typescript-eslint/no-unnecessary-type-assertion`. This is a no-op for runtime behaviour - the receiver already accepts the expression's inferred type. The fix commit calls this out explicitly in its body.

## Risk

Low. The fix is a two-line change inside two already well-tested handlers. Existing happy-path tests for both handlers continue to pass because they use identical source values for the creditor and debtor edges (which masked the typo originally); the new tests use distinct source values so the typo cannot regress unnoticed in future.

## Links

Closes #414
Unblocks tazama-lf/tazama-demo#77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected edge assignment logic in expiration date updates to ensure proper referencing of debtor and creditor information.

* **Tests**
  * Added regression tests to verify expiration date handler behavior for account and entity conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->