### PR TITLE
fix: correct configuration list filtering, totals and ordering (#418)

### DIFF
--- a/__tests__/unit/config-list.crud-plugin.test.ts
+++ b/__tests__/unit/config-list.crud-plugin.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import qs from 'qs';
+
+// Issue #418 - schema-boundary behaviour of the configuration `list` endpoints.
+//
+// This test mirrors production validation exactly (src/clients/fastify.ts):
+//   - querystringParser: qs.parse  (so `filters[active]=true` -> { active: 'true' })
+//   - Ajv with removeAdditional: 'all', coerceTypes: 'array', useDefaults: true
+// and registers the CRUD plugin with the per-entity `Query` override the router will
+// pass in production. It asserts:
+//   - `sort` outside the per-entity allowlist -> 400 (enum value rejection)
+//   - `order` outside ASC|DESC -> 400
+//   - a recognised filter (`active`) reaches repo.list
+//   - an UNKNOWN filter key is STRIPPED by removeAdditional (200, not 400, not forwarded) [D1]
+//   - `meta.total` echoes the value repo.list returns (passthrough)
+
+const mockRuleList = jest.fn();
+const mockNetworkMapList = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: { log: jest.fn(), error: jest.fn(), trace: jest.fn(), debug: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('../../src/repositories/configuration/rule.config.repository', () => ({
+  RuleConfigRepo: {
+    list: (...args: unknown[]) => mockRuleList(...args),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/network.map.repository', () => ({
+  NetworkMapRepo: {
+    list: (...args: unknown[]) => mockNetworkMapList(...args),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { RuleConfigRepo } from '../../src/repositories/configuration/rule.config.repository';
+import { NetworkMapRepo } from '../../src/repositories/configuration/network.map.repository';
+import { RuleSchema } from '../../src/schemas/ruleSchema';
+import { NetworkMapSchema } from '../../src/schemas/networkMapSchema';
+// New per-entity query schemas (created in the green step). They constrain `sort` to an
+// allowlist enum and `filters` to a closed set of fields.
+import { RuleListQuery, NetworkMapListQuery } from '../../src/schemas/configListQuerySchema';
+
+describe('configuration list - schema-boundary behaviour (#418)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    // Mirror production (src/clients/fastify.ts): the qs parser is nested under
+    // routerOptions in Fastify v5, so `filters[active]=true` becomes { filters: { active: 'true' } }.
+    app = Fastify({ routerOptions: { querystringParser: (str) => qs.parse(str) } });
+
+    const ajv = new Ajv({ removeAdditional: 'all', useDefaults: true, coerceTypes: 'array', strictTuples: false });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/rule',
+        repo: RuleConfigRepo,
+        schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema, Query: RuleListQuery },
+        idParam: { kind: 'single', name: 'id' },
+      }),
+    );
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/network_map',
+        repo: NetworkMapRepo,
+        schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema, Query: NetworkMapListQuery },
+        idParam: { kind: 'cfg' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockRuleList.mockReset();
+    mockNetworkMapList.mockReset();
+    mockRuleList.mockResolvedValue({ data: [], total: 0 });
+    mockNetworkMapList.mockResolvedValue({ data: [], total: 0 });
+  });
+
+  it('rejects a `sort` value outside the per-entity allowlist with 400', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?sort=nope' });
+    expect(res.statusCode).toBe(400);
+    expect(mockRuleList).not.toHaveBeenCalled();
+  });
+
+  it('accepts an allowlisted `sort` value', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?sort=id' });
+    expect(res.statusCode).toBe(200);
+    expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ sort: 'id' }));
+  });
+
+  it('rejects an `order` outside ASC|DESC with 400', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?order=SIDEWAYS' });
+    expect(res.statusCode).toBe(400);
+    expect(mockRuleList).not.toHaveBeenCalled();
+  });
+
+  it('forwards a recognised filter (`active`) to repo.list', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/network_map?filters[active]=true' });
+    expect(res.statusCode).toBe(200);
+    expect(mockNetworkMapList).toHaveBeenCalledWith(expect.objectContaining({ filters: { active: 'true' } }));
+  });
+
+  it('rejects a malformed boolean `active` filter with 400 (avoids a Postgres ::boolean cast 500)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/network_map?filters[active]=foo' });
+    expect(res.statusCode).toBe(400);
+    expect(mockNetworkMapList).not.toHaveBeenCalled();
+  });
+
+  it('strips an unknown filter key (D1: ignored, not 400, not forwarded)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/network_map?filters[nope]=x&filters[active]=true' });
+    expect(res.statusCode).toBe(200);
+    const forwarded = mockNetworkMapList.mock.calls[0][0] as { filters?: Record<string, string> };
+    expect(forwarded.filters).toEqual({ active: 'true' });
+    expect(forwarded.filters).not.toHaveProperty('nope');
+  });
+
+  it('passes meta.total straight through from repo.list', async () => {
+    mockNetworkMapList.mockResolvedValueOnce({ data: [], total: 99 });
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/network_map' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().meta).toEqual({ total: 99, limit: 20, offset: 0 });
+  });
+});

--- a/__tests__/unit/repositories/network.map.repository.test.ts
+++ b/__tests__/unit/repositories/network.map.repository.test.ts
@@ -76,14 +76,13 @@ describe('NetworkMapRepository', () => {
   });
 
   describe('list', () => {
-    it('should list network maps with default sort and no filters', async () => {
+    it('counts all matching rows and pages deterministically on the generated key (no filters)', async () => {
       const firstMap = createMockNetworkMap();
       const secondMap = { ...createMockNetworkMap(), cfg: '2.0.0', active: false };
 
-      mockHandlePostExecuteSqlStatement.mockResolvedValue({
-        rows: [{ configuration: firstMap }, { configuration: secondMap }],
-        rowCount: 2,
-      });
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: firstMap }, { configuration: secondMap }], rowCount: 2 });
 
       const result = await NetworkMapRepo.list({
         offset: 5,
@@ -93,35 +92,89 @@ describe('NetworkMapRepository', () => {
       });
 
       expect(result).toEqual({ data: [firstMap, secondMap], total: 2 });
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
         {
-          text: "SELECT configuration FROM network_map WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 DESC OFFSET $4 LIMIT $5;",
-          values: ['cfg', '', 'cfg', 5, 10, mockTenantId],
+          text: 'SELECT COUNT(*) AS total FROM network_map WHERE tenantid = $1;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+      // network_map's unique key is the single generated `cfg` column
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM network_map WHERE tenantid = $1 ORDER BY cfg DESC OFFSET $2 LIMIT $3;',
+          values: [mockTenantId, 5, 10],
         },
         'configuration',
       );
     });
 
-    it('should list with the first provided filter and custom sort', async () => {
-      mockHandlePostExecuteSqlStatement.mockResolvedValue({
-        rows: [],
-        rowCount: 0,
-      });
+    it('applies every supplied filter (ANDed), casting the generated boolean `active` column', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
       const result = await NetworkMapRepo.list({
         filters: { active: 'true', cfg: '1.0.0' },
         offset: 0,
         limit: 25,
         order: 'ASC',
-        sort: 'active',
         tenantId: mockTenantId,
       });
 
       expect(result).toEqual({ data: [], total: 0 });
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
         {
-          text: "SELECT configuration FROM network_map WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 ASC OFFSET $4 LIMIT $5;",
-          values: ['active', 'true', 'active', 0, 25, mockTenantId],
+          text: 'SELECT COUNT(*) AS total FROM network_map WHERE tenantid = $1 AND active = $2::boolean AND cfg = $3;',
+          values: [mockTenantId, 'true', '1.0.0'],
+        },
+        'configuration',
+      );
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM network_map WHERE tenantid = $1 AND active = $2::boolean AND cfg = $3 ORDER BY cfg ASC OFFSET $4 LIMIT $5;',
+          values: [mockTenantId, 'true', '1.0.0', 0, 25],
+        },
+        'configuration',
+      );
+    });
+
+    it('takes total from COUNT (not the page length) and never returns null', async () => {
+      const map = createMockNetworkMap();
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '42' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: map }], rowCount: null });
+
+      const result = await NetworkMapRepo.list({ offset: 0, limit: 20, order: 'ASC', tenantId: mockTenantId });
+
+      expect(result.total).toBe(42);
+      expect(result.data).toEqual([map]);
+    });
+
+    it('ignores filter fields that are not in the allowlist', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await NetworkMapRepo.list({
+        filters: { nope: 'x', active: 'true' },
+        offset: 0,
+        limit: 20,
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM network_map WHERE tenantid = $1 AND active = $2::boolean;',
+          values: [mockTenantId, 'true'],
         },
         'configuration',
       );

--- a/__tests__/unit/repositories/rule.config.repository.test.ts
+++ b/__tests__/unit/repositories/rule.config.repository.test.ts
@@ -80,14 +80,14 @@ describe('RuleConfigRepository', () => {
   });
 
   describe('list', () => {
-    it('should list rule configurations with default sort and no filters', async () => {
+    it('counts all matching rows and pages deterministically on the generated key (no filters)', async () => {
       const firstConfig = createMockRuleConfig();
       const secondConfig = { ...createMockRuleConfig(), id: 'rule-002', cfg: '2.0.0' };
 
-      mockHandlePostExecuteSqlStatement.mockResolvedValue({
-        rows: [{ configuration: firstConfig }, { configuration: secondConfig }],
-        rowCount: 2,
-      });
+      // The shared list issues COUNT(*) first, then the page query.
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: firstConfig }, { configuration: secondConfig }], rowCount: 2 });
 
       const result = await RuleConfigRepo.list({
         offset: 5,
@@ -97,20 +97,31 @@ describe('RuleConfigRepository', () => {
       });
 
       expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+
+      // total comes from a real COUNT(*) over the same predicates
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
         {
-          text: "SELECT configuration FROM rule WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 DESC OFFSET $4 LIMIT $5;",
-          values: ['ruleid', '', 'cfg', 5, 10, mockTenantId],
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+      // ordering is on the generated unique-key columns (rulecfg, ruleid), not configuration->>...
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 ORDER BY rulecfg DESC, ruleid DESC OFFSET $2 LIMIT $3;',
+          values: [mockTenantId, 5, 10],
         },
         'configuration',
       );
     });
 
-    it('should list with the first provided filter and custom sort', async () => {
-      mockHandlePostExecuteSqlStatement.mockResolvedValue({
-        rows: [],
-        rowCount: 0,
-      });
+    it('applies every supplied filter (ANDed) on the generated columns and sorts by the chosen key', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
       const result = await RuleConfigRepo.list({
         filters: { id: 'rule-002', cfg: '2.0.0' },
@@ -122,13 +133,82 @@ describe('RuleConfigRepository', () => {
       });
 
       expect(result).toEqual({ data: [], total: 0 });
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+
+      // BOTH filters become separate ANDed, parameterised predicates (single-filter bug fixed)
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
         {
-          text: "SELECT configuration FROM rule WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 ASC OFFSET $4 LIMIT $5;",
-          values: ['id', 'rule-002', 'id', 0, 25, mockTenantId],
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1 AND ruleid = $2 AND rulecfg = $3;',
+          values: [mockTenantId, 'rule-002', '2.0.0'],
         },
         'configuration',
       );
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 AND ruleid = $2 AND rulecfg = $3 ORDER BY ruleid ASC, rulecfg ASC OFFSET $4 LIMIT $5;',
+          values: [mockTenantId, 'rule-002', '2.0.0', 0, 25],
+        },
+        'configuration',
+      );
+    });
+
+    it('takes total from COUNT (not the page length) and never returns null', async () => {
+      const cfg = createMockRuleConfig();
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '42' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: cfg }], rowCount: null });
+
+      const result = await RuleConfigRepo.list({ offset: 0, limit: 20, order: 'ASC', tenantId: mockTenantId });
+
+      expect(result.total).toBe(42);
+      expect(result.data).toEqual([cfg]);
+    });
+
+    it('ignores filter fields that are not in the allowlist', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await RuleConfigRepo.list({
+        filters: { nope: 'x', id: 'rule-1' },
+        offset: 0,
+        limit: 20,
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      // only the recognised `id` filter becomes a predicate; `nope` is dropped
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1 AND ruleid = $2;',
+          values: [mockTenantId, 'rule-1'],
+        },
+        'configuration',
+      );
+    });
+
+    it('reports the real total on an over-paged (empty) page (separate COUNT, not COUNT(*) OVER())', async () => {
+      // offset past the end => the page query returns zero rows, but COUNT still answers 42.
+      // A COUNT(*) OVER() implementation would read no window row here and wrongly report 0.
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '42' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const result = await RuleConfigRepo.list({ offset: 1000, limit: 20, order: 'ASC', tenantId: mockTenantId });
+
+      expect(result).toEqual({ data: [], total: 42 });
+    });
+
+    it('coerces a missing/null COUNT result to total 0 (never null/NaN)', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: null }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const result = await RuleConfigRepo.list({ offset: 0, limit: 20, order: 'ASC', tenantId: mockTenantId });
+
+      expect(result).toEqual({ data: [], total: 0 });
     });
   });
 

--- a/__tests__/unit/repositories/typology.config.repository.test.ts
+++ b/__tests__/unit/repositories/typology.config.repository.test.ts
@@ -88,14 +88,13 @@ describe('TypologyConfigRepository', () => {
   });
 
   describe('list', () => {
-    it('should list typology configurations with default sort and no filters', async () => {
+    it('counts all matching rows and pages deterministically on the generated key (no filters)', async () => {
       const firstConfig = createMockTypologyConfig();
       const secondConfig = { ...createMockTypologyConfig(), id: 'typology-002', cfg: '2.0.0' };
 
-      mockHandlePostExecuteSqlStatement.mockResolvedValue({
-        rows: [{ configuration: firstConfig }, { configuration: secondConfig }],
-        rowCount: 2,
-      });
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: firstConfig }, { configuration: secondConfig }], rowCount: 2 });
 
       const result = await TypologyConfigRepo.list({
         offset: 5,
@@ -105,20 +104,29 @@ describe('TypologyConfigRepository', () => {
       });
 
       expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
         {
-          text: "SELECT configuration FROM typology WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$5 DESC OFFSET $3 LIMIT $4;",
-          values: ['typologyid', '', 5, 10, 'cfg', mockTenantId],
+          text: 'SELECT COUNT(*) AS total FROM typology WHERE tenantid = $1;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM typology WHERE tenantid = $1 ORDER BY typologycfg DESC, typologyid DESC OFFSET $2 LIMIT $3;',
+          values: [mockTenantId, 5, 10],
         },
         'configuration',
       );
     });
 
-    it('should list with the first provided filter and custom sort', async () => {
-      mockHandlePostExecuteSqlStatement.mockResolvedValue({
-        rows: [],
-        rowCount: 0,
-      });
+    it('applies every supplied filter (ANDed) on the generated columns and sorts by the chosen key', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
       const result = await TypologyConfigRepo.list({
         filters: { id: 'typology-002', cfg: '2.0.0' },
@@ -130,10 +138,55 @@ describe('TypologyConfigRepository', () => {
       });
 
       expect(result).toEqual({ data: [], total: 0 });
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
         {
-          text: "SELECT configuration FROM typology WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$5 ASC OFFSET $3 LIMIT $4;",
-          values: ['id', 'typology-002', 0, 25, 'id', mockTenantId],
+          text: 'SELECT COUNT(*) AS total FROM typology WHERE tenantid = $1 AND typologyid = $2 AND typologycfg = $3;',
+          values: [mockTenantId, 'typology-002', '2.0.0'],
+        },
+        'configuration',
+      );
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM typology WHERE tenantid = $1 AND typologyid = $2 AND typologycfg = $3 ORDER BY typologyid ASC, typologycfg ASC OFFSET $4 LIMIT $5;',
+          values: [mockTenantId, 'typology-002', '2.0.0', 0, 25],
+        },
+        'configuration',
+      );
+    });
+
+    it('takes total from COUNT (not the page length) and never returns null', async () => {
+      const cfg = createMockTypologyConfig();
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '42' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: cfg }], rowCount: null });
+
+      const result = await TypologyConfigRepo.list({ offset: 0, limit: 20, order: 'ASC', tenantId: mockTenantId });
+
+      expect(result.total).toBe(42);
+      expect(result.data).toEqual([cfg]);
+    });
+
+    it('ignores filter fields that are not in the allowlist', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await TypologyConfigRepo.list({
+        filters: { nope: 'x', id: 'typology-1' },
+        offset: 0,
+        limit: 20,
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM typology WHERE tenantid = $1 AND typologyid = $2;',
+          values: [mockTenantId, 'typology-1'],
         },
         'configuration',
       );

--- a/src/repositories/configuration/config-list.shared.ts
+++ b/src/repositories/configuration/config-list.shared.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
+import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import type { ListQuery } from '../repository.base';
+
+// Shared, parameterised implementation of the configuration `list` endpoints (#418).
+//
+// Fixes the defects of the per-entity hand-rolled queries:
+//   - every supplied filter becomes its own ANDed, parameterised predicate
+//     (previously only the first filter was applied);
+//   - `total` comes from a SEPARATE COUNT(*) issued before the page query, so an
+//     over-paged (empty) page still reports the real total (COUNT(*) OVER() would not);
+//   - ordering is on the generated key columns with a deterministic tiebreak;
+//   - the chosen `sort` and each `filter` field are mapped through an allowlist
+//     descriptor, never interpolated from caller-supplied identifiers.
+
+export interface ConfigFilterColumn {
+  /** Querystring filter key (e.g. `id`). */
+  key: string;
+  /** Generated database column the key maps to (e.g. `ruleid`). */
+  column: string;
+  /** Optional SQL cast appended to the placeholder (e.g. `::boolean`). */
+  cast?: string;
+}
+
+export interface ConfigListDescriptor {
+  /** Configuration table name. */
+  table: string;
+  /** Allowlist of sort keys mapped to generated columns. */
+  sortColumns: Record<string, string>;
+  /** Sort key applied when the caller omits `sort`. */
+  defaultSort: string;
+  /** Canonical order of generated unique-key columns for deterministic tiebreaks. */
+  uniqueKeyOrder: string[];
+  /** Ordered allowlist of filter fields; iteration order is part of the SQL contract. */
+  filters: ConfigFilterColumn[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- TEntity gives call sites their concrete config type for `data`.
+export const listConfiguration = async <TEntity>(
+  descriptor: ConfigListDescriptor,
+  query: ListQuery,
+): Promise<{ data: TEntity[]; total: number }> => {
+  const { offset = 0, limit = 20, order = 'ASC', sort, filters, tenantId } = query;
+  const direction = order === 'DESC' ? 'DESC' : 'ASC';
+
+  // tenantId is always the first bound parameter.
+  const predicates: string[] = ['tenantid = $1'];
+  const filterValues: string[] = [];
+  for (const { key, column, cast } of descriptor.filters) {
+    const value = filters?.[key];
+    if (value !== undefined) {
+      filterValues.push(value);
+      predicates.push(`${column} = $${filterValues.length + 1}${cast ?? ''}`);
+    }
+  }
+  const whereClause = predicates.join(' AND ');
+
+  // COUNT first: a dedicated COUNT(*) reports the true total even on an empty/over-paged page.
+  const countRes = await handlePostExecuteSqlStatement<{ total: string }>(
+    {
+      text: `SELECT COUNT(*) AS total FROM ${descriptor.table} WHERE ${whereClause};`,
+      values: [tenantId, ...filterValues],
+    } satisfies PgQueryConfig,
+    'configuration',
+  );
+  const total = parseInt(countRes.rows[0]?.total ?? '', 10) || 0;
+
+  // Deterministic ORDER BY: the chosen sort column first, then the remaining unique-key columns.
+  const sortColumn = descriptor.sortColumns[sort ?? ''] ?? descriptor.sortColumns[descriptor.defaultSort];
+  const orderColumns = [sortColumn, ...descriptor.uniqueKeyOrder.filter((column) => column !== sortColumn)];
+  const orderByClause = orderColumns.map((column) => `${column} ${direction}`).join(', ');
+
+  const offsetParam = filterValues.length + 2;
+  const limitParam = filterValues.length + 3;
+  const pageRes = await handlePostExecuteSqlStatement<{ configuration: TEntity }>(
+    {
+      text: `SELECT configuration FROM ${descriptor.table} WHERE ${whereClause} ORDER BY ${orderByClause} OFFSET $${offsetParam} LIMIT $${limitParam};`,
+      values: [tenantId, ...filterValues, offset, limit],
+    } satisfies PgQueryConfig,
+    'configuration',
+  );
+
+  return { data: pageRes.rows.map((row) => row.configuration), total };
+};

--- a/src/repositories/configuration/network.map.repository.ts
+++ b/src/repositories/configuration/network.map.repository.ts
@@ -3,27 +3,22 @@ import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
 import type { ConfigVersion, CrudRepository } from '../repository.base';
+import { listConfiguration, type ConfigListDescriptor } from './config-list.shared';
+
+const networkMapListDescriptor: ConfigListDescriptor = {
+  table: 'network_map',
+  sortColumns: { cfg: 'cfg' },
+  defaultSort: 'cfg',
+  uniqueKeyOrder: ['cfg'],
+  filters: [
+    { key: 'active', column: 'active', cast: '::boolean' },
+    { key: 'cfg', column: 'cfg' },
+  ],
+};
 
 export const NetworkMapRepo: CrudRepository<NetworkMap, ConfigVersion> = {
-  list: async function ({ limit, offset, sort, order, filters, tenantId }): Promise<{ data: NetworkMap[]; total: number }> {
-    sort ??= 'cfg';
-    const filter: { field: string; value: string } = { field: 'cfg', value: '' };
-    if (filters) {
-      const [[field, value]] = Object.entries(filters);
-      filter.field = field;
-      filter.value = value;
-    }
-    const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
-      {
-        text: `SELECT configuration FROM network_map WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 ${order} OFFSET $4 LIMIT $5;`,
-        values: [filter.field, filter.value, sort, offset, limit, tenantId],
-      } satisfies PgQueryConfig,
-      'configuration',
-    );
-
-    return queryRes.rows.length > 0
-      ? { data: queryRes.rows.map((values) => values.configuration), total: queryRes.rowCount! }
-      : { data: [], total: 0 };
+  list: async function (params): Promise<{ data: NetworkMap[]; total: number }> {
+    return await listConfiguration<NetworkMap>(networkMapListDescriptor, params);
   },
 
   get: async function ({ cfg, tenantId }): Promise<NetworkMap | null> {

--- a/src/repositories/configuration/rule.config.repository.ts
+++ b/src/repositories/configuration/rule.config.repository.ts
@@ -3,28 +3,22 @@ import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
 import type { CrudRepository } from '../repository.base';
+import { listConfiguration, type ConfigListDescriptor } from './config-list.shared';
+
+const ruleListDescriptor: ConfigListDescriptor = {
+  table: 'rule',
+  sortColumns: { id: 'ruleid', cfg: 'rulecfg' },
+  defaultSort: 'cfg',
+  uniqueKeyOrder: ['ruleid', 'rulecfg'],
+  filters: [
+    { key: 'id', column: 'ruleid' },
+    { key: 'cfg', column: 'rulecfg' },
+  ],
+};
 
 export const RuleConfigRepo: CrudRepository<RuleConfig> = {
-  list: async function ({ offset, limit, filters, order, sort, tenantId }): Promise<{ data: RuleConfig[]; total: number }> {
-    sort ??= 'cfg';
-    const filter: { field: string; value: string } = { field: 'ruleid', value: '' };
-    if (filters) {
-      const [[field, value]] = Object.entries(filters);
-      filter.field = field;
-      filter.value = value;
-    }
-
-    const queryRes = await handlePostExecuteSqlStatement<{ configuration: RuleConfig }>(
-      {
-        text: `SELECT configuration FROM rule WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$3 ${order} OFFSET $4 LIMIT $5;`,
-        values: [filter.field, filter.value, sort, offset, limit, tenantId],
-      } satisfies PgQueryConfig,
-      'configuration',
-    );
-
-    return queryRes.rows.length > 0
-      ? { data: queryRes.rows.map((values) => values.configuration), total: queryRes.rowCount! }
-      : { data: [], total: 0 };
+  list: async function (params): Promise<{ data: RuleConfig[]; total: number }> {
+    return await listConfiguration<RuleConfig>(ruleListDescriptor, params);
   },
 
   get: async function ({ id, cfg, tenantId }): Promise<RuleConfig | null> {

--- a/src/repositories/configuration/typology.config.repository.ts
+++ b/src/repositories/configuration/typology.config.repository.ts
@@ -3,28 +3,22 @@ import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { TypologyConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
 import type { CrudRepository } from '../repository.base';
+import { listConfiguration, type ConfigListDescriptor } from './config-list.shared';
+
+const typologyListDescriptor: ConfigListDescriptor = {
+  table: 'typology',
+  sortColumns: { id: 'typologyid', cfg: 'typologycfg' },
+  defaultSort: 'cfg',
+  uniqueKeyOrder: ['typologyid', 'typologycfg'],
+  filters: [
+    { key: 'id', column: 'typologyid' },
+    { key: 'cfg', column: 'typologycfg' },
+  ],
+};
 
 export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
-  list: async function ({ filters, limit, offset, order, sort, tenantId }): Promise<{ data: TypologyConfig[]; total: number }> {
-    sort ??= 'cfg';
-    const filter: { field: string; value: string } = { field: 'typologyid', value: '' };
-    if (filters) {
-      const [[field, value]] = Object.entries(filters);
-      filter.field = field;
-      filter.value = value;
-    }
-
-    const queryRes = await handlePostExecuteSqlStatement<{ configuration: TypologyConfig }>(
-      {
-        text: `SELECT configuration FROM typology WHERE ($2 = '' OR configuration->>$1 = $2) AND tenantId = $6 ORDER BY configuration->>$5 ${order} OFFSET $3 LIMIT $4;`,
-        values: [filter.field, filter.value, offset, limit, sort, tenantId],
-      } satisfies PgQueryConfig,
-      'configuration',
-    );
-
-    return queryRes.rows.length > 0
-      ? { data: queryRes.rows.map((values) => values.configuration), total: queryRes.rowCount! }
-      : { data: [], total: 0 };
+  list: async function (params): Promise<{ data: TypologyConfig[]; total: number }> {
+    return await listConfiguration<TypologyConfig>(typologyListDescriptor, params);
   },
 
   get: async function ({ id, cfg, tenantId }): Promise<TypologyConfig | null> {

--- a/src/router.ts
+++ b/src/router.ts
@@ -78,6 +78,9 @@ import {
   QueryEntityConditionSchema,
   RuleSchema,
   TypologySchema,
+  NetworkMapListQuery,
+  RuleListQuery,
+  TypologyListQuery,
 } from './schemas';
 import { buildCrudPlugin } from './utils/crud-schema';
 import { SetOptionsBodyAndParams } from './utils/schema-utils';
@@ -147,7 +150,7 @@ function Routes(fastify: FastifyInstance): void {
     buildCrudPlugin({
       prefix: '/v1/admin/configuration/network_map',
       repo: NetworkMapRepo,
-      schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema },
+      schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema, Query: NetworkMapListQuery },
       idParam: { kind: 'cfg' },
     }),
   );
@@ -156,7 +159,7 @@ function Routes(fastify: FastifyInstance): void {
     buildCrudPlugin({
       prefix: '/v1/admin/configuration/rule',
       repo: RuleConfigRepo,
-      schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
+      schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema, Query: RuleListQuery },
       idParam: { kind: 'single', name: 'id' },
     }),
   );
@@ -165,7 +168,7 @@ function Routes(fastify: FastifyInstance): void {
     buildCrudPlugin({
       prefix: '/v1/admin/configuration/typology',
       repo: TypologyConfigRepo,
-      schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema },
+      schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema, Query: TypologyListQuery },
       idParam: { kind: 'single', name: 'id' },
     }),
   );

--- a/src/schemas/configListQuerySchema.ts
+++ b/src/schemas/configListQuerySchema.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Type } from '@sinclair/typebox';
+
+// Per-entity querystring schemas for the configuration `list` endpoints (#418).
+//
+// These constrain `sort` to an allowlist of generated key columns and `filters`
+// to a closed set of known fields. Combined with the production Ajv settings
+// (removeAdditional: 'all'), an unknown `filters[...]` key is silently stripped
+// (D1) while an out-of-range `sort`/`order` value is rejected with 400.
+
+const Order = Type.Optional(Type.Union([Type.Literal('ASC'), Type.Literal('DESC')]));
+const Limit = Type.Optional(Type.Integer({ minimum: 1, maximum: 100 }));
+const Offset = Type.Optional(Type.Integer({ minimum: 0 }));
+
+export const RuleListQuery = Type.Object({
+  limit: Limit,
+  offset: Offset,
+  order: Order,
+  sort: Type.Optional(Type.Union([Type.Literal('id'), Type.Literal('cfg')])),
+  filters: Type.Optional(
+    Type.Object(
+      {
+        id: Type.Optional(Type.String()),
+        cfg: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+  ),
+});
+
+export const TypologyListQuery = Type.Object({
+  limit: Limit,
+  offset: Offset,
+  order: Order,
+  sort: Type.Optional(Type.Union([Type.Literal('id'), Type.Literal('cfg')])),
+  filters: Type.Optional(
+    Type.Object(
+      {
+        id: Type.Optional(Type.String()),
+        cfg: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+  ),
+});
+
+export const NetworkMapListQuery = Type.Object({
+  limit: Limit,
+  offset: Offset,
+  order: Order,
+  sort: Type.Optional(Type.Literal('cfg')),
+  filters: Type.Optional(
+    Type.Object(
+      {
+        cfg: Type.Optional(Type.String()),
+        // `active` maps to a generated boolean column cast `::boolean`; constrain it to
+        // the two valid literals so a malformed value is rejected with 400 at the schema
+        // boundary rather than raising a Postgres cast error (500).
+        active: Type.Optional(Type.Union([Type.Literal('true'), Type.Literal('false')])),
+      },
+      { additionalProperties: false },
+    ),
+  ),
+});

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -11,6 +11,7 @@ import { QueryAccountConditionSchema } from './queryAccountConditionSchema';
 import { QueryEntityConditionSchema } from './queryEntityConditionSchema';
 import { RuleSchema } from './ruleSchema';
 import { TypologySchema } from './typologySchema';
+import { NetworkMapListQuery, RuleListQuery, TypologyListQuery } from './configListQuerySchema';
 export {
   AccountConditionSchema,
   EntityConditionSchema,
@@ -23,4 +24,7 @@ export {
   QueryEntityConditionSchema,
   RuleSchema,
   TypologySchema,
+  NetworkMapListQuery,
+  RuleListQuery,
+  TypologyListQuery,
 };

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -14,7 +14,7 @@ export interface CrudSchemas {
   Create: TSchema;
   Update: TSchema;
   Id?: TSchema;
-  Query?: typeof DefaultQuery;
+  Query?: TObject;
 }
 
 type IdParamConfig = { kind: 'single'; name?: string } | { kind: 'cfg' } | { kind: 'composite'; names: readonly [string, string] };
@@ -100,7 +100,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
           : [validateTenantMiddleware],
       },
       async (req, reply) => {
-        const queryParams = req.query as Static<typeof QuerySchema>;
+        const queryParams = req.query as Static<typeof DefaultQuery>;
         const { tenantId } = req as ITenantRequest;
         const { limit = 20, offset = 0, sort, order = 'ASC', filters } = queryParams;
 


### PR DESCRIPTION
## Summary

Fixes #418. Reworks the `rule`, `typology` and `network_map` configuration `list`
endpoints so pagination, filtering and sorting are correct and deterministic.

## Defects fixed

1. **Only the first filter was applied.** Every supplied filter is now applied as
   its own ANDed, parameterised predicate.
2. **`total` was taken from the page rowCount.** It is now derived from a dedicated
   `SELECT COUNT(*)` issued before the page query, so an over-paged (empty) page still
   reports the real total.
3. **Ordering used a caller-supplied JSON field.** Ordering is now on the generated
   key columns with a deterministic tiebreak.
4. **`sort` / `order` were unvalidated.** `sort` is validated against a per-entity
   allowlist and `order` against `ASC|DESC`; unknown filter keys are stripped by Ajv
   `removeAdditional`.
5. **Typology had ORDER BY parameter drift.** All three entities now share one
   implementation, removing the drift.

## Approach

- New shared `listConfiguration` helper driven by a per-entity `ConfigListDescriptor`
  (table, sort-column allowlist, default sort, unique-key tiebreak order, filter map).
- New per-entity querystring schemas (`RuleListQuery`, `TypologyListQuery`,
  `NetworkMapListQuery`) wired through `buildCrudPlugin`.
- The `active` `network_map` filter is constrained to `true|false`, so a malformed
  value is rejected at the schema boundary (400) instead of raising a Postgres
  `::boolean` cast error (500).

## Testing

- Repository tests rewritten to assert the new contract (separate COUNT, deterministic
  ORDER BY on key columns, every filter ANDed, total from COUNT, allowlist stripping,
  over-paged empty page, null COUNT coerced to zero).
- New schema-boundary test mirroring production Ajv + `qs` config: out-of-range
  `sort`/`order` -> 400, unknown filter stripped -> 200, malformed `active` -> 400,
  recognised filters reach `repo.list`, `meta.total` passed through unchanged.
- Full suite: 29 suites / 663 tests passing. Lint and build clean.

## Compatibility

The only known consumer (`tazama-lf/tazama-demo`) sends `filters[active]=true` on
`network_map` with no `sort` and no other filters; the new allowlist does not affect it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query parameter schema validation for configuration list endpoints, including constraints on sort order, filter values, and pagination limits.

* **Bug Fixes**
  * Invalid sort/order values and malformed filter values are now rejected with HTTP 400 errors.
  * Unknown filter fields are ignored without affecting query results.
  * List responses now return accurate total counts regardless of pagination state.

* **Tests**
  * Expanded test coverage for list endpoints to verify schema boundary behavior and SQL query correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->