### PR TITLE
feat: support limit=all for unbounded configuration listing (#422)

### DIFF
--- a/__tests__/unit/config-list.crud-plugin.test.ts
+++ b/__tests__/unit/config-list.crud-plugin.test.ts
@@ -142,4 +142,50 @@ describe('configuration list - schema-boundary behaviour (#418)', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().meta).toEqual({ total: 99, limit: 20, offset: 0 });
   });
+
+  // --- limit=all (#422): bounded default stays, explicit opt-in for the full set ---
+
+  it('accepts limit=all and forwards it to repo.list (#422)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?limit=all' });
+    expect(res.statusCode).toBe(200);
+    expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ limit: 'all' }));
+  });
+
+  it('reports meta.limit = total and meta.offset = 0 for limit=all (#422)', async () => {
+    mockRuleList.mockResolvedValueOnce({ data: [], total: 99 });
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?limit=all' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().meta).toEqual({ total: 99, limit: 99, offset: 0 });
+  });
+
+  it('allows limit=all with an explicit offset=0 (#422)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?limit=all&offset=0' });
+    expect(res.statusCode).toBe(200);
+    expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ limit: 'all' }));
+  });
+
+  it('rejects limit=all combined with a non-zero offset with 400 (mutually exclusive, #422)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?limit=all&offset=10' });
+    expect(res.statusCode).toBe(400);
+    // Must be the handler-level cross-field guard, not the schema rejecting the literal 'all'.
+    expect(res.json().message).toMatch(/offset/i);
+    expect(mockRuleList).not.toHaveBeenCalled();
+  });
+
+  it('forwards the bounded default limit:20 and offset:0 when no paging params are supplied (#422)', async () => {
+    await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule' });
+    expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ limit: 20, offset: 0 }));
+  });
+
+  it('forwards a bare offset with the bounded default limit:20 (#422)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?offset=10' });
+    expect(res.statusCode).toBe(200);
+    expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ offset: 10, limit: 20 }));
+  });
+
+  it('still rejects an over-cap numeric limit with 400 (#422)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?limit=500' });
+    expect(res.statusCode).toBe(400);
+    expect(mockRuleList).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/unit/repositories/network.map.repository.test.ts
+++ b/__tests__/unit/repositories/network.map.repository.test.ts
@@ -179,6 +179,25 @@ describe('NetworkMapRepository', () => {
         'configuration',
       );
     });
+
+    it('keeps the ::boolean filter but omits OFFSET and LIMIT when limit is "all" (#422)', async () => {
+      const map = createMockNetworkMap();
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '1' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: map }], rowCount: 1 });
+
+      await NetworkMapRepo.list({ filters: { active: 'true' }, limit: 'all', order: 'ASC', tenantId: mockTenantId });
+
+      // The active predicate (cast ::boolean) is preserved; no OFFSET/LIMIT is appended.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM network_map WHERE tenantid = $1 AND active = $2::boolean ORDER BY cfg ASC;',
+          values: [mockTenantId, 'true'],
+        },
+        'configuration',
+      );
+    });
   });
 
   describe('get', () => {

--- a/__tests__/unit/repositories/rule.config.repository.test.ts
+++ b/__tests__/unit/repositories/rule.config.repository.test.ts
@@ -210,6 +210,56 @@ describe('RuleConfigRepository', () => {
 
       expect(result).toEqual({ data: [], total: 0 });
     });
+
+    it('omits OFFSET and LIMIT when limit is "all" (unbounded full-set retrieval, #422)', async () => {
+      const firstConfig = createMockRuleConfig();
+      const secondConfig = { ...createMockRuleConfig(), id: 'rule-002', cfg: '2.0.0' };
+
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: firstConfig }, { configuration: secondConfig }], rowCount: 2 });
+
+      const result = await RuleConfigRepo.list({ limit: 'all', order: 'ASC', tenantId: mockTenantId });
+
+      expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
+
+      // COUNT(*) is unchanged - the real total is still reported.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+      // The page query carries NEITHER OFFSET NOR LIMIT and binds only the tenant (+ any filters).
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 ORDER BY rulecfg ASC, ruleid ASC;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('applies filters but still omits OFFSET and LIMIT when limit is "all" (#422)', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '1' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await RuleConfigRepo.list({ filters: { id: 'rule-002' }, limit: 'all', order: 'ASC', tenantId: mockTenantId });
+
+      // The recognised filter is still ANDed and parameterised; no OFFSET/LIMIT is appended.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 AND ruleid = $2 ORDER BY rulecfg ASC, ruleid ASC;',
+          values: [mockTenantId, 'rule-002'],
+        },
+        'configuration',
+      );
+    });
   });
 
   describe('get', () => {

--- a/__tests__/unit/repositories/typology.config.repository.test.ts
+++ b/__tests__/unit/repositories/typology.config.repository.test.ts
@@ -191,6 +191,25 @@ describe('TypologyConfigRepository', () => {
         'configuration',
       );
     });
+
+    it('omits OFFSET and LIMIT when limit is "all" (unbounded full-set retrieval, #422)', async () => {
+      const cfg = createMockTypologyConfig();
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: cfg }], rowCount: 1 });
+
+      await TypologyConfigRepo.list({ limit: 'all', order: 'ASC', tenantId: mockTenantId });
+
+      // COUNT(*) is unchanged; the page query carries no OFFSET/LIMIT and binds only the tenant.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM typology WHERE tenantid = $1 ORDER BY typologycfg ASC, typologyid ASC;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+    });
   });
 
   describe('get', () => {

--- a/src/repositories/configuration/config-list.shared.ts
+++ b/src/repositories/configuration/config-list.shared.ts
@@ -71,12 +71,15 @@ export const listConfiguration = async <TEntity>(
   const orderColumns = [sortColumn, ...descriptor.uniqueKeyOrder.filter((column) => column !== sortColumn)];
   const orderByClause = orderColumns.map((column) => `${column} ${direction}`).join(', ');
 
-  const offsetParam = filterValues.length + 2;
-  const limitParam = filterValues.length + 3;
+  // `limit === 'all'` returns the full tenant-scoped set: omit OFFSET/LIMIT entirely and bind
+  // neither param (#422). The handler guarantees offset is 0 on this path (mutually exclusive).
+  const isUnbounded = limit === 'all';
+  const pageClause = isUnbounded ? '' : ` OFFSET $${filterValues.length + 2} LIMIT $${filterValues.length + 3}`;
+  const pageValues = isUnbounded ? [tenantId, ...filterValues] : [tenantId, ...filterValues, offset, limit];
   const pageRes = await handlePostExecuteSqlStatement<{ configuration: TEntity }>(
     {
-      text: `SELECT configuration FROM ${descriptor.table} WHERE ${whereClause} ORDER BY ${orderByClause} OFFSET $${offsetParam} LIMIT $${limitParam};`,
-      values: [tenantId, ...filterValues, offset, limit],
+      text: `SELECT configuration FROM ${descriptor.table} WHERE ${whereClause} ORDER BY ${orderByClause}${pageClause};`,
+      values: pageValues,
     } satisfies PgQueryConfig,
     'configuration',
   );

--- a/src/repositories/repository.base.ts
+++ b/src/repositories/repository.base.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 type StringKeys<T> = Extract<keyof T, string>;
 export interface ListQuery<TSort extends string = string> {
-  limit?: number; // default 20
+  limit?: number | 'all'; // default 20; 'all' returns the full tenant-scoped set (#422)
   tenantId?: string; // tenant id is (optional) default "DEFAULT"
   offset?: number; // default 0
   sort?: TSort; // field name

--- a/src/schemas/configListQuerySchema.ts
+++ b/src/schemas/configListQuerySchema.ts
@@ -9,7 +9,9 @@ import { Type } from '@sinclair/typebox';
 // (D1) while an out-of-range `sort`/`order` value is rejected with 400.
 
 const Order = Type.Optional(Type.Union([Type.Literal('ASC'), Type.Literal('DESC')]));
-const Limit = Type.Optional(Type.Integer({ minimum: 1, maximum: 100 }));
+// `all` returns the full tenant-scoped set in one response (#422); it is mutually exclusive
+// with a non-zero `offset`, which the list handler enforces as a 400 cross-field guard.
+const Limit = Type.Optional(Type.Union([Type.Integer({ minimum: 1, maximum: 100 }), Type.Literal('all')]));
 const Offset = Type.Optional(Type.Integer({ minimum: 0 }));
 
 export const RuleListQuery = Type.Object({

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -27,7 +27,7 @@ interface BuildCrudOptions<TEntity, TId extends AllowedId> {
 }
 
 const DefaultQuery = Type.Object({
-  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  limit: Type.Optional(Type.Union([Type.Integer({ minimum: 1, maximum: 100 }), Type.Literal('all')])),
   offset: Type.Optional(Type.Integer({ minimum: 0 })),
   sort: Type.Optional(Type.String()),
   order: Type.Optional(Type.Union([Type.Literal('ASC'), Type.Literal('DESC')])),
@@ -93,7 +93,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         schema: {
           tags: [prefix],
           querystring: QuerySchema,
-          response: { 200: ListResponse },
+          response: { 200: ListResponse, 400: Type.Object({ message: Type.String() }) },
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`LIST${prefix.replaceAll('/', '_').toUpperCase()}`)]
@@ -103,6 +103,12 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         const queryParams = req.query as Static<typeof DefaultQuery>;
         const { tenantId } = req as ITenantRequest;
         const { limit = 20, offset = 0, sort, order = 'ASC', filters } = queryParams;
+
+        // `limit=all` and a non-zero `offset` are mutually exclusive: an unbounded fetch has no
+        // page to skip into, so combining them is a client error rather than a silent no-op (#422).
+        if (limit === 'all' && offset !== 0) {
+          return await reply.code(400).send({ message: 'offset cannot be combined with limit=all' });
+        }
 
         type SortField = Extract<keyof TEntity, string>;
 
@@ -116,7 +122,9 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         };
 
         const { data, total } = await repo.list(params);
-        return await reply.send({ data, meta: { total, limit, offset } });
+        // For the unbounded path report the truthful window: the whole set was returned from offset 0.
+        const meta = limit === 'all' ? { total, limit: total, offset: 0 } : { total, limit, offset };
+        return await reply.send({ data, meta });
       },
     );
 


### PR DESCRIPTION
## What

Adds an explicit `limit=all` option to the configuration list endpoints (`rule`,
`typology`, `network_map`), returning the full tenant-scoped result set in a single
response alongside the existing bounded default (`limit` 20). This is Issue B of the
configuration-CRUD roadmap and builds on the shared `listConfiguration` helper from
Issue A (#425).

Resolves #422.

## How

- **Schema**: the shared and per-entity list query schemas now accept `limit` as a
  union of `Integer(1..100)` and the literal `'all'`. An over-cap numeric limit (for
  example `limit=500`) still returns `400` at the schema boundary.
- **Handler** (`crud-schema.ts`): `limit=all` and a non-zero `offset` are mutually
  exclusive - combining them returns `400` with a clear message
  (`offset cannot be combined with limit=all`). On the unbounded path the response
  reports `meta.limit = total` and `meta.offset = 0`, a truthful description of the
  window returned.
- **Repository** (`config-list.shared.ts`): on the unbounded path the page query omits
  both `OFFSET` and `LIMIT` and binds neither parameter. The separate `COUNT(*)` and the
  bounded path are unchanged.
- `ListQuery.limit` is widened to `number | 'all'`.

## Behaviour summary

| Request | Result |
| --- | --- |
| no paging params | bounded default page (`limit` 20, `offset` 0), accurate `meta.total` |
| `?limit=all` | full tenant-scoped set; `meta = { total, limit: total, offset: 0 }` |
| `?limit=all&offset=0` | allowed |
| `?limit=all&offset=10` | `400` (mutually exclusive) |
| `?limit=500` | `400` (over cap) |
| `?offset=10` | bounded default `limit` 20 from offset 10 |

## Testing

- Red-first TDD: failing tests written and reviewed before implementation.
- Targeted suite: 68 passing (crud plugin boundary + rule/typology/network_map repos).
- Full suite: 674 passing; build clean; changed files lint clean.

## Notes

- The unbounded path drops `OFFSET`/`LIMIT` entirely (vs `LIMIT ALL`) - a purely internal
  back-end choice with no change to the response contract.
- OpenAPI is generated from the TypeBox schema, so `limit=all` and the `400` response
  surface automatically.
