### PR TITLE
feat: targeted batch fetch of configurations by (id, cfg) set (#423)

### DIFF
--- a/__tests__/unit/config-list.crud-plugin.test.ts
+++ b/__tests__/unit/config-list.crud-plugin.test.ts
@@ -188,4 +188,50 @@ describe('configuration list - schema-boundary behaviour (#418)', () => {
     expect(res.statusCode).toBe(400);
     expect(mockRuleList).not.toHaveBeenCalled();
   });
+
+  // --- targeted batch fetch by (id, cfg) set (#423) ---
+
+  it('forwards a parsed (id, cfg) set to repo.list as an array of {id, cfg} (#423)', async () => {
+    const url = '/v1/admin/configuration/rule?keys[0][id]=EFRuP@1.0.0&keys[0][cfg]=1.0.0&keys[1][id]=Foo@1.0.0&keys[1][cfg]=1.0.0';
+    const res = await app.inject({ method: 'GET', url });
+    expect(res.statusCode).toBe(200);
+    expect(mockRuleList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keys: [
+          { id: 'EFRuP@1.0.0', cfg: '1.0.0' },
+          { id: 'Foo@1.0.0', cfg: '1.0.0' },
+        ],
+      }),
+    );
+  });
+
+  it('accepts the (id, cfg) set together with limit=all (the canonical client call, #423)', async () => {
+    const url = '/v1/admin/configuration/rule?keys[0][id]=EFRuP@1.0.0&keys[0][cfg]=1.0.0&limit=all';
+    const res = await app.inject({ method: 'GET', url });
+    expect(res.statusCode).toBe(200);
+    expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ keys: [{ id: 'EFRuP@1.0.0', cfg: '1.0.0' }], limit: 'all' }));
+  });
+
+  it('rejects a malformed set entry (a pair missing cfg) with 400 (#423)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/configuration/rule?keys[0][id]=EFRuP@1.0.0' });
+    expect(res.statusCode).toBe(400);
+    expect(mockRuleList).not.toHaveBeenCalled();
+  });
+
+  it('rejects a set larger than the maxItems cap with 400 (#423)', async () => {
+    const pairs = Array.from({ length: 201 }, (_, i) => `keys[${i}][id]=r${i}&keys[${i}][cfg]=1.0.0`).join('&');
+    const res = await app.inject({ method: 'GET', url: `/v1/admin/configuration/rule?${pairs}` });
+    expect(res.statusCode).toBe(400);
+    expect(mockRuleList).not.toHaveBeenCalled();
+  });
+
+  it('does not expose the (id, cfg) set on network_map - the param is stripped, not forwarded (#423 scope)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/admin/configuration/network_map?keys[0][id]=x&keys[0][cfg]=1.0.0',
+    });
+    expect(res.statusCode).toBe(200);
+    const forwarded = mockNetworkMapList.mock.calls[0][0] as { keys?: unknown };
+    expect(forwarded).not.toHaveProperty('keys');
+  });
 });

--- a/__tests__/unit/repositories/rule.config.repository.test.ts
+++ b/__tests__/unit/repositories/rule.config.repository.test.ts
@@ -262,6 +262,155 @@ describe('RuleConfigRepository', () => {
     });
   });
 
+  describe('list - targeted batch fetch by (id, cfg) set (#423)', () => {
+    it('matches a set of (id, cfg) pairs with a parameterised row-value IN, with limit=all (the canonical client call)', async () => {
+      const firstConfig = createMockRuleConfig();
+      const secondConfig = { ...createMockRuleConfig(), id: 'rule-002', cfg: '2.0.0' };
+
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: firstConfig }, { configuration: secondConfig }], rowCount: 2 });
+
+      const result = await RuleConfigRepo.list({
+        keys: [
+          { id: 'rule-001', cfg: '1.0.0' },
+          { id: 'rule-002', cfg: '2.0.0' },
+        ],
+        limit: 'all',
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
+
+      // COUNT(*) carries the same row-value IN predicate over the generated key columns.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1 AND (ruleid, rulecfg) IN (($2, $3), ($4, $5));',
+          values: [mockTenantId, 'rule-001', '1.0.0', 'rule-002', '2.0.0'],
+        },
+        'configuration',
+      );
+      // The page query: same IN predicate, deterministic ORDER BY, and (limit=all) no OFFSET/LIMIT.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 AND (ruleid, rulecfg) IN (($2, $3), ($4, $5)) ORDER BY rulecfg ASC, ruleid ASC;',
+          values: [mockTenantId, 'rule-001', '1.0.0', 'rule-002', '2.0.0'],
+        },
+        'configuration',
+      );
+    });
+
+    it('appends OFFSET/LIMIT after the IN-set parameters on the bounded path', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '1' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await RuleConfigRepo.list({
+        keys: [{ id: 'rule-001', cfg: '1.0.0' }],
+        offset: 0,
+        limit: 20,
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      // The set values come first; OFFSET/LIMIT placeholders follow them.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 AND (ruleid, rulecfg) IN (($2, $3)) ORDER BY rulecfg ASC, ruleid ASC OFFSET $4 LIMIT $5;',
+          values: [mockTenantId, 'rule-001', '1.0.0', 0, 20],
+        },
+        'configuration',
+      );
+    });
+
+    it('returns the found subset silently when some requested pairs do not exist (no error, total = matched count)', async () => {
+      const onlyMatch = createMockRuleConfig();
+
+      // Three pairs requested; COUNT and the page both report only the one that exists.
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '1' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: onlyMatch }], rowCount: 1 });
+
+      const result = await RuleConfigRepo.list({
+        keys: [
+          { id: 'rule-001', cfg: '1.0.0' },
+          { id: 'missing-a', cfg: '9.9.9' },
+          { id: 'missing-b', cfg: '9.9.9' },
+        ],
+        limit: 'all',
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      // All three pairs are bound into the IN predicate; the DB silently returns only the matches.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 AND (ruleid, rulecfg) IN (($2, $3), ($4, $5), ($6, $7)) ORDER BY rulecfg ASC, ruleid ASC;',
+          values: [mockTenantId, 'rule-001', '1.0.0', 'missing-a', '9.9.9', 'missing-b', '9.9.9'],
+        },
+        'configuration',
+      );
+      // No error is raised for the unmatched pairs; the found subset and matched total are returned.
+      expect(result).toEqual({ data: [onlyMatch], total: 1 });
+    });
+
+    it('treats an empty (id, cfg) set as no set filter (guards against an invalid empty IN ())', async () => {
+      const cfg = createMockRuleConfig();
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '1' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: cfg }], rowCount: 1 });
+
+      await RuleConfigRepo.list({ keys: [], limit: 'all', order: 'ASC', tenantId: mockTenantId });
+
+      // An empty set must not emit `IN ()`; the query degrades to the tenant-only predicate.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM rule WHERE tenantid = $1 ORDER BY rulecfg ASC, ruleid ASC;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('ANDs a scalar filter and the (id, cfg) set, numbering the set params after the filter params', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await RuleConfigRepo.list({
+        filters: { cfg: '1.0.0' },
+        keys: [{ id: 'rule-001', cfg: '1.0.0' }],
+        limit: 'all',
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      // tenant ($1), then the scalar filter ($2), then the set tuple ($3, $4): set params follow the filter.
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM rule WHERE tenantid = $1 AND rulecfg = $2 AND (ruleid, rulecfg) IN (($3, $4));',
+          values: [mockTenantId, '1.0.0', 'rule-001', '1.0.0'],
+        },
+        'configuration',
+      );
+    });
+  });
+
   describe('get', () => {
     const mockIdentifier = { id: 'rule-001', cfg: '1.0.0', tenantId: mockTenantId };
 

--- a/__tests__/unit/repositories/typology.config.repository.test.ts
+++ b/__tests__/unit/repositories/typology.config.repository.test.ts
@@ -210,6 +210,44 @@ describe('TypologyConfigRepository', () => {
         'configuration',
       );
     });
+
+    it('matches a set of (id, cfg) pairs with a parameterised row-value IN on the typology key columns (#423)', async () => {
+      const firstConfig = createMockTypologyConfig();
+      const secondConfig = { ...createMockTypologyConfig(), id: 'typology-002', cfg: '2.0.0' };
+
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ configuration: firstConfig }, { configuration: secondConfig }], rowCount: 2 });
+
+      const result = await TypologyConfigRepo.list({
+        keys: [
+          { id: 'typology-001', cfg: '1.0.0' },
+          { id: 'typology-002', cfg: '2.0.0' },
+        ],
+        limit: 'all',
+        order: 'ASC',
+        tenantId: mockTenantId,
+      });
+
+      expect(result).toEqual({ data: [firstConfig, secondConfig], total: 2 });
+
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        1,
+        {
+          text: 'SELECT COUNT(*) AS total FROM typology WHERE tenantid = $1 AND (typologyid, typologycfg) IN (($2, $3), ($4, $5));',
+          values: [mockTenantId, 'typology-001', '1.0.0', 'typology-002', '2.0.0'],
+        },
+        'configuration',
+      );
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'SELECT configuration FROM typology WHERE tenantid = $1 AND (typologyid, typologycfg) IN (($2, $3), ($4, $5)) ORDER BY typologycfg ASC, typologyid ASC;',
+          values: [mockTenantId, 'typology-001', '1.0.0', 'typology-002', '2.0.0'],
+        },
+        'configuration',
+      );
+    });
   });
 
   describe('get', () => {

--- a/src/repositories/configuration/config-list.shared.ts
+++ b/src/repositories/configuration/config-list.shared.ts
@@ -34,6 +34,12 @@ export interface ConfigListDescriptor {
   uniqueKeyOrder: string[];
   /** Ordered allowlist of filter fields; iteration order is part of the SQL contract. */
   filters: ConfigFilterColumn[];
+  /**
+   * Generated [idColumn, cfgColumn] columns enabling the targeted batch fetch (#423): a set of
+   * (id, cfg) pairs matched with a single parameterised row-value tuple `IN`. Omitted for entities
+   * outside scope (e.g. network_map, whose single (cfg) key has no composite set semantics).
+   */
+  keySetColumns?: readonly [string, string];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- TEntity gives call sites their concrete config type for `data`.
@@ -41,7 +47,7 @@ export const listConfiguration = async <TEntity>(
   descriptor: ConfigListDescriptor,
   query: ListQuery,
 ): Promise<{ data: TEntity[]; total: number }> => {
-  const { offset = 0, limit = 20, order = 'ASC', sort, filters, tenantId } = query;
+  const { offset = 0, limit = 20, order = 'ASC', sort, filters, keys, tenantId } = query;
   const direction = order === 'DESC' ? 'DESC' : 'ASC';
 
   // tenantId is always the first bound parameter.
@@ -54,13 +60,32 @@ export const listConfiguration = async <TEntity>(
       predicates.push(`${column} = $${filterValues.length + 1}${cast ?? ''}`);
     }
   }
+
+  // Optional targeted batch fetch (#423): match a SET of (id, cfg) pairs with a single
+  // parameterised row-value tuple `IN` over the generated key columns. Enabled per-entity via
+  // `keySetColumns` (rule + typology only); every pair value is bound, never interpolated. An
+  // empty set is treated as no set filter so the query never degrades to an invalid `IN ()`.
+  const keySetValues: string[] = [];
+  if (descriptor.keySetColumns && keys && keys.length > 0) {
+    const [idColumn, cfgColumn] = descriptor.keySetColumns;
+    const placeholderBase = 1 + filterValues.length;
+    const tuples = keys.map(({ id, cfg }) => {
+      const idPlaceholder = placeholderBase + keySetValues.length + 1;
+      keySetValues.push(id);
+      const cfgPlaceholder = placeholderBase + keySetValues.length + 1;
+      keySetValues.push(cfg);
+      return `($${idPlaceholder}, $${cfgPlaceholder})`;
+    });
+    predicates.push(`(${idColumn}, ${cfgColumn}) IN (${tuples.join(', ')})`);
+  }
+
   const whereClause = predicates.join(' AND ');
 
   // COUNT first: a dedicated COUNT(*) reports the true total even on an empty/over-paged page.
   const countRes = await handlePostExecuteSqlStatement<{ total: string }>(
     {
       text: `SELECT COUNT(*) AS total FROM ${descriptor.table} WHERE ${whereClause};`,
-      values: [tenantId, ...filterValues],
+      values: [tenantId, ...filterValues, ...keySetValues],
     } satisfies PgQueryConfig,
     'configuration',
   );
@@ -74,8 +99,11 @@ export const listConfiguration = async <TEntity>(
   // `limit === 'all'` returns the full tenant-scoped set: omit OFFSET/LIMIT entirely and bind
   // neither param (#422). The handler guarantees offset is 0 on this path (mutually exclusive).
   const isUnbounded = limit === 'all';
-  const pageClause = isUnbounded ? '' : ` OFFSET $${filterValues.length + 2} LIMIT $${filterValues.length + 3}`;
-  const pageValues = isUnbounded ? [tenantId, ...filterValues] : [tenantId, ...filterValues, offset, limit];
+  const boundBase = filterValues.length + keySetValues.length;
+  const pageClause = isUnbounded ? '' : ` OFFSET $${boundBase + 2} LIMIT $${boundBase + 3}`;
+  const pageValues = isUnbounded
+    ? [tenantId, ...filterValues, ...keySetValues]
+    : [tenantId, ...filterValues, ...keySetValues, offset, limit];
   const pageRes = await handlePostExecuteSqlStatement<{ configuration: TEntity }>(
     {
       text: `SELECT configuration FROM ${descriptor.table} WHERE ${whereClause} ORDER BY ${orderByClause}${pageClause};`,

--- a/src/repositories/configuration/rule.config.repository.ts
+++ b/src/repositories/configuration/rule.config.repository.ts
@@ -14,6 +14,7 @@ const ruleListDescriptor: ConfigListDescriptor = {
     { key: 'id', column: 'ruleid' },
     { key: 'cfg', column: 'rulecfg' },
   ],
+  keySetColumns: ['ruleid', 'rulecfg'],
 };
 
 export const RuleConfigRepo: CrudRepository<RuleConfig> = {

--- a/src/repositories/configuration/typology.config.repository.ts
+++ b/src/repositories/configuration/typology.config.repository.ts
@@ -14,6 +14,7 @@ const typologyListDescriptor: ConfigListDescriptor = {
     { key: 'id', column: 'typologyid' },
     { key: 'cfg', column: 'typologycfg' },
   ],
+  keySetColumns: ['typologyid', 'typologycfg'],
 };
 
 export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {

--- a/src/repositories/repository.base.ts
+++ b/src/repositories/repository.base.ts
@@ -7,6 +7,7 @@ export interface ListQuery<TSort extends string = string> {
   sort?: TSort; // field name
   order?: 'ASC' | 'DESC';
   filters?: Record<string, string>; // exact-match filters
+  keys?: Array<{ id: string; cfg: string }>; // targeted batch fetch by composite (id, cfg) set (#423)
 }
 
 export interface Node {

--- a/src/schemas/configListQuerySchema.ts
+++ b/src/schemas/configListQuerySchema.ts
@@ -14,6 +14,15 @@ const Order = Type.Optional(Type.Union([Type.Literal('ASC'), Type.Literal('DESC'
 const Limit = Type.Optional(Type.Union([Type.Integer({ minimum: 1, maximum: 100 }), Type.Literal('all')]));
 const Offset = Type.Optional(Type.Integer({ minimum: 0 }));
 
+// Targeted batch fetch (#423): an optional set of (id, cfg) pairs matched in one query against the
+// generated composite-key columns. A top-level param (not part of scalar `filters`); bounded by
+// `maxItems` so an oversized request is rejected with 400 at the schema boundary. Supplied via the
+// qs nested-array form `keys[0][id]=..&keys[0][cfg]=..`. Scoped to rule + typology (composite key);
+// network_map (single (cfg) key) deliberately omits it, so the param is stripped (removeAdditional).
+const Keys = Type.Optional(
+  Type.Array(Type.Object({ id: Type.String(), cfg: Type.String() }, { additionalProperties: false }), { maxItems: 200 }),
+);
+
 export const RuleListQuery = Type.Object({
   limit: Limit,
   offset: Offset,
@@ -28,6 +37,7 @@ export const RuleListQuery = Type.Object({
       { additionalProperties: false },
     ),
   ),
+  keys: Keys,
 });
 
 export const TypologyListQuery = Type.Object({
@@ -44,6 +54,7 @@ export const TypologyListQuery = Type.Object({
       { additionalProperties: false },
     ),
   ),
+  keys: Keys,
 });
 
 export const NetworkMapListQuery = Type.Object({

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -100,9 +100,12 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
           : [validateTenantMiddleware],
       },
       async (req, reply) => {
-        const queryParams = req.query as Static<typeof DefaultQuery>;
+        // The batch-fetch set (#423) is validated/bounded only by the per-entity Query schema
+        // (rule + typology, maxItems 200); entities without it have `keys` stripped by Ajv. It is
+        // typed here so the handler can forward it without widening the generic fallback schema.
+        const queryParams = req.query as Static<typeof DefaultQuery> & { keys?: Array<{ id: string; cfg: string }> };
         const { tenantId } = req as ITenantRequest;
-        const { limit = 20, offset = 0, sort, order = 'ASC', filters } = queryParams;
+        const { limit = 20, offset = 0, sort, order = 'ASC', filters, keys } = queryParams;
 
         // `limit=all` and a non-zero `offset` are mutually exclusive: an unbounded fetch has no
         // page to skip into, so combining them is a client error rather than a silent no-op (#422).
@@ -119,6 +122,9 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
           sort: sort as SortField | undefined,
           order,
           filters,
+          // Only forward the batch-fetch set when the per-entity schema kept it; entities out of
+          // scope (e.g. network_map) have `keys` stripped to undefined and must not receive it.
+          ...(keys ? { keys } : {}),
         };
 
         const { data, total } = await repo.list(params);


### PR DESCRIPTION
## Summary

Adds a targeted batch-fetch capability to the configuration `LIST` endpoints (#423). Callers can now supply a set of composite `(id, cfg)` keys and receive exactly the matching configurations in a single request, instead of fetching all configurations and filtering client-side.

This is **STEP 1 (server-side)** of a two-step split. STEP 2 (the tazama-demo client that consumes this, #143) follows in a separate cycle once this is merged.

## What changed

- **`config-list.shared.ts`** - the shared `listConfiguration` helper now accepts an optional `keys` array of `(id, cfg)` pairs. When the list descriptor declares `keySetColumns`, it builds a fully parameterised row-value tuple predicate `(idCol, cfgCol) IN ((..), (..))`, ANDed after the tenant filter and any scalar filters. An empty `keys` array is ignored (never emits `IN ()`).
- **`rule.config.repository.ts` / `typology.config.repository.ts`** - declare `keySetColumns` for their composite keys (`ruleid, rulecfg` and `typologyid, typologycfg`).
- **`configListQuerySchema.ts`** - add a bounded `keys` field (array of `{ id, cfg }`, `maxItems: 200`) to the **rule** and **typology** list query schemas only.
- **`crud-schema.ts`** - forward the validated `keys` from the route handler, without widening the generic fallback query schema used by other endpoints.
- **`repository.base.ts`** - add the optional `keys` field to `ListQuery`.

## Scope decisions

- **rule + typology only.** `network_map` has a single `cfg` key (no composite `(id, cfg)`), so it is intentionally excluded - its query schema is unchanged and the param is stripped by Ajv.
- **Missing / not-found pairs return the found subset silently** (set semantics); `meta.total` reflects the matched count.
- **Backward compatible** - the param is optional; existing callers that pass no `keys` are unaffected.

## Security

- Column names come only from the server-side descriptor allowlist; all values are bound parameters. No SQL injection surface.
- The `keys` array is bounded at `maxItems: 200`; oversized or malformed pairs are rejected with `400` by schema validation.

## Testing

- Repository unit tests assert the exact SQL text and bound value order for: `limit=all` tuple `IN`, bounded `OFFSET`/`LIMIT` after the keyset placeholders, silent found-subset, empty `keys` fallback, and scalar-filter-plus-keys placeholder numbering.
- CRUD-plugin tests cover forwarding, `400` on malformed pair, `400` on exceeding `maxItems`, and the `network_map` strip.
- Full suite: 685 passed. Build clean. Changed source files lint-clean.

Closes #423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch fetch capability enabling retrieval of multiple configurations simultaneously using composite (id, configuration) key pairs in query parameters. Includes validation for oversized requests and seamless integration with pagination and filtering options.

* **Tests**
  * Added comprehensive test coverage for batch fetch validation, parameter binding, boundary conditions, pagination integration, and entity-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->