### PR TITLE
fix: return 404 from configuration DELETE for a missing row (#420)

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,10 +575,47 @@ Each repository implementation follows a standardized interface, ensuring consis
 | 2. | Rule Configuration |  rule.config.repository | `/v1/admin/configuration/rule` |  GET,POST,PUT,DEL |
 | 3. | Typology Configuration | typology.config.repository | `/v1/admin/configuration/typology` | GET,POST,PUT,DEL |
 
-For all GET queries:
- * You can either do a pure GET, which will list all items; 
- * You can do a GET with a query parameter to find, for example, only Active networkmaps: /v1/admin/configuration/network_map?filters[active]=true;
- * Right now, if you specify more than one query param, only the first one will take afffect. 
+### Configuration LIST query contract
+
+The three configuration LIST endpoints (`network_map`, `rule`, `typology`) share a common query
+contract, implemented by a single parameterised helper. A bare `GET` is **safe by default**: it
+returns the first page only, not the whole table.
+
+#### Query parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer `1-100`, or `all` | `20` | Page size. Use `all` to return the full tenant-scoped set in one response. `all` is mutually exclusive with a non-zero `offset` (returns `400`). Values above `100` return `400`. |
+| `offset` | integer `>= 0` | `0` | Rows to skip for pagination. Cannot be combined with `limit=all`. |
+| `sort` | per-entity allowlist | `id` (rule/typology), `cfg` (network_map) | Lead ordering column. The remaining unique-key column is always appended so paging is deterministic. A value outside the allowlist returns `400`. |
+| `order` | `ASC` or `DESC` | `ASC` | Sort direction. |
+| `filters[<field>]` | string | - | Exact-match filters. **All** supplied filters are ANDed (not just the first). Each `<field>` is allowlisted per entity; unknown keys are ignored. |
+| `keys` | array of `{ id, cfg }` | - | Targeted batch fetch (rule/typology only): return exactly the listed composite `(id, cfg)` pairs in one query. Maximum 200 pairs (`400` past the cap). Supplied as `keys[0][id]=..&keys[0][cfg]=..`. |
+
+Per-entity allowlists: `rule`/`typology` accept `sort`/`filters` of `id` and `cfg`; `network_map`
+accepts `cfg` and `active` (`true`/`false`).
+
+#### Response shape
+
+```json
+{
+  "data": [ /* entity objects */ ],
+  "meta": { "total": 128, "limit": 20, "offset": 0 }
+}
+```
+
+`meta.total` is the real `COUNT(*)` of all matching rows (not the size of the returned page), so a
+client can compute the number of pages. On the `limit=all` path, `meta.limit` equals `total` and
+`meta.offset` is `0`.
+
+#### Examples
+
+```http
+GET /v1/admin/configuration/network_map?filters[active]=true HTTP/1.1
+GET /v1/admin/configuration/rule?limit=50&offset=50&sort=id&order=DESC HTTP/1.1
+GET /v1/admin/configuration/typology?limit=all HTTP/1.1
+GET /v1/admin/configuration/rule?keys[0][id]=EFRuP@1.0.0&keys[0][cfg]=1.0.0&keys[1][id]=R1&keys[1][cfg]=1.0.0&limit=all HTTP/1.1
+```
 
 
 ---
@@ -587,13 +624,13 @@ For all GET queries:
 
 ### List Operation
 
-When listing entities, the repository constructs a SQL statement dynamically using optional filters and sort parameters. Tenant ID is always included to ensure the query operates within the tenant’s data domain.
+When listing entities, the repository constructs a SQL statement dynamically using optional filters and sort parameters. Tenant ID is always included to ensure the query operates within the tenant’s data domain. Every supplied filter is applied (ANDed), and ordering is deterministic: the chosen `sort` column followed by the remaining unique-key columns.
 
-The result is normalized into a consistent `{ data, total }` format expected by the CRUD plugin.
+The result is normalized into a consistent `{ data, total }` format expected by the CRUD plugin, where `total` is a separate `COUNT(*)` of all matching rows (not the size of the returned page). The CRUD plugin then shapes the HTTP response as `{ data, meta }`.
 
 ### Get Operation
 
-The `get` method retrieves a single entity record based on the combination of `cfg` and tenantId. If the record exists, it returns the parsed configuration object.
+The `get` method retrieves a single entity record based on its unique key and `tenantId` — `(id, cfg)` for rule and typology, and `(cfg)` for network_map. If the record exists, it returns the parsed configuration object; otherwise the endpoint responds `404`.
 
 ### Create Operation
 
@@ -605,7 +642,7 @@ The update process replaces an existing configuration record that matches `cfg` 
 
 ### Delete Operation
 
-The deletion process removes the record from the table matching the same `cfg` and `tenantId` identifiers. It returns a boolean indicating success, enabling the API to respond with a standardized `{ success: boolean }` payload.
+The deletion process removes the record from the table matching its unique key and `tenantId`. When a row is deleted it returns `200` with `{ "success": true }`. When no matching row exists it returns `404` (parity with GET and PUT), rather than `200 { "success": false }`.
 
 ---
 

--- a/__tests__/unit/config-delete.crud-plugin.test.ts
+++ b/__tests__/unit/config-delete.crud-plugin.test.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+// Issue D (#420): the DELETE handler in buildCrudPlugin returns 200 { success: ok }
+// unconditionally. When repo.remove reports no row was deleted (false), the client
+// gets 200 { success: false } instead of a 404, which is inconsistent with GET and
+// PUT (both 404 on a missing entity). These tests pin the desired parity: a missing
+// row returns 404 and an existing row returns 200 { success: true }, across all three
+// configuration entities that share the factory (network_map, rule, typology).
+
+const mockRuleRemove = jest.fn();
+const mockTypologyRemove = jest.fn();
+const mockNetworkMapRemove = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/rule.config.repository', () => ({
+  RuleConfigRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: (...args: unknown[]) => mockRuleRemove(...args),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/typology.config.repository', () => ({
+  TypologyConfigRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: (...args: unknown[]) => mockTypologyRemove(...args),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/network.map.repository', () => ({
+  NetworkMapRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: (...args: unknown[]) => mockNetworkMapRemove(...args),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { RuleConfigRepo } from '../../src/repositories/configuration/rule.config.repository';
+import { TypologyConfigRepo } from '../../src/repositories/configuration/typology.config.repository';
+import { NetworkMapRepo } from '../../src/repositories/configuration/network.map.repository';
+import { RuleSchema } from '../../src/schemas/ruleSchema';
+import { TypologySchema } from '../../src/schemas/typologySchema';
+import { NetworkMapSchema } from '../../src/schemas/networkMapSchema';
+
+describe('DELETE /v1/admin/configuration/* returns 404 for a missing row (#420)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+    const ajv = new Ajv({
+      removeAdditional: 'all',
+      useDefaults: true,
+      coerceTypes: 'array',
+      strictTuples: false,
+    });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/network_map',
+        repo: NetworkMapRepo,
+        schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema },
+        idParam: { kind: 'cfg' },
+      }),
+    );
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/rule',
+        repo: RuleConfigRepo,
+        schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
+        idParam: { kind: 'single', name: 'id' },
+      }),
+    );
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/typology',
+        repo: TypologyConfigRepo,
+        schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema },
+        idParam: { kind: 'single', name: 'id' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockRuleRemove.mockReset();
+    mockTypologyRemove.mockReset();
+    mockNetworkMapRemove.mockReset();
+  });
+
+  describe('rule', () => {
+    it('DELETE of an existing row returns 200 { success: true }', async () => {
+      mockRuleRemove.mockResolvedValue(true);
+
+      const response = await app.inject({ method: 'DELETE', url: '/v1/admin/configuration/rule/rule-001/1.0.0' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ success: true });
+    });
+
+    it('DELETE of a missing row returns 404, not 200 { success: false }', async () => {
+      mockRuleRemove.mockResolvedValue(false);
+
+      const response = await app.inject({ method: 'DELETE', url: '/v1/admin/configuration/rule/missing/9.9.9' });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toHaveProperty('message');
+    });
+  });
+
+  describe('typology', () => {
+    it('DELETE of an existing row returns 200 { success: true }', async () => {
+      mockTypologyRemove.mockResolvedValue(true);
+
+      const response = await app.inject({ method: 'DELETE', url: '/v1/admin/configuration/typology/typology-001/1.0.0' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ success: true });
+    });
+
+    it('DELETE of a missing row returns 404, not 200 { success: false }', async () => {
+      mockTypologyRemove.mockResolvedValue(false);
+
+      const response = await app.inject({ method: 'DELETE', url: '/v1/admin/configuration/typology/missing/9.9.9' });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toHaveProperty('message');
+    });
+  });
+
+  describe('network_map', () => {
+    it('DELETE of an existing row returns 200 { success: true }', async () => {
+      mockNetworkMapRemove.mockResolvedValue(true);
+
+      const response = await app.inject({ method: 'DELETE', url: '/v1/admin/configuration/network_map/1.0.0' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ success: true });
+    });
+
+    it('DELETE of a missing row returns 404, not 200 { success: false }', async () => {
+      mockNetworkMapRemove.mockResolvedValue(false);
+
+      const response = await app.inject({ method: 'DELETE', url: '/v1/admin/configuration/network_map/9.9.9' });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toHaveProperty('message');
+    });
+  });
+});

--- a/src/clients/fastify.ts
+++ b/src/clients/fastify.ts
@@ -7,7 +7,18 @@ import { fastifySwagger } from '@fastify/swagger';
 import { fastifySwaggerUi } from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { configuration } from '..';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
 import qs from 'qs';
+
+// Single source of truth for the documented API version: read it from package.json at startup so
+// the OpenAPI `info.version` cannot drift from the published package version. A missing package.json
+// is left to throw loudly (it signals a broken build); a missing/invalid `version` field falls back
+// to a neutral value so the generated spec always carries a valid version string.
+const parsedPkg = JSON.parse(readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8')) as {
+  version?: unknown;
+};
+const apiVersion = typeof parsedPkg.version === 'string' && parsedPkg.version.length > 0 ? parsedPkg.version : '0.0.0';
 
 const fastify = Fastify({
   routerOptions: {
@@ -26,6 +37,18 @@ addFormats(ajv); // <-- add this line
 export default async function initializeFastifyClient(): Promise<FastifyInstance> {
   await fastify.register(fastifySwagger, {
     prefix: '/swagger',
+    openapi: {
+      info: {
+        title: 'Tazama Admin Service API',
+        description: 'Administrative API for managing Tazama configuration (network maps, rules and typologies) and related operations.',
+        version: apiVersion,
+      },
+      tags: [
+        { name: '/v1/admin/configuration/network_map', description: 'CRUD operations for network map configurations.' },
+        { name: '/v1/admin/configuration/rule', description: 'CRUD operations for rule configurations.' },
+        { name: '/v1/admin/configuration/typology', description: 'CRUD operations for typology configurations.' },
+      ],
+    },
   });
 
   await fastify.register(fastifySwaggerUi, {

--- a/src/schemas/configListQuerySchema.ts
+++ b/src/schemas/configListQuerySchema.ts
@@ -8,11 +8,25 @@ import { Type } from '@sinclair/typebox';
 // (removeAdditional: 'all'), an unknown `filters[...]` key is silently stripped
 // (D1) while an out-of-range `sort`/`order` value is rejected with 400.
 
-const Order = Type.Optional(Type.Union([Type.Literal('ASC'), Type.Literal('DESC')]));
+const Order = Type.Optional(
+  Type.Union([Type.Literal('ASC'), Type.Literal('DESC')], {
+    description: 'Sort direction applied to the ordering columns. Defaults to ASC when omitted.',
+  }),
+);
 // `all` returns the full tenant-scoped set in one response (#422); it is mutually exclusive
 // with a non-zero `offset`, which the list handler enforces as a 400 cross-field guard.
-const Limit = Type.Optional(Type.Union([Type.Integer({ minimum: 1, maximum: 100 }), Type.Literal('all')]));
-const Offset = Type.Optional(Type.Integer({ minimum: 0 }));
+const Limit = Type.Optional(
+  Type.Union([Type.Integer({ minimum: 1, maximum: 100 }), Type.Literal('all')], {
+    description:
+      "Page size: an integer between 1 and 100 (defaults to 20 when omitted), or the literal 'all' to return the full tenant-scoped set in a single response. 'all' is mutually exclusive with a non-zero offset (rejected with 400).",
+  }),
+);
+const Offset = Type.Optional(
+  Type.Integer({
+    minimum: 0,
+    description: 'Number of matching rows to skip for pagination. Defaults to 0; cannot be combined with limit=all.',
+  }),
+);
 
 // Targeted batch fetch (#423): an optional set of (id, cfg) pairs matched in one query against the
 // generated composite-key columns. A top-level param (not part of scalar `filters`); bounded by
@@ -20,14 +34,23 @@ const Offset = Type.Optional(Type.Integer({ minimum: 0 }));
 // qs nested-array form `keys[0][id]=..&keys[0][cfg]=..`. Scoped to rule + typology (composite key);
 // network_map (single (cfg) key) deliberately omits it, so the param is stripped (removeAdditional).
 const Keys = Type.Optional(
-  Type.Array(Type.Object({ id: Type.String(), cfg: Type.String() }, { additionalProperties: false }), { maxItems: 200 }),
+  Type.Array(Type.Object({ id: Type.String(), cfg: Type.String() }, { additionalProperties: false }), {
+    maxItems: 200,
+    description:
+      'Targeted batch fetch: a set of composite (id, cfg) pairs returned in a single query (maximum 200). Supplied via the nested-array form keys[0][id]=..&keys[0][cfg]=.. Supported on rule and typology only.',
+  }),
 );
 
 export const RuleListQuery = Type.Object({
   limit: Limit,
   offset: Offset,
   order: Order,
-  sort: Type.Optional(Type.Union([Type.Literal('id'), Type.Literal('cfg')])),
+  sort: Type.Optional(
+    Type.Union([Type.Literal('id'), Type.Literal('cfg')], {
+      description:
+        "Lead ordering column (defaults to 'id'). The remaining unique-key column is always appended so paging is deterministic.",
+    }),
+  ),
   filters: Type.Optional(
     Type.Object(
       {
@@ -44,7 +67,12 @@ export const TypologyListQuery = Type.Object({
   limit: Limit,
   offset: Offset,
   order: Order,
-  sort: Type.Optional(Type.Union([Type.Literal('id'), Type.Literal('cfg')])),
+  sort: Type.Optional(
+    Type.Union([Type.Literal('id'), Type.Literal('cfg')], {
+      description:
+        "Lead ordering column (defaults to 'id'). The remaining unique-key column is always appended so paging is deterministic.",
+    }),
+  ),
   filters: Type.Optional(
     Type.Object(
       {
@@ -61,7 +89,7 @@ export const NetworkMapListQuery = Type.Object({
   limit: Limit,
   offset: Offset,
   order: Order,
-  sort: Type.Optional(Type.Literal('cfg')),
+  sort: Type.Optional(Type.Literal('cfg', { description: "Only sortable key for network maps; 'cfg' is the unique key." })),
   filters: Type.Optional(
     Type.Object(
       {

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -34,6 +34,13 @@ const DefaultQuery = Type.Object({
   filters: Type.Optional(Type.Record(Type.String(), Type.String())),
 });
 
+// Shared error body for every CRUD route, so the documented 400/404 shapes stay consistent in one
+// place and surface a description in the generated OpenAPI spec.
+const ErrorResponse = Type.Object(
+  { message: Type.String({ description: 'Human-readable description of why the request failed.' }) },
+  { description: 'Standard error response returned for validation (400) and not-found (404) errors.' },
+);
+
 const makeIdSchema = (
   cfg?: { kind: 'single'; name?: string } | { kind: 'cfg' } | { kind: 'composite'; names: readonly [string, string] },
 ): TObject => {
@@ -95,7 +102,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         schema: {
           tags: [prefix],
           querystring: QuerySchema,
-          response: { 200: ListResponse, 400: Type.Object({ message: Type.String() }) },
+          response: { 200: ListResponse, 400: ErrorResponse },
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`LIST${prefix.replaceAll('/', '_').toUpperCase()}`)]
@@ -143,7 +150,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         schema: {
           tags: [prefix],
           params: IdParam,
-          response: { 200: Entity, 404: Type.Object({ message: Type.String() }) },
+          response: { 200: Entity, 404: ErrorResponse },
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`GET${prefix.replaceAll('/', '_').toUpperCase()}`)]
@@ -187,7 +194,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
           tags: [prefix],
           params: IdParam,
           body: Update,
-          response: { 200: Entity, 404: Type.Object({ message: Type.String() }) },
+          response: { 200: Entity, 404: ErrorResponse },
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`PUT${prefix.replaceAll('/', '_').toUpperCase()}`)]
@@ -210,7 +217,10 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         schema: {
           tags: [prefix],
           params: IdParam,
-          response: { 200: Type.Object({ success: Type.Boolean() }), 404: Type.Object({ message: Type.String() }) },
+          response: {
+            200: Type.Object({ success: Type.Boolean({ description: 'Always true when a row was deleted.' }) }),
+            404: ErrorResponse,
+          },
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`DELETE${prefix.replaceAll('/', '_').toUpperCase()}`)]

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -81,9 +81,11 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
     const ListResponse = Type.Object({
       data: Type.Array(Entity),
       meta: Type.Object({
-        total: Type.Integer(),
-        limit: Type.Integer(),
-        offset: Type.Integer(),
+        total: Type.Integer({
+          description: 'Total number of rows matching the query (a real COUNT(*), not the size of the returned page).',
+        }),
+        limit: Type.Integer({ description: 'Page size applied to this response. Equals total on the limit=all path.' }),
+        offset: Type.Integer({ description: 'Row offset applied to this response. Always 0 on the limit=all path.' }),
       }),
     });
     // --- LIST --- AUTH:EXAMPLE(LIST_V1_ADMIN_RAW_HISTORY_PACS002)

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -208,7 +208,7 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         schema: {
           tags: [prefix],
           params: IdParam,
-          response: { 200: Type.Object({ success: Type.Boolean() }) },
+          response: { 200: Type.Object({ success: Type.Boolean() }), 404: Type.Object({ message: Type.String() }) },
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`DELETE${prefix.replaceAll('/', '_').toUpperCase()}`)]
@@ -219,7 +219,9 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
         const { tenantId } = req as ITenantRequest;
 
         const ok = await repo.remove(makeRepositoryId(p, tenantId));
-        return { success: ok };
+        // Parity with GET/PUT: a missing row is a 404, not a 200 { success: false } (#420).
+        if (!ok) return await reply.code(404).send({ message: 'Not found' });
+        return { success: true };
       },
     );
 


### PR DESCRIPTION
## Summary

Closes #420.

The shared `buildCrudPlugin` DELETE handler returned `200 { success: false }` when no row
matched, instead of a `404`. This was inconsistent with the GET and PUT handlers, which both
return `404` on a missing entity.

This change routes a `false` result from `repo.remove` to `404 { message: 'Not found' }` and
adds the `404` response schema, giving DELETE parity with GET/PUT across all three configuration
entities that share the factory (`network_map`, `rule`, `typology`). A successful delete still
returns `200 { success: true }`.

It also folds in a documentation pass (README + generated OpenAPI/Swagger) that brings the docs
in line with the config CRUD behaviour shipped across issues A-D.

## Behaviour

| Request | Before | After |
|---|---|---|
| DELETE an existing row | `200 { success: true }` | `200 { success: true }` (unchanged) |
| DELETE a missing row | `200 { success: false }` | `404 { message: 'Not found' }` |

## Changes

### Fix (#420)

- `src/utils/crud-schema.ts` - DELETE handler returns `404` when `remove()` reports no rows
  affected; `404` added to the DELETE response schema.
- `__tests__/unit/config-delete.crud-plugin.test.ts` - end-to-end tests asserting DELETE `404`
  for a missing row and `200 { success: true }` for an existing one, across all three entities.

### Documentation

- `README.md` - corrected and expanded the configuration CRUD docs (see below).
- `src/schemas/configListQuerySchema.ts` - `description` annotations on the shared list-query
  params (`limit`, `offset`, `order`, `keys`) and the per-entity `sort`.
- `src/utils/crud-schema.ts` - OpenAPI `description`s on the list-response `meta`
  (`total`, `limit`, `offset`).

### OpenAPI/Swagger enrichment (Tier 1)

- `src/clients/fastify.ts` - added an OpenAPI `info` block (title, description, version) with the
  version sourced from `package.json` at startup so it cannot drift, plus descriptions for the
  three configuration tags.
- `src/utils/crud-schema.ts` - replaced the duplicated inline `{ message }` error bodies with a
  single shared, described `ErrorResponse` schema reused by every documented `400`/`404`.

## Documentation corrections

The README carried statements that no longer matched the API after issues A-C:

- **LIST defaults**: a bare `GET` returns a bounded page of 20, not "all items"; documented
  `limit=all` as the explicit opt-in for the full set.
- **Multi-filter**: every supplied `filters[...]` is ANDed, not "only the first one takes effect".
- **DELETE**: a missing row now returns `404` (parity with GET/PUT), not `200 { success: false }`.
- **Unique key**: GET/DELETE match on the `(id, cfg)` composite key for rule/typology (and `cfg`
  for network_map), not "cfg and tenantId" alone.
- Added a **LIST query contract** subsection covering `limit`/`offset`/`limit=all`, the `400`
  guard for `limit=all` + non-zero `offset`, the per-entity `sort` allowlist, deterministic
  ordering, the `keys` batch fetch, and the `{ data, meta }` response shape with a real
  `COUNT(*)` total, with examples.

## Validation

- New DELETE tests: 6 passing (existing + missing per entity).
- Full suite: 30 suites / 691 tests passing (after the schema and factory changes).
- `tsc` build clean; changed source lints clean.
- No runtime behaviour change from the OpenAPI/Swagger changes - the documented response shapes
  are unchanged.

## Follow-up

- #428 tracks the remaining Tier 2/3 OpenAPI work (per-operation summaries/descriptions/operationIds
  via the factory, reusable component `$ref`s, body-level examples, and a contract test that
  enforces every operation is documented).

## Notes

This is **Issue D** of the configuration CRUD triage. Issue E (#421, tolerant reads) was closed
as won't-fix in favour of the single trusted write boundary. Issues A (#425), B (#426) and
C (#427) are already merged. The documentation and Swagger commits are `docs:`-typed and folded
into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DELETE operations now return HTTP 404 when no matching row is found instead of HTTP 200.

* **Documentation**
  * Updated configuration query API documentation with pagination, sorting, filtering, and batch-key specifications.
  * API version in Swagger documentation now synchronized with package metadata.

* **Tests**
  * Added test coverage for DELETE operation behavior across configuration entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->