### PR TITLE
fix: align qs arrayLimit with keys maxItems so large batch fetches parse (#432)

### DIFF
--- a/__tests__/unit/config-list.crud-plugin.test.ts
+++ b/__tests__/unit/config-list.crud-plugin.test.ts
@@ -3,12 +3,13 @@ import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@je
 import Fastify, { type FastifyInstance } from 'fastify';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import qs from 'qs';
+import { parseQueryString } from '../../src/clients/querystringParser';
 
 // Issue #418 - schema-boundary behaviour of the configuration `list` endpoints.
 //
 // This test mirrors production validation exactly (src/clients/fastify.ts):
-//   - querystringParser: qs.parse  (so `filters[active]=true` -> { active: 'true' })
+//   - querystringParser: parseQueryString (shared qs parser, arrayLimit aligned with the keys
+//     maxItems so >20 (id, cfg) pairs parse as an array, #432)
 //   - Ajv with removeAdditional: 'all', coerceTypes: 'array', useDefaults: true
 // and registers the CRUD plugin with the per-entity `Query` override the router will
 // pass in production. It asserts:
@@ -61,7 +62,7 @@ describe('configuration list - schema-boundary behaviour (#418)', () => {
   beforeAll(async () => {
     // Mirror production (src/clients/fastify.ts): the qs parser is nested under
     // routerOptions in Fastify v5, so `filters[active]=true` becomes { filters: { active: 'true' } }.
-    app = Fastify({ routerOptions: { querystringParser: (str) => qs.parse(str) } });
+    app = Fastify({ routerOptions: { querystringParser: (str) => parseQueryString(str) } });
 
     const ajv = new Ajv({ removeAdditional: 'all', useDefaults: true, coerceTypes: 'array', strictTuples: false });
     addFormats(ajv);
@@ -210,6 +211,20 @@ describe('configuration list - schema-boundary behaviour (#418)', () => {
     const res = await app.inject({ method: 'GET', url });
     expect(res.statusCode).toBe(200);
     expect(mockRuleList).toHaveBeenCalledWith(expect.objectContaining({ keys: [{ id: 'EFRuP@1.0.0', cfg: '1.0.0' }], limit: 'all' }));
+  });
+
+  it('parses a set larger than the qs default arrayLimit (25 pairs) as an array, not an object (#432)', async () => {
+    // qs defaults arrayLimit to 20: beyond index 20 it degrades the array into an object with
+    // numeric keys, which the Ajv array schema then rejects with 400. The parser must build the
+    // array up to the schema maxItems so realistic network maps (30+ rules) batch in one call.
+    const count = 25;
+    const pairs = Array.from({ length: count }, (_, i) => `keys[${i}][id]=r${i}@1.0.0&keys[${i}][cfg]=1.0.0`).join('&');
+    const res = await app.inject({ method: 'GET', url: `/v1/admin/configuration/rule?${pairs}&limit=all` });
+    expect(res.statusCode).toBe(200);
+    const forwarded = mockRuleList.mock.calls[0][0] as { keys?: Array<{ id: string; cfg: string }> };
+    expect(Array.isArray(forwarded.keys)).toBe(true);
+    expect(forwarded.keys).toHaveLength(count);
+    expect(forwarded.keys?.[24]).toEqual({ id: 'r24@1.0.0', cfg: '1.0.0' });
   });
 
   it('rejects a malformed set entry (a pair missing cfg) with 400 (#423)', async () => {

--- a/src/clients/fastify.ts
+++ b/src/clients/fastify.ts
@@ -9,7 +9,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { configuration } from '..';
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
-import qs from 'qs';
+import { parseQueryString } from './querystringParser';
 
 // Single source of truth for the documented API version: read it from package.json at startup so
 // the OpenAPI `info.version` cannot drift from the published package version. A missing package.json
@@ -22,7 +22,7 @@ const apiVersion = typeof parsedPkg.version === 'string' && parsedPkg.version.le
 
 const fastify = Fastify({
   routerOptions: {
-    querystringParser: (str) => qs.parse(str),
+    querystringParser: (str) => parseQueryString(str),
   },
 });
 

--- a/src/clients/querystringParser.ts
+++ b/src/clients/querystringParser.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+import qs from 'qs';
+
+// `qs` defaults `arrayLimit` to 20: once an array index exceeds 20 it silently degrades the array
+// into an object keyed by the numeric indices, which the Ajv array schemas (e.g. the batch-fetch
+// `keys` set) then reject with 400. Align the limit with the schema cap (configListQuerySchema
+// `keys` maxItems = 200) so realistic requests - a network map referencing 30+ rules - parse as an
+// array and are bounded by the schema rather than truncated by the parser (#432).
+export const QS_ARRAY_LIMIT = 200;
+
+export const parseQueryString = (str: string): ReturnType<typeof qs.parse> => qs.parse(str, { arrayLimit: QS_ARRAY_LIMIT });


### PR DESCRIPTION
## What

Fixes the batch-fetch `keys` query parameter silently breaking with **400 Bad Request** once a request carries more than 21 `(id, cfg)` pairs.

Closes #432.

## Root cause

Fastify parsed query strings with `qs.parse(str)` and no options, so `arrayLimit` defaulted to **20**. Beyond index 20, `qs` degrades the array into an object with numeric keys (`{ "0": {...}, ... }`), which the Ajv `Type.Array(..., { maxItems: 200 })` schema then rejects with 400. The schema advertised capacity for 200 keys, but the parser capped real arrays at 21 elements.

This surfaced in `tazama-demo`: a network map referencing 34 distinct rules sends `keys[0]..keys[33]` and admin-service returned 400, so no rules or typologies rendered.

## Change

- Extract the parser into a shared module, `src/clients/querystringParser.ts`, exporting `parseQueryString` with `arrayLimit: 200` (aligned with the `keys` `maxItems`).
- Use it in both the production Fastify instance (`src/clients/fastify.ts`) and the schema-boundary test harness, so the two cannot drift.

## Behaviour after the fix

- A `keys` request with 22-200 pairs parses as an array and returns 200 (was 400).
- A request with more than the cap is still rejected with 400 by the schema.
- All other query parsing (filters, sort, small key sets) is unaffected.

## Tests

- New red-then-green test in `config-list.crud-plugin.test.ts`: a 25-pair `keys` set now parses as an array and is forwarded to `repo.list` with length 25 (previously 400).
- Existing 201-pair over-cap test still asserts 400, now for the right reason (schema `maxItems`, not parser degradation).
- Full suite: 692 passing. `tsc` build clean.

## TDD

Red test confirmed failing (400 vs 200) on the default parser before the fix, green after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of large array parameters in query strings to prevent data degradation and ensure proper validation alignment.

* **Tests**
  * Added test case for issue `#432` verifying correct parsing of large key-set arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->