### PR TITLE
feat: atomic network map activate/deactivate endpoints (#434)

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Each repository implementation follows a standardized interface, ensuring consis
 
 | No. | Config  | File name | Endpoint | Methods | 
 | --- | --- | --------- | -------- | ----------- | 
-| 1. | Network Map | network.map.repository | `/v1/admin/configuration/network_map` |  GET,POST,PUT,DEL |
+| 1. | Network Map | network.map.repository | `/v1/admin/configuration/network_map` |  GET,POST,PUT,DEL, plus `POST {cfg}/activate` and `POST {cfg}/deactivate` |
 | 2. | Rule Configuration |  rule.config.repository | `/v1/admin/configuration/rule` |  GET,POST,PUT,DEL |
 | 3. | Typology Configuration | typology.config.repository | `/v1/admin/configuration/typology` | GET,POST,PUT,DEL |
 
@@ -643,6 +643,21 @@ The update process replaces an existing configuration record that matches `cfg` 
 ### Delete Operation
 
 The deletion process removes the record from the table matching its unique key and `tenantId`. When a row is deleted it returns `200` with `{ "success": true }`. When no matching row exists it returns `404` (parity with GET and PUT), rather than `200 { "success": false }`.
+
+### Activate / Deactivate Operation (network_map only)
+
+Network maps carry a single-active-per-tenant invariant, enforced at the database level by the partial unique index `idx_networkmap_active_tenant on network_map (tenantId) where active = true`. Two dedicated actions switch which map is active without a full `PUT` replace:
+
+```http
+POST /v1/admin/configuration/network_map/{cfg}/activate HTTP/1.1
+POST /v1/admin/configuration/network_map/{cfg}/deactivate HTTP/1.1
+```
+
+**Activate** promotes the target map and demotes the currently-active map (if any) in a single atomic swap, returning the activated map. Because `active` (and `cfg`) are generated `STORED` columns derived from the `configuration` JSONB, the flag is flipped by rewriting the JSON with `jsonb_set` rather than a direct `UPDATE`. The partial unique index is non-deferrable and checked per row, so the swap runs inside one transaction and demotes the current map **before** promoting the target - at no instant are two rows active, regardless of physical row order (a single multi-row `UPDATE` would otherwise risk a `23505` unique-violation). The target's existence is checked first and outside the transaction: a missing map returns `404` with no writes (no rollback needed). `updDtTm` is bumped on both the demoted and promoted records.
+
+**Deactivate** sets a single map inactive in one atomic statement (zero active maps is a legal state, so no transaction is required), bumps `updDtTm`, and returns the deactivated map, or `404` when the target does not exist.
+
+> Network maps are loaded inactive and promoted when ready. Posting a map with `active = true` that would collide with an existing active map is rejected by the unique index (surfaced as a `500`); use `activate` to perform a safe swap instead.
 
 ---
 

--- a/__tests__/unit/database.transaction.service.test.ts
+++ b/__tests__/unit/database.transaction.service.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// RED tests (#434): withConfigurationTransaction does not exist yet. It wraps a unit
+// of work in a real pg transaction on the configuration pool so a multi-statement
+// active-map swap is atomic. Contract:
+//  - acquire a client from databaseManager._configuration.connect()
+//  - BEGIN, run the work, COMMIT (in that order), return the work's result
+//  - on error: ROLLBACK (not COMMIT) and rethrow
+//  - ALWAYS release the client
+
+const mockConnect = jest.fn();
+
+jest.mock('../../src', () => ({
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+  databaseManager: {
+    _configuration: { connect: (...args: unknown[]) => mockConnect(...args) },
+  },
+}));
+
+import * as dbLogic from '../../src/services/database.logic.service';
+
+type TransactionClient = { query: (text: string, values?: unknown[]) => Promise<unknown>; release: () => void };
+const withConfigurationTransaction = (
+  dbLogic as unknown as {
+    withConfigurationTransaction: <T>(work: (client: TransactionClient) => Promise<T>) => Promise<T>;
+  }
+).withConfigurationTransaction;
+
+describe('withConfigurationTransaction (#434)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs BEGIN -> work -> COMMIT in order, releases the client, and returns the work result', async () => {
+    const queryCalls: string[] = [];
+    const release = jest.fn();
+    const client: TransactionClient = {
+      query: jest.fn(async (text: string) => {
+        queryCalls.push(text);
+        return { rows: [], rowCount: 0 };
+      }),
+      release,
+    };
+    mockConnect.mockResolvedValue(client as never);
+
+    const result = await withConfigurationTransaction(async (c) => {
+      await c.query('WORK');
+      return 'done';
+    });
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(queryCalls).toEqual(['BEGIN', 'WORK', 'COMMIT']);
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(result).toBe('done');
+  });
+
+  it('rolls back (not commits) and rethrows when the work fails, still releasing the client', async () => {
+    const queryCalls: string[] = [];
+    const release = jest.fn();
+    const client: TransactionClient = {
+      query: jest.fn(async (text: string) => {
+        queryCalls.push(text);
+        return { rows: [], rowCount: 0 };
+      }),
+      release,
+    };
+    mockConnect.mockResolvedValue(client as never);
+
+    await expect(
+      withConfigurationTransaction(async () => {
+        throw new Error('swap failed');
+      }),
+    ).rejects.toThrow('swap failed');
+
+    expect(queryCalls).toContain('BEGIN');
+    expect(queryCalls).toContain('ROLLBACK');
+    expect(queryCalls).not.toContain('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/database.transaction.service.test.ts
+++ b/__tests__/unit/database.transaction.service.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../src', () => ({
 }));
 
 import * as dbLogic from '../../src/services/database.logic.service';
+import { loggerService } from '../../src';
 
 type TransactionClient = { query: (text: string, values?: unknown[]) => Promise<unknown>; release: () => void };
 const withConfigurationTransaction = (
@@ -79,6 +80,29 @@ describe('withConfigurationTransaction (#434)', () => {
     expect(queryCalls).toContain('BEGIN');
     expect(queryCalls).toContain('ROLLBACK');
     expect(queryCalls).not.toContain('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the original work error (and logs the secondary failure) when ROLLBACK itself also fails', async () => {
+    const release = jest.fn();
+    const client: TransactionClient = {
+      query: jest.fn(async (text: string) => {
+        if (text === 'ROLLBACK') throw new Error('connection terminated');
+        return { rows: [], rowCount: 0 };
+      }),
+      release,
+    };
+    mockConnect.mockResolvedValue(client as never);
+
+    // The original transaction failure must propagate, not the rollback's own error.
+    await expect(
+      withConfigurationTransaction(async () => {
+        throw new Error('swap failed');
+      }),
+    ).rejects.toThrow('swap failed');
+
+    // The secondary rollback failure is logged rather than swallowed or masking the cause.
+    expect(jest.mocked(loggerService.log)).toHaveBeenCalledWith(expect.stringContaining('connection terminated'), expect.any(String));
     expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/unit/network-map-activation.crud-plugin.test.ts
+++ b/__tests__/unit/network-map-activation.crud-plugin.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+
+// RED tests (#434): buildCrudPlugin must expose two new POST actions for the
+// network_map entity (which uses idParam kind 'cfg'):
+//   POST <prefix>/:cfg/activate    -> 200 activated map | 404 if missing
+//   POST <prefix>/:cfg/deactivate  -> 200 deactivated map | 404 if missing
+// The activate route delegates to repo.activate (atomic swap) and the deactivate
+// route to repo.deactivate; a null result from either maps to 404.
+
+const mockActivate = jest.fn();
+const mockDeactivate = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/network.map.repository', () => ({
+  NetworkMapRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    activate: (...args: unknown[]) => mockActivate(...args),
+    deactivate: (...args: unknown[]) => mockDeactivate(...args),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { NetworkMapRepo } from '../../src/repositories/configuration/network.map.repository';
+import { NetworkMapSchema } from '../../src/schemas/networkMapSchema';
+
+const makeMap = (cfg: string, active: boolean): NetworkMap =>
+  ({
+    active,
+    cfg,
+    tenantId: 'DEFAULT',
+    creDtTm: '2024-01-01T00:00:00.000Z',
+    updDtTm: '2024-06-01T12:00:00.000Z',
+    messages: [],
+  }) as unknown as NetworkMap;
+
+describe('POST /v1/admin/configuration/network_map/:cfg/(de)activate (#434)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+    const ajv = new Ajv({ removeAdditional: 'all', useDefaults: true, coerceTypes: 'array', strictTuples: false });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/network_map',
+        repo: NetworkMapRepo,
+        schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema },
+        idParam: { kind: 'cfg' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockActivate.mockReset();
+    mockDeactivate.mockReset();
+  });
+
+  describe('activate', () => {
+    it('returns 200 with the activated map for an existing cfg', async () => {
+      const activated = makeMap('2.0.0', true);
+      mockActivate.mockResolvedValue(activated);
+
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/network_map/2.0.0/activate' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ cfg: '2.0.0', active: true });
+      expect(mockActivate).toHaveBeenCalledWith(expect.objectContaining({ cfg: '2.0.0' }));
+    });
+
+    it('returns 404 (delegating to repo.activate) when the target cfg does not exist', async () => {
+      mockActivate.mockResolvedValue(null);
+
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/network_map/missing/activate' });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toHaveProperty('message');
+      // The route must exist and delegate; a plain unregistered-route 404 would not call the repo.
+      expect(mockActivate).toHaveBeenCalledWith(expect.objectContaining({ cfg: 'missing' }));
+    });
+  });
+
+  describe('deactivate', () => {
+    it('returns 200 with the deactivated map for an existing cfg', async () => {
+      const deactivated = makeMap('1.0.0', false);
+      mockDeactivate.mockResolvedValue(deactivated);
+
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/network_map/1.0.0/deactivate' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ cfg: '1.0.0', active: false });
+      expect(mockDeactivate).toHaveBeenCalledWith(expect.objectContaining({ cfg: '1.0.0' }));
+    });
+
+    it('returns 404 (delegating to repo.deactivate) when the target cfg does not exist', async () => {
+      mockDeactivate.mockResolvedValue(null);
+
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/network_map/missing/deactivate' });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toHaveProperty('message');
+      // The route must exist and delegate; a plain unregistered-route 404 would not call the repo.
+      expect(mockDeactivate).toHaveBeenCalledWith(expect.objectContaining({ cfg: 'missing' }));
+    });
+  });
+});

--- a/__tests__/unit/repositories/network.map.activation.repository.test.ts
+++ b/__tests__/unit/repositories/network.map.activation.repository.test.ts
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+
+// RED tests (#434): NetworkMapRepo.activate / .deactivate do not exist yet. These
+// pin the contract before any production code is written:
+//  - activate performs an existence check FIRST and, only if the target exists,
+//    swaps inside a single transaction by DEACTIVATING the current active map
+//    BEFORE ACTIVATING the target (the proven-safe order that never trips the
+//    partial unique index idx_networkmap_active_tenant -> no 23505).
+//  - a missing target returns null and performs NO writes (no transaction opened).
+//  - updDtTm is bumped on both the demoted and promoted records.
+//  - deactivate flips a single map inactive (single atomic statement) and returns
+//    null when the target does not exist.
+
+const mockHandlePostExecuteSqlStatement = jest.fn();
+const mockWithConfigurationTransaction = jest.fn();
+
+jest.mock('../../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: (...args: unknown[]) => mockHandlePostExecuteSqlStatement(...args),
+  withConfigurationTransaction: (...args: unknown[]) => mockWithConfigurationTransaction(...args),
+}));
+
+jest.mock('../../../src', () => ({
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+  databaseManager: {
+    _configuration: { query: jest.fn() },
+  },
+}));
+
+import { NetworkMapRepo } from '../../../src/repositories/configuration/network.map.repository';
+
+// The activate/deactivate methods are not yet part of the CrudRepository contract.
+// Access them through a typed view so the spec compiles; at RED they are undefined
+// and the calls fail, which is the intended failing state.
+type TransactionClient = { query: (text: string, values?: unknown[]) => Promise<unknown> };
+type ActivationRepo = {
+  activate: (id: { cfg: string; tenantId: string }) => Promise<NetworkMap | null>;
+  deactivate: (id: { cfg: string; tenantId: string }) => Promise<NetworkMap | null>;
+};
+const repo = NetworkMapRepo as unknown as typeof NetworkMapRepo & ActivationRepo;
+
+const TENANT = 'DEFAULT';
+const NOW = '2024-06-01T12:00:00.000Z';
+
+const makeMap = (cfg: string, active: boolean): NetworkMap =>
+  ({
+    active,
+    cfg,
+    tenantId: TENANT,
+    creDtTm: '2024-01-01T00:00:00.000Z',
+    updDtTm: '2024-01-01T00:00:00.000Z',
+    messages: [],
+  }) as unknown as NetworkMap;
+
+const DEACTIVATE_OTHERS_SQL =
+  "UPDATE network_map SET configuration = jsonb_set(jsonb_set(configuration, '{active}', 'false'), '{updDtTm}', to_jsonb($1::text)) WHERE tenantId = $2 AND active = true AND cfg <> $3;";
+const ACTIVATE_TARGET_SQL =
+  "UPDATE network_map SET configuration = jsonb_set(jsonb_set(configuration, '{active}', 'true'), '{updDtTm}', to_jsonb($1::text)) WHERE tenantId = $2 AND cfg = $3 RETURNING configuration;";
+const EXISTENCE_SQL = 'SELECT 1 FROM network_map WHERE cfg = $1 AND tenantId = $2;';
+const DEACTIVATE_SQL =
+  "UPDATE network_map SET configuration = jsonb_set(jsonb_set(configuration, '{active}', 'false'), '{updDtTm}', to_jsonb($1::text)) WHERE cfg = $2 AND tenantId = $3 RETURNING configuration;";
+
+describe('NetworkMapRepo.activate (#434)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(NOW);
+
+    // By default the transaction helper invokes its callback with a mock client so
+    // the SQL issued inside the transaction can be asserted.
+    mockWithConfigurationTransaction.mockImplementation(async (work: (client: TransactionClient) => Promise<unknown>) => {
+      const client: TransactionClient = { query: jest.fn() };
+      return await work(client);
+    });
+  });
+
+  it('checks existence first, then swaps by DEACTIVATING the current active map BEFORE ACTIVATING the target, in one transaction', async () => {
+    const activated = makeMap('2.0.0', true);
+    // existence check passes
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 });
+
+    const clientCalls: Array<{ text: string; values: unknown[] }> = [];
+    mockWithConfigurationTransaction.mockImplementation(async (work: (client: TransactionClient) => Promise<unknown>) => {
+      const client: TransactionClient = {
+        query: jest.fn(async (text: string, values?: unknown[]) => {
+          clientCalls.push({ text, values: values ?? [] });
+          // The activating UPDATE (...RETURNING configuration) yields the promoted map.
+          if (text === ACTIVATE_TARGET_SQL) return { rows: [{ configuration: activated }], rowCount: 1 };
+          // The deactivating UPDATE touches the previously-active map.
+          return { rows: [], rowCount: 1 };
+        }),
+      };
+      return await work(client);
+    });
+
+    const result = await repo.activate({ cfg: '2.0.0', tenantId: TENANT });
+
+    // existence checked before any transaction
+    expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(
+      1,
+      { text: EXISTENCE_SQL, values: ['2.0.0', TENANT] },
+      'configuration',
+    );
+    expect(mockWithConfigurationTransaction).toHaveBeenCalledTimes(1);
+
+    // exact ordering: deactivate-others first, then activate-target
+    expect(clientCalls).toHaveLength(2);
+    expect(clientCalls[0]).toEqual({ text: DEACTIVATE_OTHERS_SQL, values: [NOW, TENANT, '2.0.0'] });
+    expect(clientCalls[1]).toEqual({ text: ACTIVATE_TARGET_SQL, values: [NOW, TENANT, '2.0.0'] });
+
+    expect(result).toEqual(activated);
+  });
+
+  it('bumps updDtTm on BOTH the demoted and promoted records with the same timestamp', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 });
+
+    const clientCalls: Array<{ text: string; values: unknown[] }> = [];
+    mockWithConfigurationTransaction.mockImplementation(async (work: (client: TransactionClient) => Promise<unknown>) => {
+      const client: TransactionClient = {
+        query: jest.fn(async (text: string, values?: unknown[]) => {
+          clientCalls.push({ text, values: values ?? [] });
+          if (text === ACTIVATE_TARGET_SQL) return { rows: [{ configuration: makeMap('2.0.0', true) }], rowCount: 1 };
+          return { rows: [], rowCount: 1 };
+        }),
+      };
+      return await work(client);
+    });
+
+    await repo.activate({ cfg: '2.0.0', tenantId: TENANT });
+
+    // both statements set updDtTm via to_jsonb($1::text) and share the same NOW value
+    expect(clientCalls[0].text).toContain("'{updDtTm}', to_jsonb($1::text)");
+    expect(clientCalls[1].text).toContain("'{updDtTm}', to_jsonb($1::text)");
+    expect(clientCalls[0].values[0]).toBe(NOW);
+    expect(clientCalls[1].values[0]).toBe(NOW);
+  });
+
+  it('still promotes the target (and returns it) when no map is currently active', async () => {
+    const activated = makeMap('2.0.0', true);
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 });
+
+    mockWithConfigurationTransaction.mockImplementation(async (work: (client: TransactionClient) => Promise<unknown>) => {
+      const client: TransactionClient = {
+        query: jest.fn(async (text: string) => {
+          if (text === ACTIVATE_TARGET_SQL) return { rows: [{ configuration: activated }], rowCount: 1 };
+          // no currently-active map: the deactivate-others statement matches nothing
+          return { rows: [], rowCount: 0 };
+        }),
+      };
+      return await work(client);
+    });
+
+    const result = await repo.activate({ cfg: '2.0.0', tenantId: TENANT });
+
+    expect(result).toEqual(activated);
+    expect(mockWithConfigurationTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and performs NO writes when the target does not exist (no transaction opened)', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await repo.activate({ cfg: 'missing', tenantId: TENANT });
+
+    expect(result).toBeNull();
+    // existence check ran...
+    expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith({ text: EXISTENCE_SQL, values: ['missing', TENANT] }, 'configuration');
+    // ...but no transaction / no swap was attempted
+    expect(mockWithConfigurationTransaction).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: activating an already-active map keeps exactly that map active', async () => {
+    const activated = makeMap('1.0.0', true);
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 });
+
+    mockWithConfigurationTransaction.mockImplementation(async (work: (client: TransactionClient) => Promise<unknown>) => {
+      const client: TransactionClient = {
+        query: jest.fn(async (text: string) => {
+          if (text === ACTIVATE_TARGET_SQL) return { rows: [{ configuration: activated }], rowCount: 1 };
+          return { rows: [], rowCount: 0 };
+        }),
+      };
+      return await work(client);
+    });
+
+    const result = await repo.activate({ cfg: '1.0.0', tenantId: TENANT });
+
+    expect(result).toEqual(activated);
+  });
+});
+
+describe('NetworkMapRepo.deactivate (#434)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(NOW);
+  });
+
+  it('sets the target inactive in a single atomic statement, bumps updDtTm, and returns it', async () => {
+    const deactivated = makeMap('1.0.0', false);
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [{ configuration: deactivated }], rowCount: 1 });
+
+    const result = await repo.deactivate({ cfg: '1.0.0', tenantId: TENANT });
+
+    expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+      { text: DEACTIVATE_SQL, values: [NOW, '1.0.0', TENANT] },
+      'configuration',
+    );
+    // deactivate is a single atomic statement - it must NOT open a transaction.
+    expect(mockWithConfigurationTransaction).not.toHaveBeenCalled();
+    expect(result).toEqual(deactivated);
+  });
+
+  it('returns null when the target does not exist', async () => {
+    mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await repo.deactivate({ cfg: 'missing', tenantId: TENANT });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/clients/fastify.ts
+++ b/src/clients/fastify.ts
@@ -66,7 +66,12 @@ export default async function initializeFastifyClient(): Promise<FastifyInstance
       },
     },
     staticCSP: true,
-    transformStaticCSP: (header) => header,
+    // Drop `upgrade-insecure-requests` from the generated CSP. Swagger UI references its assets via
+    // same-origin, path-absolute URLs, so they already inherit the document's scheme (HTTP or HTTPS).
+    // The directive only ever rewrites explicit http:// subresources to https://, of which there are
+    // none here; leaving it in forces asset requests to https on a plain-HTTP deployment, which fails
+    // with ERR_SSL_PROTOCOL_ERROR and renders a blank UI. Removal is a no-op when served over HTTPS.
+    transformStaticCSP: (header) => header.replace(/\s*upgrade-insecure-requests;?/i, ''),
     transformSpecification: (swaggerObject, request, reply) => swaggerObject,
     transformSpecificationClone: true,
   });

--- a/src/repositories/configuration/network.map.repository.ts
+++ b/src/repositories/configuration/network.map.repository.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
-import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
+import { handlePostExecuteSqlStatement, withConfigurationTransaction } from '../../services/database.logic.service';
 import type { ConfigVersion, CrudRepository } from '../repository.base';
 import { listConfiguration, type ConfigListDescriptor } from './config-list.shared';
 
@@ -73,5 +73,55 @@ export const NetworkMapRepo: CrudRepository<NetworkMap, ConfigVersion> = {
       'configuration',
     );
     return queryRes.rowCount ? true : false;
+  },
+
+  // Promote one network map to active and demote the current active map in a single
+  // atomic swap. `active` is a generated STORED column derived from the JSON, so the flag
+  // is flipped by rewriting `configuration` via jsonb_set (a direct UPDATE of `active` is
+  // rejected). The partial unique index `idx_networkmap_active_tenant` (one active map per
+  // tenant) is non-deferrable and checked per-row, so the demote MUST happen before the
+  // promote inside one transaction - otherwise two rows are transiently active and the
+  // insert/update fails with 23505 depending on physical row order. The existence check
+  // runs first and outside the transaction: a missing target returns null with no writes,
+  // so no rollback is ever needed.
+  activate: async function ({ cfg, tenantId }): Promise<NetworkMap | null> {
+    const existence = await handlePostExecuteSqlStatement<{ exists: number }>(
+      {
+        text: 'SELECT 1 FROM network_map WHERE cfg = $1 AND tenantId = $2;',
+        values: [cfg, tenantId],
+      } satisfies PgQueryConfig,
+      'configuration',
+    );
+    if (!existence.rowCount) return null;
+
+    const dtTme = new Date().toISOString();
+    return await withConfigurationTransaction(async (client) => {
+      // Demote the currently-active map (if any) first - bumping updDtTm for data-warehouse deltas.
+      await client.query(
+        "UPDATE network_map SET configuration = jsonb_set(jsonb_set(configuration, '{active}', 'false'), '{updDtTm}', to_jsonb($1::text)) WHERE tenantId = $2 AND active = true AND cfg <> $3;",
+        [dtTme, tenantId, cfg],
+      );
+      // Promote the target and return its new state.
+      const activated = await client.query<{ configuration: NetworkMap }>(
+        "UPDATE network_map SET configuration = jsonb_set(jsonb_set(configuration, '{active}', 'true'), '{updDtTm}', to_jsonb($1::text)) WHERE tenantId = $2 AND cfg = $3 RETURNING configuration;",
+        [dtTme, tenantId, cfg],
+      );
+      return activated.rows[0].configuration;
+    });
+  },
+
+  // Set a single network map inactive. Zero active maps is a legal state, so this is one
+  // atomic statement with no transaction and no unique-index concern. Returns null when the
+  // target does not exist.
+  deactivate: async function ({ cfg, tenantId }): Promise<NetworkMap | null> {
+    const dtTme = new Date().toISOString();
+    const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
+      {
+        text: "UPDATE network_map SET configuration = jsonb_set(jsonb_set(configuration, '{active}', 'false'), '{updDtTm}', to_jsonb($1::text)) WHERE cfg = $2 AND tenantId = $3 RETURNING configuration;",
+        values: [dtTme, cfg, tenantId],
+      } satisfies PgQueryConfig,
+      'configuration',
+    );
+    return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 };

--- a/src/repositories/repository.base.ts
+++ b/src/repositories/repository.base.ts
@@ -35,4 +35,8 @@ export interface CrudRepository<TEntity, TId extends AllowedId = Node> {
   update: (id: TId, payload: TEntity) => Promise<TEntity | null>;
   remove: (id: TId) => Promise<boolean>;
   getNodeByName?: (nodeName: string, tenantId: string) => Promise<TEntity[] | null>;
+  // Optional lifecycle actions. Only entities with a single-active invariant (network_map)
+  // implement these; the CRUD factory registers the activate/deactivate routes only when present.
+  activate?: (id: TId) => Promise<TEntity | null>;
+  deactivate?: (id: TId) => Promise<TEntity | null>;
 }

--- a/src/services/database.logic.service.ts
+++ b/src/services/database.logic.service.ts
@@ -51,7 +51,17 @@ export const withConfigurationTransaction = async <T>(work: (client: PoolClient)
     await client.query('COMMIT');
     return result;
   } catch (error) {
-    await client.query('ROLLBACK');
+    // Roll back, but never let a rollback failure (typically a dead connection, which Postgres
+    // has already aborted server-side) mask the original cause: log the secondary error and
+    // rethrow the original transaction error.
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      loggerService.log(
+        `Failed to roll back configuration transaction: ${(rollbackError as { message: string }).message}`,
+        'withConfigurationTransaction()',
+      );
+    }
     throw error;
   } finally {
     client.release();

--- a/src/services/database.logic.service.ts
+++ b/src/services/database.logic.service.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
-import type { QueryResult, QueryResultRow } from 'pg';
+import type { PoolClient, QueryResult, QueryResultRow } from 'pg';
 import { databaseManager, loggerService } from '..';
 
 export const handlePostExecuteSqlStatement = async <T extends QueryResultRow>(
@@ -33,5 +33,27 @@ export const handlePostExecuteSqlStatement = async <T extends QueryResultRow>(
     throw new Error(errorMessage.message);
   } finally {
     loggerService.log('Completed handling execution of the query from database service');
+  }
+};
+
+// Runs a unit of work inside a single transaction on the configuration pool. A pinned
+// client is required because the configuration database manager is a pg.Pool: each
+// `.query` would otherwise borrow a different connection, so BEGIN/COMMIT could land on
+// separate sessions. This exists for the network-map active-swap, where the demote and
+// promote statements must be one atomic transaction (the partial unique index on
+// `active = true` is checked per-row, so the demote MUST commit-or-rollback together with
+// the promote). The client is always released, and any error triggers a ROLLBACK + rethrow.
+export const withConfigurationTransaction = async <T>(work: (client: PoolClient) => Promise<T>): Promise<T> => {
+  const client = await databaseManager._configuration.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await work(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
   }
 };

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -237,6 +237,59 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
       },
     );
 
+    // --- ACTIVATE / DEACTIVATE --- only for entities that expose the lifecycle actions
+    // (network_map). The activate swap is atomic in the repository; the route just maps a
+    // null result (missing target) to 404, mirroring GET/PUT/DELETE. AUTH:EXAMPLE(POST_V1_ADMIN_CONFIGURATION_NETWORK_MAP_ACTIVATE)
+    const activateFn = repo.activate;
+    if (activateFn) {
+      app.post(
+        `${prefix}${idPath}/activate`,
+        {
+          schema: {
+            tags: [prefix],
+            params: IdParam,
+            response: { 200: Entity, 404: ErrorResponse },
+          },
+          preHandler: configuration.AUTHENTICATED
+            ? [validateTenantMiddleware, tokenHandler(`POST${prefix.replaceAll('/', '_').toUpperCase()}_ACTIVATE`)]
+            : [validateTenantMiddleware],
+        },
+        async (req, reply) => {
+          const p = req.params as Record<string, string>;
+          const { tenantId } = req as ITenantRequest;
+
+          const activated = await activateFn(makeRepositoryId(p, tenantId));
+          if (!activated) return await reply.code(404).send({ message: 'Not found' });
+          return activated;
+        },
+      );
+    }
+
+    const deactivateFn = repo.deactivate;
+    if (deactivateFn) {
+      app.post(
+        `${prefix}${idPath}/deactivate`,
+        {
+          schema: {
+            tags: [prefix],
+            params: IdParam,
+            response: { 200: Entity, 404: ErrorResponse },
+          },
+          preHandler: configuration.AUTHENTICATED
+            ? [validateTenantMiddleware, tokenHandler(`POST${prefix.replaceAll('/', '_').toUpperCase()}_DEACTIVATE`)]
+            : [validateTenantMiddleware],
+        },
+        async (req, reply) => {
+          const p = req.params as Record<string, string>;
+          const { tenantId } = req as ITenantRequest;
+
+          const deactivated = await deactivateFn(makeRepositoryId(p, tenantId));
+          if (!deactivated) return await reply.code(404).send({ message: 'Not found' });
+          return deactivated;
+        },
+      );
+    }
+
     await Promise.resolve(true);
   };
 


### PR DESCRIPTION
# feat: atomic network map activate/deactivate endpoints (#434)

Closes #434.

## What

Two changes shipped as separate logical commits:

1. **`fix:` Swagger UI CSP** - strip `upgrade-insecure-requests` from the `@fastify/swagger-ui` static CSP so `/documentation` loads over plain HTTP.
2. **`feat:` network map activate/deactivate** - the active-swap feature for #434.

## Background (#434)

Network maps carry a single-active-per-tenant invariant, enforced at the database level by the partial unique index `idx_networkmap_active_tenant on network_map (tenantId) where active = true`. Operators previously had no way to change which map is active short of a full `PUT` replace of an otherwise-immutable document. This adds two dedicated actions:

```
POST /v1/admin/configuration/network_map/{cfg}/activate
POST /v1/admin/configuration/network_map/{cfg}/deactivate
```

## How the swap is made safe

- `active` (and `cfg`) are **generated STORED** columns derived from the `configuration` JSONB, so the flag cannot be set with a direct `UPDATE`; it is flipped by rewriting the JSON via `jsonb_set`.
- The partial unique index is **non-deferrable and checked per-row**, so a single multi-row `UPDATE` that demotes one map and promotes another can transiently leave two rows active and fail with `23505` depending purely on physical row-scan order. This was proven empirically before implementation.
- The swap therefore runs in **one transaction**, demoting the current active map **before** promoting the target, so at no instant are two rows active - regardless of row order.
- A new `withConfigurationTransaction(work)` helper pins a `pg` client for `BEGIN`/`COMMIT`/`ROLLBACK` on the configuration pool (the existing single-statement query path cannot express a transaction). It always releases the client and rolls back + rethrows on error.
- The target's existence is checked **first and outside** the transaction: a missing map returns `404` with **no writes**, so no rollback is ever needed.
- `updDtTm` is bumped on **both** the demoted and promoted records (for data-warehouse delta calculation).

`deactivate` sets a single map inactive in one atomic statement (zero active maps is a legal state, so no transaction is required) and returns `404` when the target is missing.

The CRUD plugin factory registers the two routes only for entities that expose the `activate`/`deactivate` actions, mapping a `null` repository result to `404` in line with `GET`/`PUT`/`DELETE`.

## Swagger CSP fix

`@fastify/swagger-ui`'s `staticCSP` emits `upgrade-insecure-requests`, which makes the browser rewrite every same-origin asset request (`swagger-ui-bundle.js`, `swagger-ui.css`, ...) from `http://` to `https://`. On a plain-HTTP deployment those upgraded requests fail with `ERR_SSL_PROTOCOL_ERROR` and the UI renders blank while `/documentation/json` still works. Swagger UI references its assets via same-origin, path-absolute URLs, so the directive provides no benefit (it never rewrites anything on HTTPS) and only breaks HTTP. `transformStaticCSP` now removes just that directive, leaving the rest of the CSP intact.

## Out of scope

- Forcing POSTed network maps to arrive with `active = false` (waived): the partial unique index already prevents a second active map; an `active = true` POST that collides returns the existing `500`.
- The `updDtTm` accuracy gap when a map's `active` flag is flipped more than once.
- Enforcement of config-document immutability (disabling `PUT`/`DELETE`).

## Testing

Developed test-first (RED tests reviewed before implementation). Coverage:

- **Repository** - existence-check-first; demote-before-promote ordering inside one transaction; `updDtTm` bumped on both with the same timestamp; not-found returns `null` with no writes / no transaction; promotes when no map is currently active; idempotent activate-already-active; `deactivate` single-statement happy path and not-found; `deactivate` opens no transaction.
- **Transaction helper** - `BEGIN -> work -> COMMIT` ordering, returns result, always releases; error path rolls back (not commits), rethrows, still releases.
- **Routes** - `200` with the map on success; `404` (delegating to the repo) when the target is missing.

Full suite: 705 passed (33 suites). `tsc` build clean. ESLint clean on all changed source files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network map activation and deactivation capabilities to admin configuration.
  * New API endpoints enable users to activate and deactivate network maps with proper validation and error handling.

* **Bug Fixes**
  * Improved Content Security Policy header handling for Swagger UI.

* **Tests**
  * Added comprehensive test coverage for database transactions, network map lifecycle operations, and CRUD activation/deactivation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->