### PR TITLE
feat: allow single-or-batch submission on rule and typology POST (#436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,12 +632,13 @@ A single object (unchanged, backwards compatible):
 { "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { /* ... */ } }
 ```
 
-An array of objects (batch):
+An array of objects (batch). A common shape is one entity identity (`id` is slow-changing) submitted
+with several config versions (`cfg` is the high-churn part of the key) in a single atomic insert:
 
 ```json
 [
   { "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { /* ... */ } },
-  { "id": "EFRuP@1.0.1", "cfg": "1.0.0", "config": { /* ... */ } }
+  { "id": "EFRuP@1.0.0", "cfg": "1.0.1", "config": { /* ... */ } }
 ]
 ```
 
@@ -656,19 +657,21 @@ top-level fields are stripped before insert on both paths (no mass-assignment vi
 
 #### Response body note
 
-For the **single-object** path the `201` response body is the created entity (unchanged).
+For the **single-object** path the `201` response body is the created entity, serialized against the
+entity schema - unchanged, and the same on batch-enabled routes as on single-only routes.
 
-For the **array** path the success body is returned but **not** re-serialized through the per-entity
-response schema. The shared CRUD response serializer is built from a `Type.Union` of the single
-entity and an array of items; the typology entity schema is recursive (`expression`), which the
-underlying `fast-json-stringify` serializer cannot compile inside that union. To keep one generic,
-auto-derived plugin for all entities (maintainability through automation) rather than hand-written
-per-entity batch serializers, the batch success path skips response serialization. A direct
-consequence is that, in the generated OpenAPI, the array request items appear as a generic object
-(`{}`); the per-item shape is the entity Create schema documented above. This is a deliberate
-trade-off favouring a single uniform code path over bespoke per-entity detail.
+For the **array** path the success body (the array of created entities) is returned with the
+per-reply serializer bypassed: a `Type.Union` of the single entity and an array of items cannot be
+compiled by `fast-json-stringify` when the entity schema is recursive (typology's `expression`), so
+the array reply uses plain JSON serialization instead of a schema-bound serializer. The single-object
+response is unaffected and keeps its entity serializer (and its OpenAPI `201`). One consequence
+remains in the generated OpenAPI: the array request items are typed as a generic object (`{}`); the
+per-item shape is the entity Create schema documented above. This is a deliberate trade-off favouring
+a single uniform code path over a bespoke per-entity serializer for the batch array case only.
 
 #### Examples
+
+A single rule (the single-object form):
 
 ```http
 POST /v1/admin/configuration/rule HTTP/1.1
@@ -677,13 +680,28 @@ Content-Type: application/json
 { "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { } }
 ```
 
+A batch of rule config versions - one `id`, several `cfg` values, inserted atomically:
+
+```http
+POST /v1/admin/configuration/rule HTTP/1.1
+Content-Type: application/json
+
+[
+  { "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { } },
+  { "id": "EFRuP@1.0.0", "cfg": "1.0.1", "config": { } }
+]
+```
+
+A batch of typology config versions (note typology's required `rules`, `expression`, `workflow`
+fields - there is no `config` field on a typology):
+
 ```http
 POST /v1/admin/configuration/typology HTTP/1.1
 Content-Type: application/json
 
 [
-  { "id": "typology-processor@1.0.0", "cfg": "1.0.0", "config": { } },
-  { "id": "typology-processor@1.0.1", "cfg": "1.0.0", "config": { } }
+  { "id": "typology-processor@1.0.0", "cfg": "1.0.0", "rules": [], "expression": [], "workflow": { "alertThreshold": 100 } },
+  { "id": "typology-processor@1.0.0", "cfg": "1.0.1", "rules": [], "expression": [], "workflow": { "alertThreshold": 100 } }
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -572,8 +572,8 @@ Each repository implementation follows a standardized interface, ensuring consis
 | No. | Config  | File name | Endpoint | Methods | 
 | --- | --- | --------- | -------- | ----------- | 
 | 1. | Network Map | network.map.repository | `/v1/admin/configuration/network_map` |  GET,POST,PUT,DEL, plus `POST {cfg}/activate` and `POST {cfg}/deactivate` |
-| 2. | Rule Configuration |  rule.config.repository | `/v1/admin/configuration/rule` |  GET,POST,PUT,DEL |
-| 3. | Typology Configuration | typology.config.repository | `/v1/admin/configuration/typology` | GET,POST,PUT,DEL |
+| 2. | Rule Configuration |  rule.config.repository | `/v1/admin/configuration/rule` |  GET,POST (single or batch),PUT,DEL |
+| 3. | Typology Configuration | typology.config.repository | `/v1/admin/configuration/typology` | GET,POST (single or batch),PUT,DEL |
 
 ### Configuration LIST query contract
 
@@ -617,6 +617,76 @@ GET /v1/admin/configuration/typology?limit=all HTTP/1.1
 GET /v1/admin/configuration/rule?keys[0][id]=EFRuP@1.0.0&keys[0][cfg]=1.0.0&keys[1][id]=R1&keys[1][cfg]=1.0.0&limit=all HTTP/1.1
 ```
 
+### Configuration POST contract (single or batch)
+
+The `rule` and `typology` POST endpoints accept **either** a single configuration object **or** an
+array of configuration objects in one request. `network_map` is intentionally excluded (its
+single-active-per-tenant invariant and `activate`/`deactivate` swap make atomic bulk insert
+semantics ambiguous), so its POST accepts a single object only.
+
+#### Accepted body shapes
+
+A single object (unchanged, backwards compatible):
+
+```json
+{ "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { /* ... */ } }
+```
+
+An array of objects (batch):
+
+```json
+[
+  { "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { /* ... */ } },
+  { "id": "EFRuP@1.0.1", "cfg": "1.0.0", "config": { /* ... */ } }
+]
+```
+
+Each array element must follow the same Create schema as the single-object body. Unknown
+top-level fields are stripped before insert on both paths (no mass-assignment via the array form).
+
+#### Semantics
+
+| Aspect | Behaviour |
+|--------|-----------|
+| Array bounds | `minItems` 1, `maxItems` 200 by default. An empty array or one over the cap returns `400`. |
+| Validation | Every item is validated **before** any insert. The first invalid item returns `400` with a body message of the form `item[<index>]: <path> <reason>`, identifying which element failed. |
+| Atomicity | All items in a batch are inserted inside a single configuration-pool transaction. If any insert fails the whole batch is rolled back - it is all-or-nothing, never a partial write. |
+| Tenant scoping | Every item is stamped with the `tenantId` from the auth token, exactly as the single-object path. |
+| Success status | `201 Created` for both the single-object and the array form. |
+
+#### Response body note
+
+For the **single-object** path the `201` response body is the created entity (unchanged).
+
+For the **array** path the success body is returned but **not** re-serialized through the per-entity
+response schema. The shared CRUD response serializer is built from a `Type.Union` of the single
+entity and an array of items; the typology entity schema is recursive (`expression`), which the
+underlying `fast-json-stringify` serializer cannot compile inside that union. To keep one generic,
+auto-derived plugin for all entities (maintainability through automation) rather than hand-written
+per-entity batch serializers, the batch success path skips response serialization. A direct
+consequence is that, in the generated OpenAPI, the array request items appear as a generic object
+(`{}`); the per-item shape is the entity Create schema documented above. This is a deliberate
+trade-off favouring a single uniform code path over bespoke per-entity detail.
+
+#### Examples
+
+```http
+POST /v1/admin/configuration/rule HTTP/1.1
+Content-Type: application/json
+
+{ "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { } }
+```
+
+```http
+POST /v1/admin/configuration/typology HTTP/1.1
+Content-Type: application/json
+
+[
+  { "id": "typology-processor@1.0.0", "cfg": "1.0.0", "config": { } },
+  { "id": "typology-processor@1.0.1", "cfg": "1.0.0", "config": { } }
+]
+```
+
 
 ---
 
@@ -634,7 +704,7 @@ The `get` method retrieves a single entity record based on its unique key and `t
 
 ### Create Operation
 
-The creation method inserts a new configuration entry into the database. The payload is augmented with the tenant identifier from auth token before being stored. The inserted configuration is returned as confirmation.
+The creation method inserts a new configuration entry into the database. The payload is augmented with the tenant identifier from auth token before being stored. The inserted configuration is returned as confirmation. The `create` method also accepts an optional transaction `client`; when supplied (by the batch POST path) the insert runs on that pinned client so a multi-item batch commits or rolls back atomically. See **Configuration POST contract (single or batch)** above for the `rule`/`typology` array form.
 
 ### Update Operation
 

--- a/__tests__/unit/crud-plugin.batch.test.ts
+++ b/__tests__/unit/crud-plugin.batch.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@je
 import Fastify, { type FastifyInstance } from 'fastify';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
+import { Type } from '@sinclair/typebox';
 
 // RED tests (#436): buildCrudPlugin must allow batch (array) submission on the
 // generic POST route for the `rule` and `typology` configuration entities.
@@ -373,6 +374,73 @@ describe('POST batch (array) submission on buildCrudPlugin (#436)', () => {
 
       expect(response.statusCode).toBe(400);
       expect(mockNetworkMapCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  // Response serialization on batch-enabled routes (CodeRabbit, PR #437): the single-object 201 must
+  // keep its strict Entity serializer (and OpenAPI 201), while ONLY the array reply bypasses it. A
+  // Union([Entity, Array(Entity)]) serializer breaks fast-json-stringify on recursive schemas, so the
+  // array path overrides reply.serializer to emit raw JSON. These tests use a deliberately strict
+  // Entity (no additionalProperties) so fast-json-stringify drops anything outside the schema - the
+  // observable signal that the schema serializer ran on the single-object reply but not the array.
+  describe('response serialization on batch routes (#436, PR #437)', () => {
+    let app: FastifyInstance;
+    const StrictEntity = Type.Object({ id: Type.String(), cfg: Type.String() });
+
+    beforeAll(async () => {
+      app = Fastify();
+      app.setValidatorCompiler(({ schema }) => makeAjv().compile(schema));
+      const { runInTransaction } = makeTxRecorder();
+
+      await app.register(
+        registerCrud({
+          prefix: '/v1/admin/configuration/rule',
+          repo: RuleConfigRepo,
+          // Entity (response) is strict; Create (request) stays the real RuleSchema.
+          schemas: { Entity: StrictEntity, Create: RuleSchema, Update: RuleSchema },
+          idParam: { kind: 'single', name: 'id' },
+          batch: { runInTransaction, maxItems: BATCH_MAX },
+        }),
+      );
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      mockRuleCreate.mockReset();
+      // The repo returns a field that is NOT in the strict Entity response schema.
+      mockRuleCreate.mockImplementation((payload: Record<string, unknown>) =>
+        Promise.resolve({ id: payload.id, cfg: payload.cfg, serverOnly: 'secret' }),
+      );
+    });
+
+    it('serializes the single-object 201 against Entity, dropping fields outside the schema', async () => {
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: validRule('r1') });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json() as Record<string, unknown>;
+      // The Entity serializer ran: only the declared id/cfg survive; serverOnly is dropped.
+      expect(body).toEqual({ id: 'r1', cfg: '1.0.0' });
+      expect(body).not.toHaveProperty('serverOnly');
+    });
+
+    it('returns the array 201 with the serializer bypassed (stays an array, keeps off-schema fields)', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/configuration/rule',
+        payload: [validRule('r1'), validRule('r2')],
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json() as Array<Record<string, unknown>>;
+      // Not coerced through the single-object Entity serializer: it stays an array of length 2 and
+      // retains fields outside the Entity schema (proof the array reply skips schema serialization).
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(2);
+      expect(body[0]).toMatchObject({ id: 'r1', cfg: '1.0.0', serverOnly: 'secret' });
     });
   });
 });

--- a/__tests__/unit/crud-plugin.batch.test.ts
+++ b/__tests__/unit/crud-plugin.batch.test.ts
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+// RED tests (#436): buildCrudPlugin must allow batch (array) submission on the
+// generic POST route for the `rule` and `typology` configuration entities.
+//
+// Locked design (post-grill arbitration):
+//  - C1 atomicity: the batch is inserted inside ONE transaction. The transaction
+//    runner is INJECTED per call site via a new `batch.runInTransaction` option
+//    (mirrors withConfigurationTransaction's signature). The pinned client is
+//    threaded into every repo.create(payload, tenantId, client) call, so a
+//    mid-batch failure rolls the whole batch back (all-or-nothing).
+//  - C2 wiring/scope: batch is a per-entity OPT-IN. It is NOT hard-wired into the
+//    generic factory, and only rule + typology enable it.
+//  - C3 network_map EXCLUDED from batch: its POST stays single-object only, so an
+//    array body must still be rejected with 400.
+//  - C4 validation: a malformed item in an array yields a 400 whose message
+//    identifies the offending index (item[i]).
+//  - Defaults: 201 for both shapes; response mirrors the request shape
+//    (object-in -> bare entity, array-in -> array, even length 1); maxItems cap.
+
+const mockRuleCreate = jest.fn();
+const mockTypologyCreate = jest.fn();
+const mockNetworkMapCreate = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: { AUTHENTICATED: false },
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/rule.config.repository', () => ({
+  RuleConfigRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: (...args: unknown[]) => mockRuleCreate(...args),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/typology.config.repository', () => ({
+  TypologyConfigRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: (...args: unknown[]) => mockTypologyCreate(...args),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/repositories/configuration/network.map.repository', () => ({
+  NetworkMapRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: (...args: unknown[]) => mockNetworkMapCreate(...args),
+    update: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+import { buildCrudPlugin } from '../../src/utils/crud-schema';
+import { RuleConfigRepo } from '../../src/repositories/configuration/rule.config.repository';
+import { TypologyConfigRepo } from '../../src/repositories/configuration/typology.config.repository';
+import { NetworkMapRepo } from '../../src/repositories/configuration/network.map.repository';
+import { RuleSchema } from '../../src/schemas/ruleSchema';
+import { TypologySchema } from '../../src/schemas/typologySchema';
+import { NetworkMapSchema } from '../../src/schemas/networkMapSchema';
+
+// --- The new `batch` option does not exist on BuildCrudOptions yet. This shim lets
+//     the file compile so the RED state is an assertion failure (array POST returns
+//     400 today instead of 201), not a type error. ---
+type BatchOption = {
+  runInTransaction: <T>(work: (client: unknown) => Promise<T>) => Promise<T>;
+  maxItems?: number;
+};
+type CrudOptions = Parameters<typeof buildCrudPlugin>[0];
+const registerCrud = (opts: CrudOptions & { batch?: BatchOption }): ReturnType<typeof buildCrudPlugin> =>
+  buildCrudPlugin(opts as CrudOptions);
+
+// A faithful stand-in for withConfigurationTransaction: BEGIN, run the work on a
+// pinned client, COMMIT on success / ROLLBACK on throw. We record the lifecycle so
+// the rollback test can prove all-or-nothing without a real database.
+interface TxRecorder {
+  begin: number;
+  commit: number;
+  rollback: number;
+  readonly client: { readonly __pinned: true };
+}
+const makeTxRecorder = (): { recorder: TxRecorder; runInTransaction: BatchOption['runInTransaction'] } => {
+  const recorder: TxRecorder = { begin: 0, commit: 0, rollback: 0, client: { __pinned: true } };
+  const runInTransaction: BatchOption['runInTransaction'] = async (work) => {
+    recorder.begin += 1;
+    try {
+      const result = await work(recorder.client);
+      recorder.commit += 1;
+      return result;
+    } catch (error) {
+      recorder.rollback += 1;
+      throw error;
+    }
+  };
+  return { recorder, runInTransaction };
+};
+
+const makeAjv = (): Ajv => {
+  const ajv = new Ajv({ removeAdditional: 'all', useDefaults: true, coerceTypes: 'array', strictTuples: false });
+  addFormats(ajv);
+  return ajv;
+};
+
+const validRule = (id: string): Record<string, unknown> => ({ id, cfg: '1.0.0', config: {} });
+const validTypology = (id: string): Record<string, unknown> => ({
+  id,
+  cfg: '1.0.0',
+  rules: [],
+  expression: [],
+  workflow: { alertThreshold: 1 },
+});
+
+const BATCH_MAX = 3; // small cap for the oversize test; production default is 200
+
+describe('POST batch (array) submission on buildCrudPlugin (#436)', () => {
+  describe('rule (batch enabled)', () => {
+    let app: FastifyInstance;
+    let tx: TxRecorder;
+
+    beforeAll(async () => {
+      app = Fastify();
+      app.setValidatorCompiler(({ schema }) => makeAjv().compile(schema));
+      const { recorder, runInTransaction } = makeTxRecorder();
+      tx = recorder;
+
+      await app.register(
+        registerCrud({
+          prefix: '/v1/admin/configuration/rule',
+          repo: RuleConfigRepo,
+          schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
+          idParam: { kind: 'single', name: 'id' },
+          batch: { runInTransaction, maxItems: BATCH_MAX },
+        }),
+      );
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      mockRuleCreate.mockReset();
+      tx.begin = 0;
+      tx.commit = 0;
+      tx.rollback = 0;
+      // Default: echo the payload back as the created entity.
+      mockRuleCreate.mockImplementation((payload: unknown) => Promise.resolve(payload));
+    });
+
+    it('single-object body still returns 201 with a bare entity and runs NO transaction (regression)', async () => {
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: validRule('r1') });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(Array.isArray(body)).toBe(false);
+      expect(body).toMatchObject({ id: 'r1' });
+      expect(mockRuleCreate).toHaveBeenCalledTimes(1);
+      // tenantId (defaulted by validateTenantMiddleware) is forwarded as the 2nd arg.
+      expect(mockRuleCreate.mock.calls[0][1]).toBe('DEFAULT');
+      // Single path does not open a transaction and passes no pinned client.
+      expect(tx.begin).toBe(0);
+      expect(mockRuleCreate.mock.calls[0][2]).toBeUndefined();
+    });
+
+    it('strips unknown fields from a single-object body before insert (AC6: no mass-assignment via the union; #436)', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/configuration/rule',
+        payload: { ...validRule('r1'), sneaky: 'leak', injected: 42 },
+      });
+
+      // Pre-#436 the single object was validated directly against Create, so the app-wide
+      // removeAdditional:'all' stripped unknown keys. Wrapping the body in Type.Union([...]) must
+      // NOT regress that (Ajv removeAdditional is documented as unreliable inside anyOf). This is a
+      // mass-assignment guard: extra keys must never round-trip into the stored configuration JSONB.
+      expect(response.statusCode).toBe(201);
+      expect(mockRuleCreate).toHaveBeenCalledTimes(1);
+      const inserted = mockRuleCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(inserted).not.toHaveProperty('sneaky');
+      expect(inserted).not.toHaveProperty('injected');
+      // The declared fields survive unchanged.
+      expect(inserted).toMatchObject({ id: 'r1', cfg: '1.0.0' });
+    });
+
+    it('array body returns 201 with an array of created entities, inserted in one committed transaction', async () => {
+      const payload = [validRule('r1'), validRule('r2')];
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json() as Array<{ id: string }>;
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.map((r) => r.id)).toEqual(['r1', 'r2']);
+
+      expect(mockRuleCreate).toHaveBeenCalledTimes(2);
+      // Atomic: exactly one transaction, committed once, never rolled back.
+      expect(tx.begin).toBe(1);
+      expect(tx.commit).toBe(1);
+      expect(tx.rollback).toBe(0);
+      // tenantId is forwarded for every item.
+      expect(mockRuleCreate.mock.calls[0][1]).toBe('DEFAULT');
+      expect(mockRuleCreate.mock.calls[1][1]).toBe('DEFAULT');
+      // Every create runs on the pinned transaction client (3rd arg).
+      expect(mockRuleCreate.mock.calls[0][2]).toBe(tx.client);
+      expect(mockRuleCreate.mock.calls[1][2]).toBe(tx.client);
+    });
+
+    it('single-element array returns a one-element array (response mirrors request shape)', async () => {
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: [validRule('r1')] });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(1);
+    });
+
+    it('rolls the whole batch back when any item fails (all-or-nothing)', async () => {
+      mockRuleCreate
+        .mockImplementationOnce((payload: unknown) => Promise.resolve(payload))
+        .mockImplementationOnce(() => Promise.reject(new Error('insert failed for item 2')));
+
+      const payload = [validRule('r1'), validRule('r2')];
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload });
+
+      // Not a success: the batch must not partially persist.
+      expect(response.statusCode).toBeGreaterThanOrEqual(500);
+      // The single transaction was rolled back and never committed.
+      expect(tx.begin).toBe(1);
+      expect(tx.commit).toBe(0);
+      expect(tx.rollback).toBe(1);
+    });
+
+    it('rejects an empty array with 400 and never opens a transaction', async () => {
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: [] });
+
+      expect(response.statusCode).toBe(400);
+      expect(tx.begin).toBe(0);
+      expect(mockRuleCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects an array larger than maxItems with 400', async () => {
+      const payload = Array.from({ length: BATCH_MAX + 1 }, (_, i) => validRule(`r${i}`));
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload });
+
+      expect(response.statusCode).toBe(400);
+      expect(tx.begin).toBe(0);
+      expect(mockRuleCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed item with a 400 that identifies the offending index', async () => {
+      // index 1 is missing the required `config` and `id` fields.
+      const payload = [validRule('r0'), { cfg: '1.0.0' }];
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload });
+
+      expect(response.statusCode).toBe(400);
+      const { message } = response.json() as { message: string };
+      // The error must point at item index 1 specifically (item[1]), not a generic
+      // "anyOf"/"body must be object" failure. Pinning the index to the `item` token
+      // avoids a coincidental match on the "1" in a version string like "1.0.0".
+      expect(message).toMatch(/item\s*\[\s*1\s*\]/i);
+      // Validation happens up-front: a malformed batch must not open a transaction
+      // or call create at all (no partial insert + rollback).
+      expect(tx.begin).toBe(0);
+      expect(mockRuleCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('typology (batch enabled)', () => {
+    let app: FastifyInstance;
+    let tx: TxRecorder;
+
+    beforeAll(async () => {
+      app = Fastify();
+      app.setValidatorCompiler(({ schema }) => makeAjv().compile(schema));
+      const { recorder, runInTransaction } = makeTxRecorder();
+      tx = recorder;
+
+      await app.register(
+        registerCrud({
+          prefix: '/v1/admin/configuration/typology',
+          repo: TypologyConfigRepo,
+          schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema },
+          idParam: { kind: 'single', name: 'id' },
+          batch: { runInTransaction, maxItems: BATCH_MAX },
+        }),
+      );
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      mockTypologyCreate.mockReset();
+      tx.begin = 0;
+      tx.commit = 0;
+      tx.rollback = 0;
+      mockTypologyCreate.mockImplementation((payload: unknown) => Promise.resolve(payload));
+    });
+
+    it('array body returns 201 with all created typologies in one committed transaction', async () => {
+      const payload = [validTypology('t1'), validTypology('t2')];
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/typology', payload });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json() as Array<{ id: string }>;
+      expect(body.map((t) => t.id)).toEqual(['t1', 't2']);
+      expect(mockTypologyCreate).toHaveBeenCalledTimes(2);
+      expect(tx.begin).toBe(1);
+      expect(tx.commit).toBe(1);
+    });
+  });
+
+  describe('network_map (batch NOT enabled - deliberate exclusion)', () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = Fastify();
+      app.setValidatorCompiler(({ schema }) => makeAjv().compile(schema));
+
+      await app.register(
+        registerCrud({
+          prefix: '/v1/admin/configuration/network_map',
+          repo: NetworkMapRepo,
+          schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema },
+          idParam: { kind: 'cfg' },
+          // no batch option -> single-object only
+        }),
+      );
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      mockNetworkMapCreate.mockReset();
+      mockNetworkMapCreate.mockImplementation((payload: unknown) => Promise.resolve(payload));
+    });
+
+    it('still accepts a single-object body (201, unchanged)', async () => {
+      const payload = { cfg: '1.0.0', tenantId: 'DEFAULT', active: false, messages: [] };
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/network_map', payload });
+
+      expect(response.statusCode).toBe(201);
+      expect(Array.isArray(response.json())).toBe(false);
+    });
+
+    it('rejects an array body with 400 (batch is out of scope for network_map)', async () => {
+      const payload = [
+        { cfg: '1.0.0', tenantId: 'DEFAULT', active: false, messages: [] },
+        { cfg: '2.0.0', tenantId: 'DEFAULT', active: false, messages: [] },
+      ];
+      const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/network_map', payload });
+
+      expect(response.statusCode).toBe(400);
+      expect(mockNetworkMapCreate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/unit/database.logic.service.test.ts
+++ b/__tests__/unit/database.logic.service.test.ts
@@ -56,6 +56,29 @@ describe('Database Logic Service', () => {
     await expect(handlePostExecuteSqlStatement(mockQueryConfig, 'unknown_db')).rejects.toThrow('Specified database was not found.');
   });
 
+  // RED (#436): when a pinned client is supplied, the statement must run on THAT client
+  // (so it joins the open transaction) and must NOT borrow a separate pool connection -
+  // otherwise a batch's INSERTs and its BEGIN/COMMIT land on different sessions and
+  // atomicity is lost. handlePostExecuteSqlStatement does not accept a client arg yet,
+  // so this is cast to keep the RED at the assertion level.
+  it('runs the statement on the supplied client instead of the pool (#436)', async () => {
+    const clientQuery = jest.fn();
+    clientQuery.mockResolvedValue(mockResult as never);
+    const client = { query: clientQuery };
+
+    const runWithClient = handlePostExecuteSqlStatement as unknown as (
+      q: typeof mockQueryConfig,
+      db: string,
+      client?: unknown,
+    ) => Promise<typeof mockResult>;
+    const result = await runWithClient(mockQueryConfig, 'configuration', client);
+
+    expect(result).toEqual(mockResult);
+    expect(clientQuery).toHaveBeenCalledWith(mockQueryConfig.text, mockQueryConfig.values);
+    // Must NOT borrow a separate pooled connection when a transaction client is given.
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   it('should throw error when query fails', async () => {
     mockQuery.mockRejectedValue(new Error('Connection refused') as never);
     await expect(handlePostExecuteSqlStatement(mockQueryConfig, 'configuration')).rejects.toThrow('Connection refused');

--- a/__tests__/unit/repositories/crud-create-client-threading.test.ts
+++ b/__tests__/unit/repositories/crud-create-client-threading.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// RED tests (#436) - atomicity seam.
+//
+// The route-level batch tests mock repo.create, so they CANNOT catch the real
+// atomicity hazard: today every repo.create runs its INSERT via
+// handlePostExecuteSqlStatement -> databaseManager._configuration.query, which
+// borrows a FRESH pooled connection per call. A batch wrapped in one
+// withConfigurationTransaction (on a pinned client) would therefore commit each
+// INSERT on a different connection - so a mid-batch failure would NOT roll back.
+//
+// The locked C1 design fixes this by threading an optional `client` into
+// create(payload, tenantId, client) and on through handlePostExecuteSqlStatement,
+// so the INSERT runs on the SAME pinned client as BEGIN/COMMIT. These tests pin
+// that seam.
+
+const mockHandle = jest.fn();
+
+jest.mock('../../../src/services/database.logic.service', () => ({
+  handlePostExecuteSqlStatement: (...args: unknown[]) => mockHandle(...args),
+}));
+
+jest.mock('../../../src', () => ({
+  loggerService: { log: jest.fn(), error: jest.fn() },
+}));
+
+import { RuleConfigRepo } from '../../../src/repositories/configuration/rule.config.repository';
+import { TypologyConfigRepo } from '../../../src/repositories/configuration/typology.config.repository';
+
+// create does not accept a 3rd `client` arg yet - cast so the file compiles and the
+// RED state is an assertion failure (3rd arg not forwarded), not a type error.
+type CreateWithClient = (payload: unknown, tenantId: string, client?: unknown) => Promise<unknown>;
+const pinnedClient = { __pinned: true } as const;
+
+describe('config repo create() threads a pinned client to the DB layer (#436)', () => {
+  beforeEach(() => {
+    mockHandle.mockReset();
+    mockHandle.mockResolvedValue({ rows: [{ configuration: {} }], rowCount: 1 } as never);
+  });
+
+  it('RuleConfigRepo.create forwards the supplied client as the 3rd arg to handlePostExecuteSqlStatement', async () => {
+    await (RuleConfigRepo.create as unknown as CreateWithClient)({ id: 'r1', cfg: '1.0.0', config: {} }, 'DEFAULT', pinnedClient);
+
+    expect(mockHandle).toHaveBeenCalledTimes(1);
+    // 3rd arg must be the pinned client so the INSERT runs inside the open transaction.
+    expect(mockHandle.mock.calls[0][2]).toBe(pinnedClient);
+  });
+
+  it('TypologyConfigRepo.create forwards the supplied client as the 3rd arg to handlePostExecuteSqlStatement', async () => {
+    await (TypologyConfigRepo.create as unknown as CreateWithClient)(
+      { id: 't1', cfg: '1.0.0', rules: [], expression: [], workflow: { alertThreshold: 1 } },
+      'DEFAULT',
+      pinnedClient,
+    );
+
+    expect(mockHandle).toHaveBeenCalledTimes(1);
+    expect(mockHandle.mock.calls[0][2]).toBe(pinnedClient);
+  });
+
+  it('omitting the client preserves the existing single-insert behaviour (no 3rd arg)', async () => {
+    await RuleConfigRepo.create({ id: 'r1', cfg: '1.0.0', config: {} } as never, 'DEFAULT');
+
+    expect(mockHandle).toHaveBeenCalledTimes(1);
+    expect(mockHandle.mock.calls[0][2]).toBeUndefined();
+  });
+});

--- a/__tests__/unit/repositories/rule.config.repository.test.ts
+++ b/__tests__/unit/repositories/rule.config.repository.test.ts
@@ -470,6 +470,7 @@ describe('RuleConfigRepository', () => {
           values: [inputPayload],
         },
         'configuration',
+        undefined,
       );
 
       expect(result).toEqual(mockCreateResponse.rows[0].configuration);

--- a/__tests__/unit/repositories/typology.config.repository.test.ts
+++ b/__tests__/unit/repositories/typology.config.repository.test.ts
@@ -311,6 +311,7 @@ describe('TypologyConfigRepository', () => {
           values: [inputPayload],
         },
         'configuration',
+        undefined,
       );
 
       expect(result).toEqual(mockCreateResponse.rows[0].configuration);

--- a/src/repositories/configuration/rule.config.repository.ts
+++ b/src/repositories/configuration/rule.config.repository.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import type { PoolClient } from 'pg';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
 import type { CrudRepository } from '../repository.base';
 import { listConfiguration, type ConfigListDescriptor } from './config-list.shared';
@@ -34,7 +35,7 @@ export const RuleConfigRepo: CrudRepository<RuleConfig> = {
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 
-  create: async function (payload: RuleConfig, tenantId: string): Promise<RuleConfig> {
+  create: async function (payload: RuleConfig, tenantId: string, client?: PoolClient): Promise<RuleConfig> {
     payload.tenantId = tenantId;
 
     const dtTme = new Date().toISOString();
@@ -47,6 +48,7 @@ export const RuleConfigRepo: CrudRepository<RuleConfig> = {
         values: [payload],
       } satisfies PgQueryConfig,
       'configuration',
+      client,
     );
     return queryRes.rows[0].configuration;
   },

--- a/src/repositories/configuration/typology.config.repository.ts
+++ b/src/repositories/configuration/typology.config.repository.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { PgQueryConfig } from '@tazama-lf/frms-coe-lib';
 import type { TypologyConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
+import type { PoolClient } from 'pg';
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
 import type { CrudRepository } from '../repository.base';
 import { listConfiguration, type ConfigListDescriptor } from './config-list.shared';
@@ -34,7 +35,7 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
     return queryRes.rowCount ? queryRes.rows[0].configuration : null;
   },
 
-  create: async function (payload: TypologyConfig, tenantId: string): Promise<TypologyConfig> {
+  create: async function (payload: TypologyConfig, tenantId: string, client?: PoolClient): Promise<TypologyConfig> {
     payload.tenantId = tenantId;
 
     const dtTme = new Date().toISOString();
@@ -47,6 +48,7 @@ export const TypologyConfigRepo: CrudRepository<TypologyConfig> = {
         values: [payload],
       } satisfies PgQueryConfig,
       'configuration',
+      client,
     );
     return queryRes.rows[0].configuration;
   },

--- a/src/repositories/repository.base.ts
+++ b/src/repositories/repository.base.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import type { PoolClient } from 'pg';
 type StringKeys<T> = Extract<keyof T, string>;
 export interface ListQuery<TSort extends string = string> {
   limit?: number | 'all'; // default 20; 'all' returns the full tenant-scoped set (#422)
@@ -31,7 +32,9 @@ export type AllowedId = Node | ConfigVersion | Connector;
 export interface CrudRepository<TEntity, TId extends AllowedId = Node> {
   list: (params: ListQuery<StringKeys<TEntity>>) => Promise<{ data: TEntity[]; total: number }>;
   get: (id: TId) => Promise<TEntity | null>;
-  create: (payload: TEntity, tenantId: string) => Promise<TEntity>;
+  // `client` (optional) pins the insert to an open transaction for atomic batch creates (#436);
+  // when omitted, the insert runs on its own pooled connection exactly as before.
+  create: (payload: TEntity, tenantId: string, client?: PoolClient) => Promise<TEntity>;
   update: (id: TId, payload: TEntity) => Promise<TEntity | null>;
   remove: (id: TId) => Promise<boolean>;
   getNodeByName?: (nodeName: string, tenantId: string) => Promise<TEntity[] | null>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -84,6 +84,7 @@ import {
 } from './schemas';
 import { buildCrudPlugin } from './utils/crud-schema';
 import { SetOptionsBodyAndParams } from './utils/schema-utils';
+import { withConfigurationTransaction } from './services/database.logic.service';
 
 // Privilege mapping for each route, for easier maintenance and claim management
 const routePrivilege = {
@@ -161,6 +162,7 @@ function Routes(fastify: FastifyInstance): void {
       repo: RuleConfigRepo,
       schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema, Query: RuleListQuery },
       idParam: { kind: 'single', name: 'id' },
+      batch: { runInTransaction: withConfigurationTransaction },
     }),
   );
 
@@ -170,6 +172,7 @@ function Routes(fastify: FastifyInstance): void {
       repo: TypologyConfigRepo,
       schemas: { Entity: TypologySchema, Create: TypologySchema, Update: TypologySchema, Query: TypologyListQuery },
       idParam: { kind: 'single', name: 'id' },
+      batch: { runInTransaction: withConfigurationTransaction },
     }),
   );
 

--- a/src/services/database.logic.service.ts
+++ b/src/services/database.logic.service.ts
@@ -6,9 +6,17 @@ import { databaseManager, loggerService } from '..';
 export const handlePostExecuteSqlStatement = async <T extends QueryResultRow>(
   queryConfig: PgQueryConfig,
   databaseName: string,
+  client?: PoolClient,
 ): Promise<QueryResult<T>> => {
   try {
     loggerService.log('Started handling execution of the sql statement');
+
+    // When a pinned transaction client is supplied (batch insert, #436), run the
+    // statement on THAT client so it joins the open BEGIN/COMMIT rather than borrowing
+    // a separate pooled connection - otherwise the batch would not be atomic.
+    if (client) {
+      return await client.query<T>(queryConfig.text, queryConfig.values);
+    }
 
     switch (databaseName) {
       case 'configuration':

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -93,12 +93,12 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
             'A single configuration object, or a non-empty array (atomic batch insert) of configuration objects following the same schema.',
         })
       : Create;
-    // Response serialization: a single object keeps the strict Entity schema. For batch routes the
-    // 201 body may be an object OR an array; we intentionally omit a response schema for that case
-    // because a Union([Entity, Array(Entity)]) breaks fast-json-stringify when Entity is recursive
-    // (e.g. TypologySchema.expression). Default JSON serialization handles both shapes. The accepted
-    // request shapes remain fully documented via CreateBody (the #436 OpenAPI acceptance criterion).
-    const CreateResponseSchema = batch ? { 400: ErrorResponse } : { 201: Entity };
+    // Response serialization: the single-object 201 always keeps the strict Entity schema (and its
+    // OpenAPI 201), on batch routes too. Only the batch ARRAY reply skips the schema serializer (see
+    // the POST handler), because a Union([Entity, Array(Entity)]) breaks fast-json-stringify when
+    // Entity is recursive (e.g. TypologySchema.expression). The accepted request shapes remain fully
+    // documented via CreateBody (the #436 OpenAPI acceptance criterion).
+    const CreateResponseSchema = batch ? { 201: Entity, 400: ErrorResponse } : { 201: Entity };
 
     // Batch runtime: the transaction runner and a standalone per-item validator are bundled together
     // so they share a single existence fact (`batch` enabled <=> both present). This lets the handler
@@ -255,6 +255,11 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
             }
             return results;
           });
+          // The route's 201 schema is the single Entity (object); an array can't be serialized
+          // against it, and a Union serializer breaks on recursive schemas (typology.expression).
+          // Bypass the schema serializer for this array reply only - the single-object path below
+          // keeps the Entity serializer (and its OpenAPI 201).
+          reply.serializer((payload) => JSON.stringify(payload));
           return await reply.code(201).send(created);
         }
 

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Type, type Static, type TObject, type TSchema } from '@sinclair/typebox';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import type { FastifyInstance, FastifyPluginAsync, RawServerDefault } from 'fastify';
 import fp from 'fastify-plugin';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { PoolClient } from 'pg';
 import { configuration } from '..';
 import { tokenHandler } from '../auth/authHandler';
 import type { AllowedId, CrudRepository, ListQuery } from '../repositories/repository.base';
@@ -17,6 +20,19 @@ export interface CrudSchemas {
   Query?: TObject;
 }
 
+// Opt-in atomic batch (array) submission for the POST route (#436). Supplied only by the
+// configuration entities that want it (rule, typology); when absent the POST route accepts a
+// single object exactly as before. `runInTransaction` is injected per call site (so the generic
+// factory never hard-codes a pool-specific helper) and pins one client for the whole batch.
+export interface BatchCreateOptions {
+  runInTransaction: <T>(work: (client: PoolClient) => Promise<T>) => Promise<T>;
+  maxItems?: number;
+}
+
+// Default upper bound on a single batch, matching the existing list `keys` batch-fetch cap (#423):
+// bounds the transaction size and the request payload.
+const DEFAULT_BATCH_MAX_ITEMS = 200;
+
 type IdParamConfig = { kind: 'single'; name?: string } | { kind: 'cfg' } | { kind: 'composite'; names: readonly [string, string] };
 
 interface BuildCrudOptions<TEntity, TId extends AllowedId> {
@@ -24,6 +40,7 @@ interface BuildCrudOptions<TEntity, TId extends AllowedId> {
   repo: CrudRepository<TEntity, TId>;
   schemas: CrudSchemas;
   idParam?: IdParamConfig;
+  batch?: BatchCreateOptions;
 }
 
 const DefaultQuery = Type.Object({
@@ -60,8 +77,41 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
   opts: BuildCrudOptions<TEntity, TId>,
 ): FastifyPluginAsync => {
   const plugin: FastifyPluginAsync = async (app: FastifyInstance<RawServerDefault, IncomingMessage, ServerResponse>) => {
-    const { prefix, repo, schemas, idParam } = opts;
+    const { prefix, repo, schemas, idParam, batch } = opts;
     const { Entity, Create, Update } = schemas;
+    const batchMaxItems = batch?.maxItems ?? DEFAULT_BATCH_MAX_ITEMS;
+
+    // When batch submission is enabled the POST body accepts BOTH a single object and an array.
+    // The array branch's items use an unconstrained schema (Type.Unknown) so the app-wide
+    // `removeAdditional: 'all'` does NOT strip their fields and malformed ITEMS reach the handler,
+    // where per-item validation reports the offending index (item[i]); the union's single-object
+    // branch still enforces the full Create schema, preserving today's single-object behaviour.
+    const BatchItem = Type.Unknown({ description: 'A configuration object following the entity Create schema.' });
+    const CreateBody = batch
+      ? Type.Union([Create, Type.Array(BatchItem, { minItems: 1, maxItems: batchMaxItems })], {
+          description:
+            'A single configuration object, or a non-empty array (atomic batch insert) of configuration objects following the same schema.',
+        })
+      : Create;
+    // Response serialization: a single object keeps the strict Entity schema. For batch routes the
+    // 201 body may be an object OR an array; we intentionally omit a response schema for that case
+    // because a Union([Entity, Array(Entity)]) breaks fast-json-stringify when Entity is recursive
+    // (e.g. TypologySchema.expression). Default JSON serialization handles both shapes. The accepted
+    // request shapes remain fully documented via CreateBody (the #436 OpenAPI acceptance criterion).
+    const CreateResponseSchema = batch ? { 400: ErrorResponse } : { 201: Entity };
+
+    // Batch runtime: the transaction runner and a standalone per-item validator are bundled together
+    // so they share a single existence fact (`batch` enabled <=> both present). This lets the handler
+    // narrow once and treat `validateItem` as non-optional, guaranteeing validation is never skipped.
+    // The validator mirrors the app-wide Ajv config (see src/clients/fastify.ts) and is compiled from
+    // the full Create schema so it can surface an item[i] message for the offending array element.
+    const batchRuntime = batch
+      ? (() => {
+          const itemAjv = new Ajv({ removeAdditional: 'all', useDefaults: true, coerceTypes: 'array', strictTuples: false });
+          addFormats(itemAjv);
+          return { runInTransaction: batch.runInTransaction, validateItem: itemAjv.compile(Create) };
+        })()
+      : undefined;
 
     // --- Build path and param schema based on idParam ---
     const singleName: string = idParam?.kind === 'single' ? (idParam.name ?? 'id') : 'id';
@@ -172,8 +222,8 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
       {
         schema: {
           tags: [prefix],
-          body: Create,
-          response: { 201: Entity },
+          body: CreateBody,
+          response: CreateResponseSchema,
         },
         preHandler: configuration.AUTHENTICATED
           ? [validateTenantMiddleware, tokenHandler(`POST${prefix.replaceAll('/', '_').toUpperCase()}`)]
@@ -181,6 +231,33 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
       },
       async (req, reply) => {
         const { tenantId } = req as ITenantRequest;
+
+        // Batch path: an array body is inserted all-or-nothing inside one injected transaction,
+        // with the pinned client threaded into every create so the rows share one BEGIN/COMMIT.
+        if (batchRuntime && Array.isArray(req.body)) {
+          const items = req.body as TEntity[];
+
+          // Validate each item up-front (before opening a transaction) so a malformed batch never
+          // partially inserts and the client gets an error that names the offending index.
+          for (let i = 0; i < items.length; i++) {
+            if (!batchRuntime.validateItem(items[i])) {
+              const firstError = batchRuntime.validateItem.errors?.[0];
+              const detail = firstError ? `${firstError.instancePath || '/'} ${firstError.message}`.trim() : 'invalid item';
+              return await reply.code(400).send({ message: `item[${i}]: ${detail}` });
+            }
+          }
+
+          const created = await batchRuntime.runInTransaction(async (client) => {
+            const results: TEntity[] = [];
+            // Inserts run serially: a single pinned PoolClient cannot execute concurrent queries.
+            for (const item of items) {
+              results.push(await repo.create(item, tenantId, client));
+            }
+            return results;
+          });
+          return await reply.code(201).send(created);
+        }
+
         const created = await repo.create(req.body as TEntity, tenantId);
         return await reply.code(201).send(created);
       },


### PR DESCRIPTION
## Summary

Closes #436.

Allows the generic CRUD `POST` route (built by `buildCrudPlugin`) to accept **either** a single
configuration object **or** an array of objects in one request, scoped to the `rule` and `typology`
configuration entities. A batch is inserted atomically (all-or-nothing) inside a single
configuration-pool transaction.

## What changed

- **Batch-aware POST body**: for `rule`/`typology` the request body schema is now a union of the
  single `Create` object and an array of items (`minItems` 1, `maxItems` 200 by default). A single
  object continues to work exactly as before (backwards compatible).
- **Per-item validation before any insert**: each array element is validated against the entity
  `Create` schema up front. The first invalid item returns `400` with a message of the form
  `item[<index>]: <path> <reason>`, so the caller knows which element failed.
- **Atomic batch insert**: an optional transaction `client` is threaded through
  `repository.create` -> `handlePostExecuteSqlStatement`. When the batch path supplies a pinned
  client (via `withConfigurationTransaction`), all inserts run in one `BEGIN`/`COMMIT`/`ROLLBACK`
  transaction. Any failure rolls back the whole batch - never a partial write.
- **Tenant scoping unchanged**: every item is stamped with the `tenantId` from the auth token, same
  as the single-object path.
- **Docs**: new "Configuration POST contract (single or batch)" section in `README.md` covering both
  body shapes, the bounds, the error format, atomicity, and the trade-offs below.

## Accepted body shapes (`rule`, `typology`)

Single object (unchanged):

```json
{ "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { } }
```

Array (batch, atomic):

```json
[
  { "id": "EFRuP@1.0.0", "cfg": "1.0.0", "config": { } },
  { "id": "EFRuP@1.0.1", "cfg": "1.0.0", "config": { } }
]
```

## Scope note: network_map deliberately excluded

The issue says "POST endpoints" generally, but `network_map` is **intentionally** left single-object
only. It carries a single-active-per-tenant invariant and dedicated `activate`/`deactivate` swap
semantics, which make atomic bulk-insert behaviour ambiguous. Narrowing batch support to
`rule`/`typology` keeps the change safe and unambiguous. Raised as a scope-clarification comment on
the issue.

## Trade-offs (called out for review)

1. **Only the batch ARRAY reply skips schema serialization.** The single-object `201` keeps its
   strict `Entity` serializer (and its OpenAPI `201`) on batch routes, exactly as on single-only
   routes. The array reply bypasses the serializer (`reply.serializer`) because a
   `Type.Union([Entity, Array(Entity)])` cannot be compiled by `fast-json-stringify` when the entity
   schema is recursive (`TypologySchema.expression`, stack overflow). Keeping one generic,
   auto-derived plugin for every entity (maintainability through automation) is preserved, and the
   array reply uses plain JSON serialization. _(Updated per CodeRabbit review - the earlier version
   dropped the serializer for single-object responses too; that has been fixed.)_
2. **OpenAPI array items show as a generic object (`{}`).** A consequence of the above: the array
   request items are typed as `Type.Unknown()` so Ajv `removeAdditional: 'all'` does not strip
   their contents. The per-item shape is the entity `Create` schema, documented in the README.

## Tests

- `__tests__/unit/crud-plugin.batch.test.ts` (13 tests): single-object still works, array insert,
  atomicity / rollback on a mid-batch failure, `minItems`/`maxItems` bounds, per-item `400` with the
  `item[<index>]` message, tenant stamping, a characterization test proving unknown top-level fields
  are stripped on the single-object path (no mass-assignment via the union), and serialization tests
  proving the single-object `201` is serialized against a strict `Entity` while the array reply is
  returned with full fidelity.
- New `__tests__/unit/repositories/crud-create-client-threading.test.ts` and a new
  `database.logic.service` test for client-vs-pool routing.
- Existing rule/typology repository tests updated for the new optional `client` arg.
- Full suite: **723 passed / 35 suites**; coverage thresholds met; build clean.

## Checklist

- [x] `git commit -s` on every commit (DCO)
- [x] `npm test` green before push
- [x] Targets `dev`
