### PR TITLE
fix: restore Swagger UI docs by bumping @fastify/static to 9.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fastify/cors": "^11.0.1",
         "@fastify/response-validation": "^3.0.3",
         "@fastify/swagger": "^9.5.1",
-        "@fastify/swagger-ui": "^5.2.3",
+        "@fastify/swagger-ui": "^5.2.6",
         "@sinclair/typebox": "^0.34.41",
         "@tazama-lf/auth-lib": "4.0.0-rc.4",
         "@tazama-lf/frms-coe-lib": "8.1.0-rc.1",
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.1.tgz",
-      "integrity": "sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
       "funding": [
         {
           "type": "github",
@@ -1216,9 +1216,9 @@
       }
     },
     "node_modules/@fastify/swagger-ui": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-5.2.5.tgz",
-      "integrity": "sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-5.2.6.tgz",
+      "integrity": "sha512-OMnms0O5s9wb6wis/K5nlrAMLsgUbr1GA8uphM41IasWe3AFdgxz6r/3bA9HTxlDNUYc2FGGKeqMp3ntxmSiNA==",
       "funding": [
         {
           "type": "github",
@@ -1231,7 +1231,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@fastify/static": "^9.0.0",
+        "@fastify/static": "^9.1.2",
         "fastify-plugin": "^5.0.0",
         "openapi-types": "^12.1.3",
         "rfdc": "^1.3.1",
@@ -9294,9 +9294,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@fastify/cors": "^11.0.1",
     "@fastify/response-validation": "^3.0.3",
     "@fastify/swagger": "^9.5.1",
-    "@fastify/swagger-ui": "^5.2.3",
+    "@fastify/swagger-ui": "^5.2.6",
     "@sinclair/typebox": "^0.34.41",
     "@tazama-lf/auth-lib": "4.0.0-rc.4",
     "@tazama-lf/frms-coe-lib": "8.1.0-rc.1",


### PR DESCRIPTION
## What

Bumps `@fastify/swagger-ui` `^5.2.3` -> `^5.2.6`, which pulls `@fastify/static` `9.1.1` -> `9.1.3` into the lockfile. This restores the Swagger UI documentation at `/documentation/`, which currently renders blank.

Fixes #440.

## Why

`@fastify/swagger-ui` serves its bundled assets by registering `@fastify/static` inside an **encapsulated** child plugin (`prefix: '/static'` under `routePrefix: '/documentation'`). `@fastify/static@9.1.1` has a regression where **wildcard routes fail to register in encapsulated contexts**, so `/documentation/static/swagger-ui-bundle.js` and `swagger-ui.css` returned Fastify's default `"route not found"` 404 even though the files are present on disk. The HTML shell and the in-memory `swagger-initializer.js` kept working, which is why the page loaded but stayed blank.

Fixed upstream in `@fastify/static` **v9.1.2** (fastify/fastify-static#574, "resolve wildcard paths in encapsulated contexts"). `@fastify/swagger-ui` `lib/routes.js` is byte-identical between 5.2.5 and 5.2.6, so the swagger-ui bump is incidental - the transitive `@fastify/static >= 9.1.2` bump is the actual fix.

## Proof (isolated A/B)

Minimal Fastify 5 server using the exact deployed versions and admin-service's registration options, changing **only** `@fastify/static`:

| Endpoint | static 9.1.1 | static 9.1.3 |
| --- | --- | --- |
| `/documentation/` | 200 | 200 |
| `/documentation/static/swagger-initializer.js` | 200 | 200 |
| `/documentation/static/swagger-ui-bundle.js` | **404** | **200** |
| `/documentation/static/swagger-ui.css` | **404** | **200** |

## Diff scope

`package.json` (1 line) + `package-lock.json` (`@fastify/static` 9.1.1->9.1.3, `@fastify/swagger-ui` 5.2.5->5.2.6, one transitive `lru-cache` patch). No source changes.

## Testing

- `npm test` - 35 suites / 723 tests pass.
- Post-deploy: `curl http://192.168.1.222:5100/documentation/static/swagger-ui-bundle.js` should return 200 and the docs should render.

## Note

Also clears the open `@fastify/static <= 9.1.0` Dependabot alert. The broader security-alert backlog (mostly transitive via the `@tazama-lf/*` libs and the gRPC/protobuf stack) is intentionally out of scope for this focused docs fix and should be handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API documentation interface library dependency to the latest patch version for stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->