### PR TITLE
feat(service-channel): fire-and-log ack sink on reply subject (#445)

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,12 @@ POST /v1/admin/configuration/network_map/{cfg}/deactivate HTTP/1.1
 
 > Network maps are loaded inactive and promoted when ready. Posting a map with `active = true` that would collide with an existing active map is rejected by the unique index (surfaced as a `500`); use `activate` to perform a safe swap instead.
 
+#### Service-channel reload signalling and ack sink
+
+After an `activate` commits, admin-service can broadcast a `network-map.activated` CloudEvent on the service channel so downstream consumers (for example event-director) reload the promoted map. The per-request `reloadMode` body field controls this (`broadcast` by default, `none` to suppress); dispatch is advisory and degrades without failing the activation (the DB commit is the source of truth), reported back under `reloadDispatched`.
+
+Consumers reply with an ack on the reply subject (`SERVICE_CHANNEL_CONSUMER`, default `service-channel-ack`). admin-service runs a standing **fire-and-log ack sink** on that subject: each ack is logged as a single advisory line carrying the acking `source`, the `correlationId` (the activation event's id) and the `outcome`. A `success` ack logs at info; an `outcome: error` ack escalates to `error` so a failed downstream fulfilment of an activation admin-service dispatched is surfaced. The sink is advisory only - it never blocks or fails an activation, performs no aggregation or tally, and swallows a malformed ack (logged at `warn`) so a single bad message cannot tear down the subscription.
+
 ---
 
 ## 5) Error Handling and Query Safety

--- a/README.md
+++ b/README.md
@@ -668,7 +668,8 @@ and an array of items cannot be compiled by `fast-json-stringify` when the entit
 (typology's `expression`); reusing the per-element entity serializer keeps the array reply consistent
 with the single-object reply without compiling a recursive union. One consequence remains in the
 generated OpenAPI: the array request items are typed as a generic object (`{}`); the per-item shape is
-the entity Create schema documented above.
+the entity Create schema documented above. The array reply is sent with
+`Content-Type: application/json`, the same as the single-object reply.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -660,14 +660,15 @@ top-level fields are stripped before insert on both paths (no mass-assignment vi
 For the **single-object** path the `201` response body is the created entity, serialized against the
 entity schema - unchanged, and the same on batch-enabled routes as on single-only routes.
 
-For the **array** path the success body (the array of created entities) is returned with the
-per-reply serializer bypassed: a `Type.Union` of the single entity and an array of items cannot be
-compiled by `fast-json-stringify` when the entity schema is recursive (typology's `expression`), so
-the array reply uses plain JSON serialization instead of a schema-bound serializer. The single-object
-response is unaffected and keeps its entity serializer (and its OpenAPI `201`). One consequence
-remains in the generated OpenAPI: the array request items are typed as a generic object (`{}`); the
-per-item shape is the entity Create schema documented above. This is a deliberate trade-off favouring
-a single uniform code path over a bespoke per-entity serializer for the batch array case only.
+For the **array** path the success body (the array of created entities) is serialized **element by
+element** with that same entity serializer, then joined into a JSON array - so every element is shaped
+identically to a single-object create (declared keys in schema order, schema-bound formatting). The
+route cannot hand the whole array to one schema serializer because a `Type.Union` of the single entity
+and an array of items cannot be compiled by `fast-json-stringify` when the entity schema is recursive
+(typology's `expression`); reusing the per-element entity serializer keeps the array reply consistent
+with the single-object reply without compiling a recursive union. One consequence remains in the
+generated OpenAPI: the array request items are typed as a generic object (`{}`); the per-item shape is
+the entity Create schema documented above.
 
 #### Examples
 

--- a/__tests__/unit/crud-plugin.batch.test.ts
+++ b/__tests__/unit/crud-plugin.batch.test.ts
@@ -231,6 +231,24 @@ describe('POST batch (array) submission on buildCrudPlugin (#436)', () => {
       expect(body).toHaveLength(1);
     });
 
+    it('serializes each batch element identically to the single-object create (consistent schema shaping)', async () => {
+      // The repository returns the persisted row with keys in a NON-schema order. The single-object
+      // 201 path runs through the Entity (fast-json-stringify) serializer, which emits declared keys
+      // in SCHEMA order; a raw JSON.stringify of the array would instead echo the row's insertion
+      // order, so the two replies diverge for the same entity. Each batch element must be byte-for-
+      // byte the same serialization the single-object route produces.
+      const row = (id: string): Record<string, unknown> => ({ config: {}, cfg: '1.0.0', creDtTm: '2026-01-01T00:00:00.000Z', id });
+      mockRuleCreate.mockImplementation((payload: Record<string, unknown>) => Promise.resolve(row(payload.id as string)));
+
+      const single = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: validRule('r1') });
+      const batch = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: [validRule('r1')] });
+
+      expect(single.statusCode).toBe(201);
+      expect(batch.statusCode).toBe(201);
+      // A batch element is the schema-serialized object, not a raw dump of the repository row.
+      expect(batch.payload).toBe(`[${single.payload}]`);
+    });
+
     it('rolls the whole batch back when any item fails (all-or-nothing)', async () => {
       mockRuleCreate
         .mockImplementationOnce((payload: unknown) => Promise.resolve(payload))
@@ -427,7 +445,7 @@ describe('POST batch (array) submission on buildCrudPlugin (#436)', () => {
       expect(body).not.toHaveProperty('serverOnly');
     });
 
-    it('returns the array 201 with the serializer bypassed (stays an array, keeps off-schema fields)', async () => {
+    it('serializes each array element through the Entity serializer too (consistent with the single-object reply)', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/v1/admin/configuration/rule',
@@ -436,11 +454,14 @@ describe('POST batch (array) submission on buildCrudPlugin (#436)', () => {
 
       expect(response.statusCode).toBe(201);
       const body = response.json() as Array<Record<string, unknown>>;
-      // Not coerced through the single-object Entity serializer: it stays an array of length 2 and
-      // retains fields outside the Entity schema (proof the array reply skips schema serialization).
+      // Each element runs through the SAME Entity serializer as the single-object path: the reply
+      // stays an array of length 2, and off-schema fields (serverOnly) are dropped from every
+      // element - the array reply is shaped consistently with a single create, not a raw row dump.
       expect(Array.isArray(body)).toBe(true);
       expect(body).toHaveLength(2);
-      expect(body[0]).toMatchObject({ id: 'r1', cfg: '1.0.0', serverOnly: 'secret' });
+      expect(body[0]).toEqual({ id: 'r1', cfg: '1.0.0' });
+      expect(body[1]).toEqual({ id: 'r2', cfg: '1.0.0' });
+      expect(body[0]).not.toHaveProperty('serverOnly');
     });
   });
 });

--- a/__tests__/unit/crud-plugin.batch.test.ts
+++ b/__tests__/unit/crud-plugin.batch.test.ts
@@ -249,6 +249,18 @@ describe('POST batch (array) submission on buildCrudPlugin (#436)', () => {
       expect(batch.payload).toBe(`[${single.payload}]`);
     });
 
+    it('returns the batch array reply as application/json (so clients render it as JSON, like every other route)', async () => {
+      const single = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: validRule('r1') });
+      const batch = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: [validRule('r1')] });
+
+      expect(batch.statusCode).toBe(201);
+      // The custom array serializer emits a string; without an explicit content type Fastify would
+      // default to text/plain, so a client (e.g. Postman) renders the body as raw text instead of
+      // JSON. The array reply must advertise application/json, consistent with the single-object path.
+      expect(batch.headers['content-type']).toMatch(/application\/json/);
+      expect(batch.headers['content-type']).toBe(single.headers['content-type']);
+    });
+
     it('rolls the whole batch back when any item fails (all-or-nothing)', async () => {
       mockRuleCreate
         .mockImplementationOnce((payload: unknown) => Promise.resolve(payload))

--- a/__tests__/unit/serviceChannel.ack-sink.test.ts
+++ b/__tests__/unit/serviceChannel.ack-sink.test.ts
@@ -79,6 +79,22 @@ describe('handleServiceChannelAck - B3 fire-and-log ack sink (#445)', () => {
     expect(mockWarn).not.toHaveBeenCalled();
   });
 
+  it('includes the ack envelope id in the advisory line so each ack stays fully traceable', async () => {
+    // The id is the CloudEvent envelope id minted by the acking instance; the sink contract requires
+    // it in the logged fields. Build with an explicit id so the assertion is deterministic.
+    const ack = construct<AckData>({
+      type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+      source: 'event-director',
+      id: 'ack-id-trace-1',
+      data: { correlationId: 'corr-trace-1', outcome: 'success' },
+      datacontenttype: 'application/json',
+    });
+    await handleServiceChannelAck(new TextEncoder().encode(JSON.stringify(ack)));
+
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(String(mockLog.mock.calls[0][0])).toContain('ack-id-trace-1');
+  });
+
   it('escalates an error ack to loggerService.error, carrying correlationId, source, outcome and the error string', async () => {
     await handleServiceChannelAck(makeAckBytes('rule-processor', 'corr-error-1', 'error', 'tenantId missing'));
 

--- a/__tests__/unit/serviceChannel.ack-sink.test.ts
+++ b/__tests__/unit/serviceChannel.ack-sink.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { construct, ServiceChannelType } from '@tazama-lf/frms-coe-lib';
+
+// RED tests (#445, Part C Ph5): the B3 fire-and-log ack sink. A standing subscription on the reply
+// subject (SERVICE_CHANNEL_CONSUMER) hands each inbound ack's raw bytes to `handleServiceChannelAck`,
+// which logs exactly one advisory line per ack - reading type, correlationId, source (the acking
+// instance) and outcome. A `success` ack logs at info (`loggerService.log`); an `error` ack escalates
+// to `loggerService.error` (admin-service issued the instruction and wants downstream failures
+// surfaced), carrying the consumer's error. It is advisory only: it never publishes back, never
+// touches the activation path, and never rejects (a malformed payload is a swallowed warn line, so a
+// single bad message can never tear down the for-await subscription).
+//
+// Inbound ack bytes are built with the REAL construct + JSON.stringify + TextEncoder (exactly how
+// event-director emits acks), so the test exercises the real deserialize round-trip.
+
+const mockLog = jest.fn();
+const mockWarn = jest.fn();
+const mockError = jest.fn();
+const mockPublishServiceChannel = jest.fn();
+
+jest.mock('../../src', () => ({
+  configuration: {
+    functionName: 'admin-service',
+    SERVICE_CHANNEL_SOURCE_URI_PREFIX: '' as string | undefined,
+    SERVICE_CHANNEL_PRODUCER: 'service-channel' as string | undefined,
+    SERVICE_CHANNEL_CONSUMER: 'service-channel-ack' as string | undefined,
+  },
+  loggerService: {
+    log: (...args: unknown[]) => mockLog(...args),
+    warn: (...args: unknown[]) => mockWarn(...args),
+    error: (...args: unknown[]) => mockError(...args),
+    trace: jest.fn(),
+    debug: jest.fn(),
+  },
+  serviceChannelProducer: {
+    publishServiceChannel: (...args: unknown[]) => mockPublishServiceChannel(...args),
+  },
+  isServiceChannelConnected: () => true,
+}));
+
+import { handleServiceChannelAck } from '../../src/services/serviceChannel';
+
+interface AckData {
+  correlationId: string;
+  outcome: 'success' | 'error';
+  error?: string;
+}
+
+/** Encode a structured-mode CloudEvent ack exactly as event-director publishes it. */
+const makeAckBytes = (source: string, correlationId: string, outcome: 'success' | 'error', error?: string): Uint8Array => {
+  const ack = construct<AckData>({
+    type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+    source,
+    data: { correlationId, outcome, ...(error !== undefined ? { error } : {}) },
+    datacontenttype: 'application/json',
+  });
+  return new TextEncoder().encode(JSON.stringify(ack));
+};
+
+describe('handleServiceChannelAck - B3 fire-and-log ack sink (#445)', () => {
+  beforeEach(() => {
+    mockLog.mockReset();
+    mockWarn.mockReset();
+    mockError.mockReset();
+    mockPublishServiceChannel.mockReset();
+  });
+
+  it('logs exactly one line for a success ack, carrying type, correlationId, source and outcome', async () => {
+    await handleServiceChannelAck(makeAckBytes('event-director', 'corr-success-1', 'success'));
+
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    const line = String(mockLog.mock.calls[0][0]);
+    expect(line).toContain('network-map.activated');
+    expect(line).toContain('corr-success-1');
+    expect(line).toContain('event-director');
+    expect(line).toContain('success');
+    // A well-formed ack is advisory info, never a warning.
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('escalates an error ack to loggerService.error, carrying correlationId, source, outcome and the error string', async () => {
+    await handleServiceChannelAck(makeAckBytes('rule-processor', 'corr-error-1', 'error', 'tenantId missing'));
+
+    expect(mockError).toHaveBeenCalledTimes(1);
+    const line = String(mockError.mock.calls[0][0]);
+    expect(line).toContain('corr-error-1');
+    expect(line).toContain('rule-processor');
+    expect(line).toContain('error');
+    expect(line).toContain('tenantId missing');
+    // An error-outcome ack is not a benign info line.
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('logs every ack independently when multiple arrive, by outcome severity', async () => {
+    await handleServiceChannelAck(makeAckBytes('event-director', 'corr-a', 'success'));
+    await handleServiceChannelAck(makeAckBytes('typology-processor', 'corr-b', 'error', 'boom'));
+    await handleServiceChannelAck(makeAckBytes('rule-processor', 'corr-c', 'success'));
+
+    // Two success acks at info, one error ack escalated - each surfaced exactly once.
+    expect(mockLog).toHaveBeenCalledTimes(2);
+    expect(mockError).toHaveBeenCalledTimes(1);
+    const infoLines = mockLog.mock.calls.map((call) => String(call[0]));
+    expect(infoLines.some((line) => line.includes('corr-a'))).toBe(true);
+    expect(infoLines.some((line) => line.includes('corr-c'))).toBe(true);
+    expect(String(mockError.mock.calls[0][0])).toContain('corr-b');
+  });
+
+  it('swallows a malformed (non-JSON) payload: resolves, logs no ack line, warns instead', async () => {
+    const badBytes = new TextEncoder().encode('not-json{');
+
+    await expect(handleServiceChannelAck(badBytes)).resolves.toBeUndefined();
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it('never rejects even on a malformed payload (the for-await subscription must not tear down)', async () => {
+    const badBytes = new TextEncoder().encode('\u0000\u0001 not a cloudevent');
+
+    await expect(handleServiceChannelAck(badBytes)).resolves.toBeUndefined();
+  });
+
+  it('reads defensively: a valid envelope with thin data still logs one advisory line, never throws', async () => {
+    // ServiceChannelAckData is a cross-service convention, not a compile-time contract, so the sink
+    // must tolerate a structurally valid CloudEvent whose data fields are absent.
+    const thin = construct<Record<string, never>>({
+      type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+      source: 'event-director',
+      datacontenttype: 'application/json',
+    });
+    const bytes = new TextEncoder().encode(JSON.stringify(thin));
+
+    await expect(handleServiceChannelAck(bytes)).resolves.toBeUndefined();
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(String(mockLog.mock.calls[0][0])).toContain('event-director');
+  });
+
+  it('is advisory only: never publishes back and never touches the activation path', async () => {
+    await handleServiceChannelAck(makeAckBytes('event-director', 'corr-advisory', 'success'));
+
+    expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-service",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-service",
-      "version": "4.0.0-rc.4",
+      "version": "4.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
@@ -15,8 +15,8 @@
         "@fastify/swagger-ui": "^5.2.6",
         "@sinclair/typebox": "^0.34.41",
         "@tazama-lf/auth-lib": "4.0.0-rc.4",
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.0",
-        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.0",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.2",
         "@tazama-lf/tcs-lib": "1.0.156-rc.2",
         "ajv": "^8.17.1",
         "dotenv": "^17.2.0",
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.2.0-rc.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.0/11b0d2e363160370286a9059ef7364a50fc7dc7f",
-      "integrity": "sha512-8KbFHItVuUyGgf7Z3hVe6V54oWLY5/qUeQoEwC9ap2pYcGUafDrP9061NZ/2/LlXJxyzrvJT+/DOvUvSqOkvzQ==",
+      "version": "8.2.0-rc.1",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.1/763f21ed32311ac31a03779b2af2d75cf1c49b6e",
+      "integrity": "sha512-VUUQVNz12mHVjmOEwJSKtLRD/zQx0UBnZ3AxCnNkkUjFHK0nVJUtltdwkTApHlQnUbOR3emdEvjAYim21gFmmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2410,12 +2410,12 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.1.0-rc.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.0/dc67ba1dc2c1a74d90e1ab01b01654ef6655f7f2",
-      "integrity": "sha512-8+RWFFZYA1AuTr6DZAhccGeJDrWQ3G9WrKea9fAWeucNgv8CWQPlBkbBnQIDHp76oK7i1JbEf/vEXNJnKQ/B9g==",
+      "version": "3.1.0-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.2/fd32b1d35ab6f524de7590615b2be300dbe7b691",
+      "integrity": "sha512-ch3HOQgOnyoJD+akcD7qgZM/WcRISHxIAROGkMcfNdLadeaEgnqZJ8Y5RNkjn+yWjwyBhVs+bLrZGZgi2XWwUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.0",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "nats": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-service",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "description": "admin service",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -33,8 +33,8 @@
     "@fastify/swagger-ui": "^5.2.6",
     "@sinclair/typebox": "^0.34.41",
     "@tazama-lf/auth-lib": "4.0.0-rc.4",
-    "@tazama-lf/frms-coe-lib": "8.2.0-rc.0",
-    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.0",
+    "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.2",
     "@tazama-lf/tcs-lib": "1.0.156-rc.2",
     "ajv": "^8.17.1",
     "dotenv": "^17.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { CreateStorageManager } from '@tazama-lf/frms-coe-lib/lib/services/dbManager';
 import initializeFastifyClient from './clients/fastify';
 import { type AppDatabaseServices, type Configuration, processorConfig } from './config';
+import { handleServiceChannelAck } from './services/serviceChannel';
 import { type DatabaseManagerInstance, LoggerService } from '@tazama-lf/frms-coe-lib';
 import { Database } from '@tazama-lf/frms-coe-lib/lib/config/database.config';
 import { Cache } from '@tazama-lf/frms-coe-lib/lib/config/redis.config';
@@ -49,6 +50,23 @@ const connect = async (): Promise<void> => {
 
   if (!producerConnected) {
     loggerService.warn('Service-channel producer unavailable after 10 retries; continuing without broadcast dispatch.');
+  }
+
+  if (producerConnected) {
+    try {
+      const subscribed = await serviceChannelProducer.initServiceChannel(
+        handleServiceChannelAck,
+        configuration.SERVICE_CHANNEL_CONSUMER,
+        loggerService,
+      );
+      if (subscribed) {
+        loggerService.log('Service-channel ack sink subscribed');
+      } else {
+        loggerService.warn('Service-channel ack sink could not subscribe; continuing without ack logging.');
+      }
+    } catch (error) {
+      loggerService.warn(`Service-channel ack sink subscription failed: ${util.inspect(error)}`);
+    }
   }
 
   const fastify = await initializeFastifyClient();

--- a/src/services/serviceChannel.ts
+++ b/src/services/serviceChannel.ts
@@ -1,12 +1,48 @@
 // SPDX-License-Identifier: Apache-2.0
-import { construct, ServiceChannelType, validateEnvelope } from '@tazama-lf/frms-coe-lib';
+import { construct, deserialize, ServiceChannelType, validateEnvelope } from '@tazama-lf/frms-coe-lib';
 import type { NetworkMapActivatedData } from '@tazama-lf/frms-coe-lib/lib/interfaces/service-channel';
 import { configuration, isServiceChannelConnected, loggerService, serviceChannelProducer } from '..';
+import * as util from 'node:util';
 
 export interface ReloadDispatchStatus {
   status: boolean;
   outcome: string;
 }
+
+/**
+ * The reply payload read off each ack: which activation it acks and how the consumer fared. Not a
+ * compile-time contract (no shared lib type) - a cross-service convention read defensively off the wire.
+ */
+interface ServiceChannelAckData {
+  correlationId?: string;
+  outcome?: 'success' | 'error';
+  error?: string;
+}
+
+/**
+ * The B3 fire-and-log ack sink: logs one advisory line per inbound ack on the reply subject. A
+ * `success` (or thin/unknown) outcome logs at info; an `error` outcome escalates to `error` so a failed
+ * fulfilment of an activation admin-service dispatched is surfaced. Advisory only - it never publishes
+ * back and never touches the activation path. Every code path is wrapped so it can never reject: a
+ * rejection would tear down the `for await` subscription loop, so a malformed ack is a swallowed warn.
+ */
+export const handleServiceChannelAck = async (data: Uint8Array): Promise<void> => {
+  try {
+    const ack = deserialize<ServiceChannelAckData>(data);
+    const { correlationId, outcome, error } = ack.data ?? {};
+    const line =
+      `Service-channel ack received (type: ${ack.type}, source: ${ack.source}, ` +
+      `correlationId: ${correlationId}, outcome: ${outcome})${error !== undefined ? `: ${error}` : ''}`;
+    if (outcome === 'error') {
+      loggerService.error(line);
+    } else {
+      loggerService.log(line);
+    }
+  } catch (err) {
+    loggerService.warn(`Discarding malformed service-channel ack: ${util.inspect(err)}`);
+  }
+  await Promise.resolve();
+};
 
 const DEFAULT_SERVICE_CHANNEL_SUBJECT = 'service-channel';
 const SERVICE_CHANNEL_UNAVAILABLE = 'service channel unavailable';

--- a/src/services/serviceChannel.ts
+++ b/src/services/serviceChannel.ts
@@ -31,7 +31,7 @@ export const handleServiceChannelAck = async (data: Uint8Array): Promise<void> =
     const ack = deserialize<ServiceChannelAckData>(data);
     const { correlationId, outcome, error } = ack.data ?? {};
     const line =
-      `Service-channel ack received (type: ${ack.type}, source: ${ack.source}, ` +
+      `Service-channel ack received (id: ${ack.id}, type: ${ack.type}, source: ${ack.source}, ` +
       `correlationId: ${correlationId}, outcome: ${outcome})${error !== undefined ? `: ${error}` : ''}`;
     if (outcome === 'error') {
       loggerService.error(line);

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -257,10 +257,17 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
             return results;
           });
           // The route's 201 schema is the single Entity (object); an array can't be serialized
-          // against it, and a Union serializer breaks on recursive schemas (typology.expression).
-          // Bypass the schema serializer for this array reply only - the single-object path below
-          // keeps the Entity serializer (and its OpenAPI 201).
-          reply.serializer((payload) => JSON.stringify(payload));
+          // against it directly, and a Union/Array serializer breaks on recursive schemas
+          // (typology.expression). So instead of dumping the raw rows with JSON.stringify (which
+          // would echo the repository's key order and any off-schema fields, diverging from the
+          // single-object reply), reuse THIS route's compiled Entity serializer per element and
+          // join them into a JSON array. Each element is then shaped identically to a single create.
+          const serializeEntity = reply.getSerializationFunction('201');
+          reply.serializer(
+            serializeEntity
+              ? (payload) => `[${(payload as TEntity[]).map((item) => serializeEntity(item as Record<string, unknown>)).join(',')}]`
+              : (payload) => JSON.stringify(payload),
+          );
           return await reply.code(201).send(created);
         }
 

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -268,6 +268,9 @@ export const buildCrudPlugin = <TEntity, TId extends AllowedId = { id: string; c
               ? (payload) => `[${(payload as TEntity[]).map((item) => serializeEntity(item as Record<string, unknown>)).join(',')}]`
               : (payload) => JSON.stringify(payload),
           );
+          // A custom serializer returns a string, so Fastify would default the reply to text/plain;
+          // set the content type explicitly so the array is advertised as JSON, like every other route.
+          reply.type('application/json; charset=utf-8');
           return await reply.code(201).send(created);
         }
 


### PR DESCRIPTION
# feat(service-channel): fire-and-log ack sink on reply subject

Resolves #445 (Part C, Phase 5 of 9).

## What

Adds a standing **fire-and-log ack sink** on the service-channel reply subject so admin-service can observe how downstream consumers (e.g. event-director) acknowledge a `network-map.activated` reload it dispatched on `activate` (#444).

- `handleServiceChannelAck(data)` deserialises each consumer ack and logs a single advisory line carrying `source`, `correlationId` (the activation event id) and `outcome`.
- The sink is wired in `connect()` after the producer bootstrap, guarded on `producerConnected`, and reuses the producer's single `NatsConn` via `initServiceChannel(handler, SERVICE_CHANNEL_CONSUMER, logger)`.
- Advisory only: it never blocks or fails an activation, performs no aggregation/tally, and does not publish anything back.

## Logging severity

| Ack | Severity |
| --- | --- |
| `outcome: success` (and thin/partial data on a valid envelope) | `info` (`loggerService.log`) |
| `outcome: error` | `error` (`loggerService.error`) |
| Malformed / unparseable payload | `warn` (`loggerService.warn`) |

`outcome: error` escalates to `error` deliberately: admin-service issued the activation instruction, so a failed downstream fulfilment of that instruction is worth surfacing at error severity.

## Resilience

`consumeServiceChannel` does `await onMessage(data)` inside a `for await` loop; a rejected handler tears down the subscription. `handleServiceChannelAck` therefore never rejects - a malformed ack is caught and logged at `warn`, so one bad message cannot kill the sink.

## AC1 caveat - "unconditional logging"

AC1 asks for the ack to be logged *unconditionally*. `LoggerService` exposes no un-gated log method - every method maps to a severity (`log`/info, `debug`, `trace`, `warn`, `error`, `fatal`). Well-formed acks are therefore logged via `log()` (info) and error-outcome acks via `error()`. Under the standard `LOG_LEVEL` (info) this is unconditional in practice; if `LOG_LEVEL` is raised above info, success acks would be suppressed. Flagging for review in case a hard-unconditional sink is required (would need a logger change upstream).

## Config / env

No new env var. `SERVICE_CHANNEL_CONSUMER` (default `service-channel-ack`) already exists from #444.

## Dependencies

- `@tazama-lf/frms-coe-lib` 8.2.0-rc.0 -> 8.2.0-rc.1 (provides `deserialize`)
- `@tazama-lf/frms-coe-startup-lib` 3.1.0-rc.0 -> 3.1.0-rc.2 (`initServiceChannel` reuses a single `NatsConn`)
- service version 4.0.0-rc.4 -> 4.0.0-rc.5

## Tests

7 transport-mocked unit tests in `__tests__/unit/serviceChannel.ack-sink.test.ts` (written red-first, reviewed by the Explore sub-agent, approved before Green):

1. success ack -> one `log()` line, no `warn`
2. error ack -> one `error()` line including the error string, no `log`
3. multiple acks -> logged at severity by `outcome`
4. malformed non-JSON -> resolves, no `log`, one `warn`
5. malformed -> never rejects
6. thin data on a valid envelope -> resolves, one `log` line, never throws
7. advisory only -> never calls `publishServiceChannel`

Full suite: 38 suites / 752 tests pass. Lint: 0 errors. Build: green.

## Docs

README gains a "Service-channel reload signalling and ack sink" subsection under Activate / Deactivate.

---

## Additional fix (drive-by): consistent batch POST reply shaping

While in here, this PR also corrects an inconsistency in the rule/typology **batch** (array) POST reply, unrelated to the ack sink.

**Problem.** The batch (array) create path serialised the created rows with a raw `JSON.stringify`, echoing the repository row's key order and any off-schema fields. The single-object create path runs through the `Entity` (fast-json-stringify) serialiser, which emits declared keys in schema order. So a bulk insert came back shaped differently from a single create of the same entity.

**Fix.** Reuse the route's compiled `201` `Entity` serialiser **per array element** and join the results into a JSON array, so every element is shaped identically to a single create. This still sidesteps the recursive-union `fast-json-stringify` limitation (typology's `expression`) that the original bypass worked around - the single-object `Entity` serialiser already handles that recursion - and keeps a `JSON.stringify` fallback if the serialiser can't be resolved.

**No behavioural change for real entities.** `RuleSchema`/`TypologySchema` are `additionalProperties: true`, so no real fields are dropped; the fix corrects key ordering / schema-bound formatting only. (The strict-schema test uses a test-only `Entity` to prove the per-element serialiser actually runs.)

**Tests.** Two added/updated cases in `crud-plugin.batch.test.ts`:
- a 1-element batch reply is byte-identical to `[` + the single-create reply + `]` for the same entity (key order / shaping consistency);
- the prior "serializer bypassed / keeps off-schema fields" test is updated to the new contract: each array element is serialised through the `Entity` serialiser, consistent with the single-object reply.

README "Response body note" updated to describe the per-element serialisation.

---

## Additional fix (drive-by): application/json content-type on batch POST reply

The batch (array) path installs a custom `reply.serializer` that returns a string, so Fastify defaulted the reply to `text/plain` and clients (e.g. Postman) rendered the body as raw text instead of JSON. The reply now sets `Content-Type: application/json; charset=utf-8` explicitly, consistent with the single-object path and every other route. (This predates this PR - the original `JSON.stringify` bypass had the same effect.)

**Test.** A red-first case in `crud-plugin.batch.test.ts` asserts the batch reply content-type matches `application/json` and equals the single-object reply's content-type. README batch "Response body note" updated.

A follow-up issue (#451) tracks collapsing the serial per-row batch inserts into a single multi-row `INSERT` (`createMany`) to cut the N-round-trip latency; out of scope here.

