### PR TITLE
feat(service-channel): dedicated network map reload endpoint with loud 503

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,12 @@ ENV RAW_HISTORY_DATABASE_USER=''
 ENV RAW_HISTORY_DATABASE_PASSWORD=''
 ENV RAW_HISTORY_DATABASE_HOST=''
 
+# SIMULATION_DATABASE is intentionally left blank: there is no simulation DB for this service yet.
+# frms-coe-lib skips the simulation store entirely when the db-name var is empty (CreateStorageManager:
+# `Database.SIMULATION && !process.env.SIMULATION_DATABASE`), so a blank name avoids requiring a HOST.
+# Do NOT set this to a non-empty value until the simulation DB is split out into its own service.
 ENV SIMULATION_DATABASE_PORT='5432'
-ENV SIMULATION_DATABASE='simulation'
+ENV SIMULATION_DATABASE=''
 ENV SIMULATION_DATABASE_CERT_PATH='/usr/local/share/ca-certificates/ca-certificates.crt'
 ENV SIMULATION_DATABASE_USER=''
 ENV SIMULATION_DATABASE_PASSWORD=''

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Each repository implementation follows a standardized interface, ensuring consis
 
 | No. | Config  | File name | Endpoint | Methods | 
 | --- | --- | --------- | -------- | ----------- | 
-| 1. | Network Map | network.map.repository | `/v1/admin/configuration/network_map` |  GET,POST,PUT,DEL, plus `POST {cfg}/activate` and `POST {cfg}/deactivate` |
+| 1. | Network Map | network.map.repository | `/v1/admin/configuration/network_map` |  GET,POST,PUT,DEL, plus `POST {cfg}/activate`, `POST {cfg}/deactivate` and `POST /reload` |
 | 2. | Rule Configuration |  rule.config.repository | `/v1/admin/configuration/rule` |  GET,POST (single or batch),PUT,DEL |
 | 3. | Typology Configuration | typology.config.repository | `/v1/admin/configuration/typology` | GET,POST (single or batch),PUT,DEL |
 
@@ -758,6 +758,21 @@ After an `activate` commits, admin-service can broadcast a `network-map.activate
 > Cascade ack-correlation assumes the deploy convention `typology.id == FUNCTION_NAME`: a typology-processor's ack `source` is its `FUNCTION_NAME`, and the typology-processor quorum is computed from the distinct `typology.id` values in the activated map, so the two must match for an ack to count toward quorum. A map reaching the typology-processor tier with zero typologies is a configuration error the admin-service configuration endpoints are expected to reject upfront; the cascade tolerates it by skipping that tier.
 
 Consumers reply with an ack on the reply subject (`SERVICE_CHANNEL_CONSUMER`, default `service-channel-ack`). admin-service runs a standing **fire-and-log ack sink** on that subject: each ack is logged as a single advisory line carrying the acking `source`, the `correlationId` (the activation event's id) and the `outcome`. A `success` ack logs at info; an `outcome: error` ack escalates to `error` so a failed downstream fulfilment of an activation admin-service dispatched is surfaced. The sink is advisory only - it never blocks or fails an activation, performs no aggregation or tally, and swallows a malformed ack (logged at `warn`) so a single bad message cannot tear down the subscription. When a `cascade` is in flight, the sink additively forwards each **successful** ack (by `correlationId` and `source`) to the cascade orchestrator so the wavefront can advance; an `error` ack still logs at `error` but does not count toward a tier's quorum (delivery is not adoption).
+
+#### Dedicated reload endpoint (no DB write, loud 503)
+
+```http
+POST /v1/admin/configuration/network_map/reload HTTP/1.1
+```
+
+The reload endpoint re-dispatches a `network-map.activated` signal for the tenant's **current active** network map without changing any state. It is a control-plane action - no row is written, no activation is performed - for when a consumer needs to be (re-)driven to reload the map that is already active (for example a consumer that started late, missed the original broadcast, or needs a fresh cascade). It is a sibling of `activate` rather than part of it: there is no `{cfg}` in the path because the endpoint always operates on whichever map is active for the tenant, resolved server-side via the single-active-per-tenant index (`getActive`). When the tenant has no active map there is nothing to reload, so the endpoint returns `404` (`No active network map`). The `cfg` and `tenantId` carried on the dispatched CloudEvent are derived from the fetched active map, not from the request.
+
+Its contract deliberately diverges from `activate` in two ways:
+
+- **`reloadMode` is required**, and must be `broadcast` or `cascade`. There is no default. A missing or unrecognised mode returns `400`. `reloadMode: 'none'` also returns `400` with a tailored message - on a dedicated reload endpoint `none` would dispatch nothing, so accepting it as a silent success would be a footgun (an operator who fat-fingered `none` would believe a reload had fired when it had not). On `activate`, `none` is legitimate (suppress the side-channel signal while still committing the activation); here it has no meaning.
+- **Dispatch failure is loud.** Unlike `activate`, where signalling is advisory and degrades to a `reloadDispatched: { status: false }` field on an otherwise-successful `200`, the reload endpoint has no underlying DB commit to fall back on - the dispatch *is* the whole operation. So when the service channel is unavailable it returns **`503`** with `{ error, event: 'network-map.activated', dispatched: false }` (and logs at `warn`), making a failed reload impossible to miss. A successful dispatch returns `200` with `{ event: 'network-map.activated', dispatched: true, outcome }`. `broadcast` and `cascade` share this success/failure shape; `cascade` drives the same ordered, ack-gated wavefront described above and reports `outcome: 'cascade initiated'` on success.
+
+The endpoint requires the `POST_V1_ADMIN_CONFIGURATION_NETWORK_MAP_RELOAD` privilege and is served by a dedicated plugin (`buildServiceChannelPlugin`) kept separate from the CRUD plugin, since it performs no persistence.
 
 ---
 

--- a/__tests__/unit/network-map-reload.service-channel.test.ts
+++ b/__tests__/unit/network-map-reload.service-channel.test.ts
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import Fastify, { type FastifyInstance } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+
+// RED tests (#447, Part C Ph9): a DEDICATED operator re-dispatch endpoint
+//   POST /v1/admin/configuration/network_map/reload
+// that re-fires `network-map.activated` for the tenant's CURRENTLY ACTIVE map. Publishing the event is
+// the WHOLE operation (no DB write), so unlike the activate side-effect (2xx-and-flag) this path fails
+// LOUDLY with a retryable 503 when the broker is unreachable.
+//
+// Contract pinned by these tests (final design, diverging from the issue's original "optional, default
+// broadcast" phrasing):
+//  - `reloadMode` is REQUIRED and must be one of { broadcast, cascade }. Missing body / `none` / any
+//    other value -> 400 (a dedicated dispatch endpoint has no neutral "do nothing" reload).
+//  - The endpoint takes NO `:cfg` param. It fetches the tenant's single active map via the new repo
+//    method `getActive(tenantId)` (DB highlander: at most one active map per tenant). No active map -> 404.
+//  - `cfg`/`tenantId` for the published event are DERIVED FROM THE FETCHED MAP, never from the request
+//    path, so the dispatch always matches what is actually active.
+//  - Broker healthy with no listener is still a success (core NATS: no PubAck, no no-responders signal).
+//
+// The seam under test is the producer primitive `publishServiceChannel(bytes, subject)` plus the live
+// connection-state accessor `isServiceChannelConnected()` (same seam the Phase 1 / Phase 8 route tests
+// use), so the real `publishNetworkMapActivated` / `dispatchCascade` run end-to-end - the test asserts
+// the WIRE contract, not which helper the handler happens to call.
+
+const mockGetActive = jest.fn();
+const mockPublishServiceChannel = jest.fn();
+const mockWarn = jest.fn();
+let mockChannelConnected = true;
+
+const DEFAULT_CONFIG = {
+  AUTHENTICATED: false,
+  functionName: 'admin-service',
+  SERVICE_CHANNEL_SOURCE_URI_PREFIX: '' as string | undefined,
+  SERVICE_CHANNEL_PRODUCER: 'service-channel' as string | undefined,
+  SERVICE_CHANNEL_CONSUMER: 'service-channel-ack' as string | undefined,
+};
+const mockConfiguration = { ...DEFAULT_CONFIG };
+
+jest.mock('../../src', () => ({
+  configuration: mockConfiguration,
+  loggerService: {
+    log: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    warn: (...args: unknown[]) => mockWarn(...args),
+  },
+  serviceChannelProducer: {
+    publishServiceChannel: (...args: unknown[]) => mockPublishServiceChannel(...args),
+  },
+  isServiceChannelConnected: () => mockChannelConnected,
+}));
+
+jest.mock('../../src/repositories/configuration/network.map.repository', () => ({
+  NetworkMapRepo: {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    activate: jest.fn(),
+    deactivate: jest.fn(),
+    getActive: (...args: unknown[]) => mockGetActive(...args),
+  },
+}));
+
+import { buildServiceChannelPlugin } from '../../src/utils/service-channel-routes';
+import { NetworkMapRepo } from '../../src/repositories/configuration/network.map.repository';
+
+const RELOAD_URL = '/v1/admin/configuration/network_map/reload';
+const ACTIVATED_EVENT = 'network-map.activated';
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const makeMap = (cfg: string, tenantId = 'DEFAULT'): NetworkMap =>
+  ({
+    active: true,
+    cfg,
+    tenantId,
+    creDtTm: '2024-01-01T00:00:00.000Z',
+    updDtTm: '2024-06-01T12:00:00.000Z',
+    messages: [],
+  }) as unknown as NetworkMap;
+
+const decodePublishedEvent = (callIndex = 0): Record<string, unknown> => {
+  const call = mockPublishServiceChannel.mock.calls[callIndex] as [Uint8Array, string?] | undefined;
+  expect(call).toBeDefined();
+  return JSON.parse(new TextDecoder().decode((call as [Uint8Array, string?])[0])) as Record<string, unknown>;
+};
+
+const tick = async (): Promise<void> => {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+};
+
+describe('POST /v1/admin/configuration/network_map/reload (#447 - dedicated reload, loud 503)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+    const ajv = new Ajv({ removeAdditional: 'all', useDefaults: true, coerceTypes: 'array', strictTuples: false });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildServiceChannelPlugin({
+        prefix: '/v1/admin/configuration/network_map',
+        repo: NetworkMapRepo,
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockGetActive.mockReset();
+    mockPublishServiceChannel.mockReset();
+    mockWarn.mockReset();
+    mockChannelConnected = true;
+    Object.assign(mockConfiguration, DEFAULT_CONFIG);
+  });
+
+  describe('reloadMode is required and narrowed to { broadcast, cascade } -> 400', () => {
+    it('rejects a request with no body and neither fetches nor publishes', async () => {
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL });
+
+      expect(response.statusCode).toBe(400);
+      // The generic invalid-value message names the only valid options.
+      expect(response.json().message).toMatch(/broadcast/);
+      expect(response.json().message).toMatch(/cascade/);
+      expect(mockGetActive).not.toHaveBeenCalled();
+      expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+    });
+
+    it('rejects reloadMode: none with a none-aware message (no neutral reload on a dedicated dispatch endpoint)', async () => {
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'none' } });
+
+      expect(response.statusCode).toBe(400);
+      // `none` is a near-miss (a legal reloadMode on activate), so it gets a tailored message that
+      // explains why it does not apply here - distinct from the generic invalid-value message.
+      expect(response.json().message).toMatch(/none/i);
+      expect(mockGetActive).not.toHaveBeenCalled();
+      expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown reloadMode value', async () => {
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'bogus' } });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().message).toMatch(/broadcast/);
+      expect(response.json().message).toMatch(/cascade/);
+      expect(mockGetActive).not.toHaveBeenCalled();
+      expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('no active map for the tenant -> 404 (the active=true query is the gate)', () => {
+    it('returns 404 with a descriptive message and never publishes', async () => {
+      mockGetActive.mockResolvedValue(null);
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'broadcast' } });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toMatchObject({ message: 'No active network map' });
+      // The route must exist and delegate to getActive scoped by the request tenant.
+      expect(mockGetActive).toHaveBeenCalledWith('DEFAULT');
+      expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reloadMode: broadcast re-fires the active map -> 200', () => {
+    it('publishes exactly one event and reports dispatched: true / published', async () => {
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'broadcast' } });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockPublishServiceChannel).toHaveBeenCalledTimes(1);
+      expect(response.json()).toMatchObject({ event: ACTIVATED_EVENT, dispatched: true, outcome: 'published' });
+    });
+
+    it('populates the CloudEvents envelope from the FETCHED active map (no :cfg param exists)', async () => {
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'broadcast' } });
+
+      const event = decodePublishedEvent();
+      expect(event.specversion).toBe('1.0');
+      expect(event.type).toBe('org.tazama.network-map.activated');
+      expect(event.source).toBe('admin-service');
+      expect(event.subject).toBe('DEFAULT/2.0.0');
+      expect(event.datacontenttype).toBe('application/json');
+      expect(event.data).toEqual({ cfg: '2.0.0', tenantId: 'DEFAULT' });
+      expect(typeof event.id).toBe('string');
+      expect((event.id as string).length).toBeGreaterThan(0);
+      expect(event.time as string).toMatch(ISO_8601);
+      expect(event).not.toHaveProperty('kind');
+      expect(event).not.toHaveProperty('audience');
+    });
+
+    it('derives cfg AND tenantId from the active map, never from the request path', async () => {
+      // Request tenant defaults to DEFAULT, but the active map belongs to BANK1: the published event
+      // must reflect the MAP, proving the dispatch can never point at a stale/wrong cfg or tenant.
+      mockGetActive.mockResolvedValue(makeMap('3.1.0', 'BANK1'));
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'broadcast' } });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockGetActive).toHaveBeenCalledWith('DEFAULT');
+      const event = decodePublishedEvent();
+      expect(event.subject).toBe('BANK1/3.1.0');
+      expect(event.data).toEqual({ cfg: '3.1.0', tenantId: 'BANK1' });
+    });
+
+    it('treats a healthy-broker publish as dispatched even though no consumer is simulated', async () => {
+      // Core NATS has no PubAck and no no-responders signal, so "nobody subscribed" is invisible and
+      // correctly a success - exactly what a healthy publish models here.
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'broadcast' } });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ dispatched: true });
+    });
+  });
+
+  describe('reloadMode: cascade runs the detached audience-addressed wavefront -> 200', () => {
+    it('returns an immediate cascade initiated status', async () => {
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'cascade' } });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ event: ACTIVATED_EVENT, dispatched: true, outcome: 'cascade initiated' });
+    });
+
+    it('starts the wavefront by addressing the event-adjudicator tier first', async () => {
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'cascade' } });
+      await tick();
+
+      expect(mockPublishServiceChannel).toHaveBeenCalled();
+      const event = decodePublishedEvent(0);
+      expect(event.audience).toBe('event-adjudicator');
+      // The wavefront must carry the FETCHED map's identity, exactly as broadcast does.
+      expect(event.subject).toBe('DEFAULT/2.0.0');
+      expect(event.data).toEqual({ cfg: '2.0.0', tenantId: 'DEFAULT' });
+    });
+  });
+
+  describe('producer disconnected -> loud, retryable 503 (publishing IS the whole operation)', () => {
+    it('fails loudly with 503 for broadcast and never publishes', async () => {
+      mockChannelConnected = false;
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'broadcast' } });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toMatchObject({
+        error: 'service channel unavailable',
+        event: ACTIVATED_EVENT,
+        dispatched: false,
+      });
+      expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+    });
+
+    it('fails loudly with 503 for cascade and starts no orchestrator', async () => {
+      mockChannelConnected = false;
+      mockGetActive.mockResolvedValue(makeMap('2.0.0'));
+
+      const response = await app.inject({ method: 'POST', url: RELOAD_URL, payload: { reloadMode: 'cascade' } });
+      await tick();
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toMatchObject({
+        error: 'service channel unavailable',
+        event: ACTIVATED_EVENT,
+        dispatched: false,
+      });
+      expect(mockPublishServiceChannel).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/unit/repositories/network.map.repository.test.ts
+++ b/__tests__/unit/repositories/network.map.repository.test.ts
@@ -234,6 +234,38 @@ describe('NetworkMapRepository', () => {
     });
   });
 
+  describe('getActive', () => {
+    it('should return the tenant single active map, querying on the active flag (highlander)', async () => {
+      const configuration = createMockNetworkMap();
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [{ configuration }],
+        rowCount: 1,
+      });
+
+      const result = await NetworkMapRepo.getActive!(mockTenantId);
+
+      expect(result).toEqual(configuration);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(
+        {
+          text: 'SELECT configuration FROM network_map WHERE tenantId = $1 AND active = true LIMIT 1;',
+          values: [mockTenantId],
+        },
+        'configuration',
+      );
+    });
+
+    it('should return null when the tenant has no active map', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await NetworkMapRepo.getActive!(mockTenantId);
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('create', () => {
     it('should set both creDtTm and updDtTm to the same ISO 8601 timestamp', async () => {
       // Mock Date.prototype.toISOString to return predictable timestamp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-service",
-  "version": "4.0.0-rc.7",
+  "version": "4.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-service",
-      "version": "4.0.0-rc.7",
+      "version": "4.0.0-rc.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-service",
-  "version": "4.0.0-rc.7",
+  "version": "4.0.0-rc.8",
   "description": "admin service",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/repositories/configuration/network.map.repository.ts
+++ b/src/repositories/configuration/network.map.repository.ts
@@ -33,6 +33,23 @@ export const NetworkMapRepo: CrudRepository<NetworkMap, ConfigVersion> = {
     return queryRes.rows.length > 0 ? queryRes.rows[0].configuration : null;
   },
 
+  // Fetch the tenant's single active network map. The partial unique index
+  // `idx_networkmap_active_tenant` enforces at most one active map per tenant, so this query
+  // returns 0 or 1 row - the result itself is the existence gate (a missing active map is null,
+  // not an error). `active` is a generated STORED column, so it is filtered directly. LIMIT 1 is
+  // defensive belt-and-braces against the (index-prevented) two-active case.
+  getActive: async function (tenantId: string): Promise<NetworkMap | null> {
+    const queryRes = await handlePostExecuteSqlStatement<{ configuration: NetworkMap }>(
+      {
+        text: 'SELECT configuration FROM network_map WHERE tenantId = $1 AND active = true LIMIT 1;',
+        values: [tenantId],
+      } satisfies PgQueryConfig,
+      'configuration',
+    );
+
+    return queryRes.rows.length > 0 ? queryRes.rows[0].configuration : null;
+  },
+
   create: async function (payload: NetworkMap, tenantId: string): Promise<NetworkMap> {
     payload.tenantId = tenantId;
 

--- a/src/repositories/repository.base.ts
+++ b/src/repositories/repository.base.ts
@@ -42,4 +42,7 @@ export interface CrudRepository<TEntity, TId extends AllowedId = Node> {
   // implement these; the CRUD factory registers the activate/deactivate routes only when present.
   activate?: (id: TId) => Promise<TEntity | null>;
   deactivate?: (id: TId) => Promise<TEntity | null>;
+  // Fetch the tenant's single active entity. Only meaningful for entities with a single-active
+  // invariant (network_map); the DB enforces at most one active row per tenant, so this returns 0 or 1.
+  getActive?: (tenantId: string) => Promise<TEntity | null>;
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -83,6 +83,7 @@ import {
   TypologyListQuery,
 } from './schemas';
 import { buildCrudPlugin } from './utils/crud-schema';
+import { buildServiceChannelPlugin } from './utils/service-channel-routes';
 import { SetOptionsBodyAndParams } from './utils/schema-utils';
 import { withConfigurationTransaction } from './services/database.logic.service';
 
@@ -153,6 +154,15 @@ function Routes(fastify: FastifyInstance): void {
       repo: NetworkMapRepo,
       schemas: { Entity: NetworkMapSchema, Create: NetworkMapSchema, Update: NetworkMapSchema, Query: NetworkMapListQuery },
       idParam: { kind: 'cfg' },
+    }),
+  );
+
+  // Dedicated no-DB-write reload endpoint (POST <prefix>/reload): re-fires network-map.activated for
+  // the tenant's active map with a loud, retryable 503 when the service channel is down (#447).
+  fastify.register(
+    buildServiceChannelPlugin({
+      prefix: '/v1/admin/configuration/network_map',
+      repo: NetworkMapRepo,
     }),
   );
 

--- a/src/utils/crud-schema.ts
+++ b/src/utils/crud-schema.ts
@@ -55,8 +55,9 @@ const DefaultQuery = Type.Object({
 });
 
 // Shared error body for every CRUD route, so the documented 400/404 shapes stay consistent in one
-// place and surface a description in the generated OpenAPI spec.
-const ErrorResponse = Type.Object(
+// place and surface a description in the generated OpenAPI spec. Exported so sibling plugins (e.g. the
+// service-channel reload route) reuse the exact same error shape.
+export const ErrorResponse = Type.Object(
   { message: Type.String({ description: 'Human-readable description of why the request failed.' }) },
   { description: 'Standard error response returned for validation (400) and not-found (404) errors.' },
 );

--- a/src/utils/service-channel-routes.ts
+++ b/src/utils/service-channel-routes.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Type } from '@sinclair/typebox';
+import type { FastifyInstance, FastifyPluginAsync, RawServerDefault } from 'fastify';
+import fp from 'fastify-plugin';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { NetworkMap } from '@tazama-lf/frms-coe-lib/lib/interfaces/NetworkMap';
+import { configuration, loggerService } from '..';
+import { tokenHandler } from '../auth/authHandler';
+import type { ITenantRequest } from '../interface/ITenantRequest';
+import { validateTenantMiddleware } from '../middleware/tenantMiddleware';
+import type { AllowedId, CrudRepository } from '../repositories/repository.base';
+import { dispatchCascade } from '../services/cascade';
+import { publishNetworkMapActivated } from '../services/serviceChannel';
+import { ErrorResponse } from './crud-schema';
+
+interface BuildServiceChannelOptions<TEntity, TId extends AllowedId> {
+  prefix: string;
+  repo: CrudRepository<TEntity, TId>;
+}
+
+// The logical event name reported back to the operator (the CloudEvents `type` on the wire is the
+// fully-qualified `org.tazama.network-map.activated`; this is the short, contract-stable label).
+const RELOAD_EVENT = 'network-map.activated';
+
+// `reloadMode` is REQUIRED here and narrowed to { broadcast, cascade } - unlike the activate route,
+// where it is optional (default broadcast) and also accepts `none`. A dedicated dispatch endpoint has
+// no neutral "do nothing" reload, so a missing / `none` / unknown value is a 400. `none` is a near-miss
+// (a legal value on activate) so it gets a tailored message distinguishing it from outright garbage.
+const VALID_MODES = 'reloadMode is required and must be one of: broadcast, cascade';
+const NONE_NOT_APPLICABLE =
+  "reloadMode 'none' does not apply to the reload endpoint - it would dispatch nothing; use 'broadcast' or 'cascade'";
+
+const ReloadResponse = Type.Object(
+  {
+    event: Type.String({ description: 'The logical event re-dispatched (network-map.activated).' }),
+    dispatched: Type.Boolean({ description: 'True when the event was handed to the broker.' }),
+    outcome: Type.String({ description: 'published (broadcast) or cascade initiated (cascade).' }),
+  },
+  { description: 'Successful re-dispatch of the tenant active map reload event.' },
+);
+
+const ReloadUnavailable = Type.Object(
+  {
+    error: Type.String({ description: 'Why the dispatch could not be performed.' }),
+    event: Type.String(),
+    dispatched: Type.Boolean({ description: 'Always false - nothing reached the broker.' }),
+  },
+  { description: 'Loud, retryable 503 returned when the service channel is unavailable.' },
+);
+
+// A DEDICATED service-channel reload plugin, kept apart from buildCrudPlugin because the reload is a
+// no-DB-write control-plane signal: it re-fires `network-map.activated` for the tenant's CURRENTLY
+// ACTIVE map and nothing else. Publishing IS the whole operation, so a broker-down dispatch fails
+// LOUDLY with a retryable 503 (not a 2xx-and-flag, as the activate side-effect does). The route is only
+// registered for a repo that exposes the single-active read `getActive` (network_map).
+export const buildServiceChannelPlugin = <TEntity, TId extends AllowedId = { id: string; cfg: string; tenantId: string }>(
+  opts: BuildServiceChannelOptions<TEntity, TId>,
+): FastifyPluginAsync => {
+  const plugin: FastifyPluginAsync = async (app: FastifyInstance<RawServerDefault, IncomingMessage, ServerResponse>) => {
+    const { prefix, repo } = opts;
+    const getActiveFn = repo.getActive;
+    if (!getActiveFn) return;
+
+    // AUTH:EXAMPLE(POST_V1_ADMIN_CONFIGURATION_NETWORK_MAP_RELOAD)
+    const privilege = `POST${prefix.replaceAll('/', '_').toUpperCase()}_RELOAD`;
+
+    app.post(
+      `${prefix}/reload`,
+      {
+        schema: {
+          tags: ['service-channel'],
+          response: { 200: ReloadResponse, 400: ErrorResponse, 404: ErrorResponse, 503: ReloadUnavailable },
+        },
+        preHandler: configuration.AUTHENTICATED ? [validateTenantMiddleware, tokenHandler(privilege)] : [validateTenantMiddleware],
+      },
+      async (req, reply) => {
+        const { tenantId } = req as ITenantRequest;
+
+        if (req.body !== undefined && (typeof req.body !== 'object' || req.body === null || Array.isArray(req.body))) {
+          return await reply.code(400).send({ message: VALID_MODES });
+        }
+
+        const { reloadMode } = (req.body ?? {}) as Record<string, unknown>;
+        if (reloadMode === 'none') {
+          return await reply.code(400).send({ message: NONE_NOT_APPLICABLE });
+        }
+        if (reloadMode !== 'broadcast' && reloadMode !== 'cascade') {
+          return await reply.code(400).send({ message: VALID_MODES });
+        }
+
+        // The tenant's single active map (highlander). A null result is the existence gate: there is
+        // nothing to reload, so 404 - no separate active-state guard is needed.
+        const active = await getActiveFn(tenantId);
+        if (!active) return await reply.code(404).send({ message: 'No active network map' });
+
+        // cfg/tenantId are taken from the FETCHED map (the source of truth for what is active), never
+        // from the request - the dispatch can therefore never point at a stale or wrong cfg.
+        const map = active as unknown as NetworkMap;
+        const resolvedTenant = typeof map.tenantId === 'string' ? map.tenantId : tenantId;
+
+        const dispatched =
+          reloadMode === 'cascade'
+            ? dispatchCascade(map, map.cfg, resolvedTenant)
+            : await publishNetworkMapActivated(map.cfg, resolvedTenant);
+
+        // Publishing IS the whole operation (no DB write to fall back on), so a degraded dispatch is a
+        // hard, retryable 503 - never a silent success.
+        if (!dispatched.status) {
+          loggerService.warn(`Network-map reload dispatch failed: ${dispatched.outcome}`);
+          return await reply.code(503).send({ error: dispatched.outcome, event: RELOAD_EVENT, dispatched: false });
+        }
+
+        return { event: RELOAD_EVENT, dispatched: true, outcome: dispatched.outcome };
+      },
+    );
+
+    await Promise.resolve(true);
+  };
+
+  return fp(plugin, { name: `service-channel:${opts.prefix}` });
+};


### PR DESCRIPTION
# feat(service-channel): dedicated network map reload endpoint with loud 503

Closes the final phase (Ph9) of Part C of the service-channel work.
Resolves #447.

## What this adds

A dedicated control-plane endpoint to re-dispatch a reload signal for a tenant's **current active** network map, without writing any state:

```
POST /v1/admin/configuration/network_map/reload
```

It re-emits a `network-map.activated` CloudEvent for whichever map is active for the tenant, so a consumer that started late, missed the original broadcast, or needs a fresh cascade can be (re-)driven to reload.
It is a sibling of `activate`, not part of it: no row is written and no activation is performed.

## Design notes (conscious divergences from `activate`)

These are intentional and documented in the README and on the issue:

- **No `{cfg}` in the path.** The endpoint always operates on the tenant's single active map, resolved server-side via the `idx_networkmap_active_tenant` highlander index (new `getActive` repository method). When the tenant has no active map there is nothing to reload, so it returns `404` (`No active network map`). The `cfg` and `tenantId` on the dispatched event are derived from the fetched map, not the request.
- **`reloadMode` is required**, and must be `broadcast` or `cascade` (no default). A missing or unrecognised mode returns `400`. `reloadMode: 'none'` also returns `400` with a tailored message: on a dedicated reload endpoint `none` would dispatch nothing, so accepting it as a silent success would be a footgun (an operator who fat-fingered `none` would believe a reload had fired). On `activate`, `none` is legitimate (suppress the side-channel while still committing); here it has no meaning.
- **Dispatch failure is loud.** Unlike `activate`, where signalling is advisory and degrades to a `reloadDispatched: { status: false }` field on an otherwise-successful `200`, the reload endpoint has no underlying DB commit to fall back on - the dispatch *is* the whole operation. So when the service channel is unavailable it returns **`503`** with `{ error, event, dispatched: false }` (logged at `warn`). A successful dispatch returns `200` with `{ event, dispatched: true, outcome }`. `broadcast` and `cascade` share this success/failure shape; `cascade` drives the same ordered, ack-gated wavefront as the activate path and reports `outcome: 'cascade initiated'`.

Served by a dedicated `buildServiceChannelPlugin` kept apart from the CRUD plugin (it performs no persistence), guarded by the `POST_V1_ADMIN_CONFIGURATION_NETWORK_MAP_RELOAD` privilege.

## Approach

TDD: red tests first, independent sub-agent review of the test set, then the minimum production change to green.

## Changes

- `feat`: `getActive` highlander lookup on the network map repository (+ optional method on the `CrudRepository` interface).
- `feat`: dedicated reload endpoint plugin, `ErrorResponse` promoted from `crud-schema` for reuse, router wiring.
- `test`: reload endpoint coverage (400 trio with message assertions, 404, 200 broadcast with full CloudEvents envelope, cfg/tenant derivation, no-consumer success, 200 cascade, 503 for both modes) and `getActive` repository coverage.
- `docs`: README endpoint documentation and summary table update.
- `build`: version bump to `4.0.0-rc.8`.

## Validation

- `npm test`: 787 passing across 40 suites, coverage thresholds met.
- `npm run build`: clean.
- eslint: 0 errors (changed files warning-free).
- prettier: changed files normalized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated network map reload endpoint that re-dispatches activation events for the active network map without database writes
  * Supports `broadcast` and `cascade` reload modes
  * Returns HTTP 503 with failure details when service channel is unavailable (retryable error)

* **Documentation**
  * Updated README with new reload endpoint documentation and behavior specifications

* **Chores**
  * Version bumped to 4.0.0-rc.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->