### PR TITLE
fix: preserve config.parameters on rule config write (#467)

### DIFF
--- a/__tests__/unit/rule.crud-plugin.test.ts
+++ b/__tests__/unit/rule.crud-plugin.test.ts
@@ -132,3 +132,77 @@ describe('GET /v1/admin/configuration/rule response schema', () => {
     expect(body.data[0].config?.cases).toBeUndefined();
   });
 });
+
+// Regression test for
+// https://github.com/tazama-lf/admin-service/issues/467
+//
+// Before the fix, src/schemas/ruleSchema.ts declared
+//   parameters: Type.Optional(Type.Record(Type.Optional(Type.Union([Type.String(), Type.Number()])), Type.Optional(Type.Unknown())))
+// The malformed key schema made TypeBox emit a JSON Schema with no
+// patternProperties/additionalProperties, so Ajv's `removeAdditional: 'all'`
+// stripped every real key from config.parameters on POST/PUT, persisting an
+// empty object. These tests assert that a submitted config.parameters object
+// survives request validation intact and reaches the repository.
+describe('POST /v1/admin/configuration/rule preserves config.parameters', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+
+    const ajv = new Ajv({
+      removeAdditional: 'all',
+      useDefaults: true,
+      coerceTypes: 'array',
+      strictTuples: false,
+    });
+    addFormats(ajv);
+    app.setValidatorCompiler(({ schema }) => ajv.compile(schema));
+
+    await app.register(
+      buildCrudPlugin({
+        prefix: '/v1/admin/configuration/rule',
+        repo: RuleConfigRepo,
+        schemas: { Entity: RuleSchema, Create: RuleSchema, Update: RuleSchema },
+        idParam: { kind: 'single', name: 'id' },
+      }),
+    );
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('does not strip parameter keys from config.parameters on create', async () => {
+    const createMock = RuleConfigRepo.create as jest.Mock;
+    createMock.mockImplementation((payload: unknown) => Promise.resolve(payload as RuleConfig));
+
+    const rule = {
+      id: '016@1.0.0',
+      cfg: '4.0.0',
+      desc: 'Transaction convergence - creditor',
+      config: {
+        parameters: { maxQueryRange: 86400000 },
+        exitConditions: [],
+        bands: [
+          { subRuleRef: '.01', upperLimit: 5, reason: 'No Transaction convergence detected on creditor account' },
+          { subRuleRef: '.02', lowerLimit: 5, reason: 'Transaction convergence detected on creditor account' },
+        ],
+      },
+    };
+
+    const response = await app.inject({ method: 'POST', url: '/v1/admin/configuration/rule', payload: rule });
+
+    expect(response.statusCode).toBe(201);
+
+    // The payload the repository received reflects req.body AFTER Ajv validation:
+    // this is where the strip used to happen.
+    const received = createMock.mock.calls[0][0] as RuleConfig;
+    expect(received.config?.parameters).toEqual({ maxQueryRange: 86400000 });
+
+    // The serialised response must also retain the parameters.
+    const body = response.json() as RuleConfig;
+    expect(body.config?.parameters).toEqual({ maxQueryRange: 86400000 });
+  });
+});

--- a/src/schemas/ruleSchema.ts
+++ b/src/schemas/ruleSchema.ts
@@ -26,12 +26,15 @@ export const Case = Type.Object({
   alternative: OutcomeResult,
 });
 
-export const Config = Type.Object({
-  parameters: Type.Optional(Type.Record(Type.Optional(Type.Union([Type.String(), Type.Number()])), Type.Optional(Type.Unknown()))),
-  exitConditions: Type.Optional(Type.Array(OutcomeResult)),
-  bands: Type.Optional(Type.Array(Band)),
-  cases: Type.Optional(Case),
-});
+export const Config = Type.Object(
+  {
+    parameters: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    exitConditions: Type.Optional(Type.Array(OutcomeResult)),
+    bands: Type.Optional(Type.Array(Band)),
+    cases: Type.Optional(Case),
+  },
+  { additionalProperties: true },
+);
 
 export type Rule = Static<typeof RuleSchema>;
 export const RuleSchema = Type.Object(


### PR DESCRIPTION
## What

Fixes the rule config write path stripping the contents of `config.parameters`, which stored `parameters: {}` in the database regardless of what was submitted.

Resolves #467.

## Why

The `parameters` field in the rule `Config` schema was declared with a malformed `Type.Record` key schema:

```ts
parameters: Type.Optional(Type.Record(Type.Optional(Type.Union([Type.String(), Type.Number()])), Type.Optional(Type.Unknown()))),
```

`Type.Record(keySchema, valueSchema)` expects a plain key schema. The `Type.Optional(Type.Union([...]))` key made TypeBox emit a JSON Schema with no `patternProperties`/`additionalProperties`:

```json
{ "type": "object", "properties": { "[number]": {} } }
```

Combined with the service's Ajv setting `removeAdditional: 'all'` (`src/clients/fastify.ts`), every real parameter key (e.g. `maxQueryRange`) was stripped during Fastify body validation, before the CRUD handler ran. Release 4 added Zod validation of rule configs on DB fetch, so the emptied config then threw at runtime inside the rule processors:

```
Error while getting rule configuration
ZodError: [ { "path": ["config","parameters","maxQueryRange"], "message": "Invalid input: expected number, received undefined" } ]
```

## Change

`src/schemas/ruleSchema.ts`:

```ts
export const Config = Type.Object(
  {
    parameters: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
    exitConditions: Type.Optional(Type.Array(OutcomeResult)),
    bands: Type.Optional(Type.Array(Band)),
    cases: Type.Optional(Case),
  },
  { additionalProperties: true },
);
```

- `Type.Record(Type.String(), Type.Unknown())` compiles to `patternProperties: { "^(.*)$": {} }`, so arbitrary parameter keys match and are preserved.
- `{ additionalProperties: true }` on `Config` guards nested keys against `removeAdditional: 'all'`, matching the top-level `RuleSchema`.

## Scope

The rule `parameters` field is the only open-ended map (`Type.Record`) in the schemas. The typology and network_map schemas contain only fixed-shape nested objects whose legitimate keys are all declared, so they are unaffected by this class of bug. This is the only occurrence.

## Tests

Added a POST regression test in `__tests__/unit/rule.crud-plugin.test.ts` that asserts a submitted `config.parameters` object survives request validation and reaches the repository intact (both the repository payload and the serialised response are checked).

- Full suite: 1314 passed.
- `tsc` build clean, schema lints clean.

## Deployment note

Any rule config posted via the admin-service API since this schema was introduced will already have empty `parameters` in the DB and must be re-posted after this fix is deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for rule configuration parameters so valid keys are no longer stripped from requests or responses.
  * Improved support for flexible parameter objects in admin rule configuration, helping preserve submitted data accurately.
  * Added regression coverage to prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->