### PR TITLE
fix: bump frms-coe-startup-lib to 3.1.0-rc.9 for axios CVE remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-service",
-  "version": "4.0.0-rc.8",
+  "version": "4.0.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-service",
-      "version": "4.0.0-rc.8",
+      "version": "4.0.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
@@ -16,7 +16,7 @@
         "@sinclair/typebox": "^0.34.41",
         "@tazama-lf/auth-lib": "4.0.0-rc.5",
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
-        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.8",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.9",
         "@tazama-lf/tcs-lib": "1.0.157-rc.0",
         "ajv": "^8.17.1",
         "dotenv": "^17.2.0",
@@ -2417,14 +2417,14 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.1.0-rc.8",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.8/65158cc89ae26c324d2f2958e4d4eeec620d4aa7",
-      "integrity": "sha512-rjgyf0eGg+2FfSk2wgfxRZjZbEleBq6nUu11Ph/ggMOvNMuejxP+5nI7ig6wqut8PqBqUKNibNKA/iNsMMme/w==",
+      "version": "3.1.0-rc.9",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.9/9a0a62305de53441354df30da5aa4d90b7752369",
+      "integrity": "sha512-dZtAnrxuBcdS8YPfH4xw3NFo+nfUgr61VxNUdH+pKWVVxieDtWSAnQFuD7GmRZ6sXkUyB5HYoBBa61xfIdpOqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
         "amqplib": "0.10.6",
-        "axios": "^1.13.5",
+        "axios": "^1.18.1",
         "nats": "^2.29.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@sinclair/typebox": "^0.34.41",
     "@tazama-lf/auth-lib": "4.0.0-rc.5",
     "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
-    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.8",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.9",
     "@tazama-lf/tcs-lib": "1.0.157-rc.0",
     "ajv": "^8.17.1",
     "dotenv": "^17.2.0",


### PR DESCRIPTION
# fix: bump frms-coe-startup-lib to 3.1.0-rc.9 for axios CVE remediation

## Why

Part of the platform-wide axios remediation for the June 2026 advisory batch (CVE-2026-44486..44496 plus the June GHSA wave). `admin-service` has no direct axios dependency - it inherited a vulnerable axios transitively through `@tazama-lf/frms-coe-startup-lib`.

## What

- `package.json`: `@tazama-lf/frms-coe-startup-lib 3.1.0-rc.8` -> `3.1.0-rc.9` (the axios-remediated RC)
- `package-lock.json` regenerated; `npm ls axios` confirms `axios@1.18.1`

## Verification

- `npm run build` - clean
- `npm test` - 1314/1314 pass (62 suites)
- `npm run lint` - eslint clean (prettier line-ending warnings are the known local CRLF artefact; CI runs on Linux/LF)

## Regression watch (axios 1.18.x behaviour changes)

- Cross-origin redirects now strip caller-set auth/API-key headers
- Malformed `http:`/`https:` URLs (missing `//`) now throw `ERR_INVALID_URL`
- Merged config/header objects are null-prototype
- `AxiosError.toJSON()` now redacts sensitive keys (log output changes)
