### PR TITLE
build(deps): bump library dependencies to latest rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tazama-lf/auth-lib": "4.0.0-rc.5",
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
         "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.9",
-        "@tazama-lf/tcs-lib": "1.0.157-rc.0",
+        "@tazama-lf/tcs-lib": "1.0.157-rc.1",
         "ajv": "^8.17.1",
         "dotenv": "^17.2.0",
         "fastify": "^5.4.0",
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@tazama-lf/tcs-lib": {
-      "version": "1.0.157-rc.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/tcs-lib/1.0.157-rc.0/71e2c1bb3d1c1ee4167db2c83a1913fbe76d5733",
-      "integrity": "sha512-NrluTbQUN+5B9h2/7St51p8cfkerh9Bz9RJ3unrdTeTtPrJcixn494xSfr6gR7hNI7eGg9RIi5gVmGW2NB3fFw==",
+      "version": "1.0.157-rc.1",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/tcs-lib/1.0.157-rc.1/63b247af41048941ae3ac428b357b7587c4a243e",
+      "integrity": "sha512-e9kf+lo3StMHE+KEnuZTedmG3hrrK1H38/ZbmkYW7MZXxUzWP1bHEu6Eon5tHRmG02W77RkpjmF+MDXAHSaySw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tazama-lf/auth-lib": "4.0.0-rc.5",
     "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
     "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.9",
-    "@tazama-lf/tcs-lib": "1.0.157-rc.0",
+    "@tazama-lf/tcs-lib": "1.0.157-rc.1",
     "ajv": "^8.17.1",
     "dotenv": "^17.2.0",
     "fastify": "^5.4.0",


### PR DESCRIPTION
## Summary

Bumps internal library dependencies on `dev` to the latest published `rc` versions. The previous automated bump PR (#341) was closed without merging, leaving `dev` pinned to an rc version that no longer exists in the registry.

## Changes

| Package | From | To |
|---|---|---|
| `@tazama-lf/tcs-lib` | 1.0.157-rc.0 | 1.0.157-rc.1 |

`package-lock.json` regenerated.

## Verification

- `npm run build` passes
- `npm test` passes (62 suites, 1314 tests)
